### PR TITLE
Fix for spruce dependency issue

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
           ],
   srcs = ["find_resource.cc"],
   deps = [
-        "@drake//common",
+        "@drake//common:essential",
+        "//third_party/spruce",
         ]
 )

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -4,11 +4,9 @@
 #include <utility>
 #include <vector>
 
-#include <spruce.hh>
+#include "third_party/spruce/spruce.hh"
 
-#include "drake/common/drake_marker.h"
 #include "drake/common/drake_throw.h"
-#include "drake/common/find_loaded_library.h"
 #include "drake/common/never_destroyed.h"
 
 using std::string;

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -6,7 +6,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
-#include "drake/common/find_resource.h"
 
 // Copied from drake/common/find_resource.h
 namespace dairlib {

--- a/third_party/spruce/BUILD.bazel
+++ b/third_party/spruce/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD-3-Clause
+
+cc_library(
+  name = "spruce",
+  hdrs = [
+          "spruce.hh"
+          ],
+  srcs = ["spruce.cc"],
+  deps = [
+        ]
+)

--- a/third_party/spruce/LICENSE
+++ b/third_party/spruce/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Joseph Davis (@josephdavisco)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the project nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/spruce/spruce.cc
+++ b/third_party/spruce/spruce.cc
@@ -1,0 +1,413 @@
+/*-------------------------------------------------------
+
+                        Spruce
+            Filesystem Wrapper Library for C++11
+
+    Copyright (c) 2014, Joseph Davis (@josephdavisco)
+    All rights reserved. See LICENSE for license info.
+
+---------------------------------------------------------*/
+#include "spruce.hh"
+
+#include <utility>
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <cstdio>
+extern "C" {
+#include <sys/stat.h>
+}
+/*-------------------------------------------------------
+
+    Windows includes
+
+---------------------------------------------------------
+Notes:
+
+POSIX functions named such as mkdir are deprecated on
+Windows. Functions are prefixed with an underscore (_),
+mkdir() becomes _mkdir().
+
+"In Windows NT, both the (\) and (/) are valid path
+delimiters in character strings in run-time routines."
+
+http://msdn.microsoft.com/en-us/library/
+
+---------------------------------------------------------*/
+#if defined(_WIN32) || defined(_WIN64)
+#define SPRUCE_WIN
+#include <direct.h>
+auto SPRUCE_CHDIR = _chdir;
+auto SPRUCE_GETCWD = _getcwd;
+auto SPRUCE_RMDIR = _rmdir;
+auto SPRUCE_MKDIR = _mkdir;
+#else
+/*-------------------------------------------------------
+
+    Unix/Posix includes
+
+---------------------------------------------------------*/
+extern "C" {
+#include <sys/types.h>
+#include <unistd.h>
+}
+auto SPRUCE_CHDIR = chdir;
+auto SPRUCE_GETCWD = getcwd;
+auto SPRUCE_RMDIR = rmdir;
+auto SPRUCE_MKDIR = [](const char* pathTomake) {
+  return mkdir(pathTomake, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+};
+#endif
+
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode)&S_IFMT) == S_IFDIR)
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode)&S_IFMT) == S_IFREG)
+#endif
+
+/*-------------------------------------------------------
+    class path default constructor
+---------------------------------------------------------*/
+spruce::path::path() { path_str = ""; }
+
+/*-------------------------------------------------------
+    class path constructor
+---------------------------------------------------------*/
+spruce::path::path(std::string path_) : path_str(path_) { normalize(); }
+
+/*-------------------------------------------------------
+    class path destructor
+---------------------------------------------------------*/
+spruce::path::~path() {}
+
+/*-------------------------------------------------------
+    path.setStr
+---------------------------------------------------------*/
+void spruce::path::setStr(std::string path_) {
+  path_str = path_;
+  normalize();
+}
+
+/*-------------------------------------------------------
+    path.getStr
+---------------------------------------------------------*/
+std::string spruce::path::getStr() const { return path_str; }
+
+/*-------------------------------------------------------
+    class path.split
+---------------------------------------------------------*/
+std::vector<std::string> spruce::path::split() {
+  std::vector<std::string> v;
+  std::istringstream ss(path_str);
+  while (!ss.eof()) {
+    std::string temp;
+    std::getline(ss, temp, '/');
+    v.push_back(temp);
+  }
+  return v;
+}
+
+/*-------------------------------------------------------
+    class path.extension
+---------------------------------------------------------*/
+std::string spruce::path::extension() {
+  size_t dot(path_str.rfind('.'));
+
+  if (dot == std::string::npos) {
+    return "";
+  }
+
+  return path_str.substr(dot);
+}
+
+void spruce::path::append(std::string const& str) {
+  if (isFile()) return;
+  std::string str_append;
+
+  if (str.find('/') == 0)
+    str_append = str.substr(1, str.length());
+  else
+    str_append = str;
+
+  if (path_str.rfind('/') == path_str.length())
+    path_str.append(str_append);
+  else
+    path_str.append("/" + str_append);
+}
+
+void spruce::path::setExtension(std::string const& str) {
+  size_t ext = path_str.rfind(extension());
+  if (ext == std::string::npos) ext = path_str.length();
+  path_str = path_str.substr(0, ext) + str;
+}
+
+/*-------------------------------------------------------
+    class path.root
+---------------------------------------------------------*/
+std::string spruce::path::root() {
+  size_t position(path_str.rfind('/'));
+
+  if (position == std::string::npos) {
+    return "";
+  }
+
+  return path_str.substr(0, position);
+}
+
+/*-------------------------------------------------------
+    class path.isFile
+---------------------------------------------------------*/
+bool spruce::path::isFile() const {
+  if (!exists()) return false;
+
+#ifdef SPRUCE_WIN
+
+  struct _stat attributes;
+  _stat(path_str.c_str(), &attributes);
+
+#else
+
+  struct stat attributes;
+  stat(path_str.c_str(), &attributes);
+
+#endif
+
+  return S_ISREG(attributes.st_mode) != 0;
+}
+
+/*-------------------------------------------------------
+    class path.isDir
+---------------------------------------------------------*/
+bool spruce::path::isDir() const {
+  if (!exists()) return false;
+
+#ifdef SPRUCE_WIN
+
+  struct _stat attributes;
+  _stat(path_str.c_str(), &attributes);
+
+#else
+
+  struct stat attributes;
+  stat(path_str.c_str(), &attributes);
+
+#endif
+
+  return S_ISDIR(attributes.st_mode) != 0;
+}
+
+/*-------------------------------------------------------
+    class path.exists
+---------------------------------------------------------*/
+bool spruce::path::exists() const {
+#ifdef SPRUCE_WIN
+  struct _stat attributes;
+  return _stat(path_str.c_str(), &attributes) == 0;
+#else
+  struct stat attributes;
+  return stat(path_str.c_str(), &attributes) == 0;
+#endif
+}
+
+/*-------------------------------------------------------
+    class path.setAsHome
+---------------------------------------------------------*/
+void spruce::path::setAsHome() {
+  char* home;
+#ifdef SPRUCE_WIN
+  home = std::getenv("HOMEPATH");
+#else
+  home = std::getenv("HOME");
+#endif
+  if (home != NULL) {
+    setStr(home);
+  }
+}
+
+/*-------------------------------------------------------
+    class path.setAsTemp
+---------------------------------------------------------*/
+void spruce::path::setAsTemp() {
+  char* cwd = std::getenv("TMPDIR");
+  if (!cwd) cwd = std::getenv("TEMPDIR");
+  if (!cwd) cwd = std::getenv("TMP");
+  if (!cwd) cwd = std::getenv("TEMP");
+  if (!cwd) {
+    setStr("/tmp");
+  } else {
+    setStr(cwd);
+  }
+}
+
+/*-------------------------------------------------------
+    class path.setAsCurrent
+---------------------------------------------------------*/
+void spruce::path::setAsCurrent() {
+  char* cwd = SPRUCE_GETCWD(NULL, 0);
+  setStr(cwd);
+  free(cwd);
+}
+
+/*-------------------------------------------------------
+    class path.normalize
+---------------------------------------------------------*/
+void spruce::path::normalize() {
+  std::replace(path_str.begin(), path_str.end(), '\\', '/');
+
+  if (path_str.back() == '/')
+    path_str = path_str.substr(0, path_str.length() - 1);
+}
+
+/*-------------------------------------------------------
+    ostream operator<< class path
+---------------------------------------------------------*/
+std::ostream& operator<<(std::ostream& output, const spruce::path& p) {
+  return output << p.getStr();
+}
+
+/*-------------------------------------------------------
+    file::remove
+---------------------------------------------------------*/
+bool spruce::file::remove(const spruce::path& p) {
+  if (!p.isFile() || (std::remove((p.getStr()).c_str()) != 0)) return false;
+  return true;
+}
+
+/*-------------------------------------------------------
+    file::rename
+---------------------------------------------------------*/
+bool spruce::file::rename(const spruce::path& source,
+                          const spruce::path& dest) {
+  if (std::rename(source.getStr().c_str(), dest.getStr().c_str()) != 0)
+    return false;
+  return true;
+}
+
+/*-------------------------------------------------------
+    file::copy
+---------------------------------------------------------*/
+bool spruce::file::copy(const spruce::path& source, const spruce::path& dest) {
+  std::ifstream in(source.getStr(), std::ios::binary);
+  std::ofstream out(dest.getStr(), std::ios::binary);
+
+  out << in.rdbuf();
+  if (out.fail()) {
+    return false;
+  }
+  return true;
+}
+
+/*-------------------------------------------------------
+    file::readAsString
+---------------------------------------------------------*/
+bool spruce::file::readAsString(const spruce::path& p, std::string& readTo) {
+  std::ifstream file(p.getStr());
+  std::stringstream ss;
+
+  if (file.is_open()) {
+    while (!file.eof()) {
+      ss << static_cast<char>(file.get());
+    }
+    file.close();
+  } else {
+    return false;
+  }
+
+  readTo = ss.str();
+
+  return true;
+}
+
+/*-------------------------------------------------------
+    file::writeAsString
+---------------------------------------------------------*/
+bool spruce::file::writeAsString(const spruce::path& p,
+                                 const std::string& content, bool append) {
+  std::ofstream out;
+
+  if (append) {
+    out.open((p.getStr()).c_str(), std::ios_base::out | std::ios_base::app);
+  }
+
+  else {
+    out.open((p.getStr()).c_str());
+  }
+
+  if (out.fail()) {
+    return false;
+  }
+
+  out << content;
+
+  out.close();
+
+  return true;
+}
+
+/*-------------------------------------------------------
+    dir::mkdir
+---------------------------------------------------------*/
+bool spruce::dir::mkdir(const spruce::path& p) {
+  if (SPRUCE_MKDIR((p.getStr()).c_str()) != 0) {
+    return false;
+  }
+  return true;
+}
+
+/*-------------------------------------------------------
+    dir::mkdirAll
+---------------------------------------------------------*/
+bool spruce::dir::mkdirAll(const spruce::path& p) {
+  size_t pos = 1;
+  std::string temp(p.getStr());
+
+  if (temp == "") return false;
+
+  while ((pos = temp.find('/', pos + 1)) != std::string::npos) {
+    if ((path(temp.substr(0, pos))).exists()) continue;
+    // if making a directory on the path fails we cannot continue
+    if (SPRUCE_MKDIR((temp.substr(0, pos)).c_str()) != 0) return false;
+  }
+
+  if (SPRUCE_MKDIR(temp.c_str()) != 0) return false;
+
+  return true;
+}
+
+/*-------------------------------------------------------
+    dir::rmdir
+---------------------------------------------------------*/
+bool spruce::dir::rmdir(const spruce::path& p) {
+  if (SPRUCE_RMDIR((p.getStr()).c_str()) != 0) {
+    return false;
+  }
+  return true;
+}
+
+/*-------------------------------------------------------
+    dir::rename
+---------------------------------------------------------*/
+bool spruce::dir::rename(const spruce::path& source, const spruce::path& dest) {
+  // cstdio accepts the name of a file or directory
+  return spruce::file::rename(source, dest);
+}
+
+/*-------------------------------------------------------
+    dir::chdir
+---------------------------------------------------------*/
+bool spruce::dir::chdir(const spruce::path& p) {
+  std::string target = p.getStr();
+  if (target.empty()) {  // Empty denotes the root folder.
+    target = "/";
+  }
+  if (SPRUCE_CHDIR(target.c_str()) != 0) return false;
+  return true;
+}
+
+spruce::path spruce::dir::getcwd() {
+  spruce::path result;
+  result.setAsCurrent();
+  return result;
+}

--- a/third_party/spruce/spruce.hh
+++ b/third_party/spruce/spruce.hh
@@ -1,0 +1,105 @@
+/*-------------------------------------------------------
+
+                        Spruce
+            Filesystem Wrapper Library for C++11
+
+    Copyright (c) 2014, Joseph Davis (@josephdavisco)
+    All rights reserved. See LICENSE for license info.
+
+---------------------------------------------------------*/
+#ifndef SPRUCE_H_
+#define SPRUCE_H_
+
+#include <vector>
+#include <iostream>
+#include <string>
+
+#undef DLLEXPORT_spruce
+#if defined(WIN32) || defined(WIN64)
+  #if defined(spruce_EXPORTS)
+    #define DLLEXPORT_spruce __declspec( dllexport )
+  #else
+    #define DLLEXPORT_spruce __declspec( dllimport )
+  #endif
+#else
+    #define DLLEXPORT_spruce [[gnu::visibility("default")]]
+#endif
+
+namespace spruce
+{
+
+class DLLEXPORT_spruce path
+{
+    std::string path_str;
+public:
+    path();
+
+    path( std::string path_ );
+
+    ~path();
+
+    void setStr( std::string path_ );
+
+    std::string getStr() const;
+
+    std::vector<std::string> split();
+
+    std::string extension();
+
+    void setExtension(std::string const & ext);
+
+    void append(std::string const & str);
+
+    std::string root();
+
+    bool isFile() const;
+
+    bool isDir() const;
+
+    bool exists() const;
+
+    void setAsHome();
+
+    void setAsTemp();
+
+    void setAsCurrent();
+
+private:
+    void normalize();
+
+    friend std::ostream& operator<<( std::ostream& output, const spruce::path& p );
+};
+
+namespace file
+{
+bool remove( const spruce::path& p );
+
+bool rename( const spruce::path& source, const spruce::path& dest );
+
+bool copy( const spruce::path& source, const spruce::path& dest );
+
+bool readAsString( const spruce::path& p, std::string& readTo );
+
+bool writeAsString( const spruce::path& p, const std::string& content,
+                    bool append );
+}
+
+namespace dir
+{
+bool mkdir( const spruce::path& p );
+
+bool mkdirAll( const spruce::path& p );
+
+bool rmdir( const spruce::path& p );
+
+bool rename( const spruce::path& source, const spruce::path& dest );
+
+bool chdir( const spruce::path& p );
+
+spruce::path getcwd();
+
+}
+
+}
+
+#endif /* SPRUCE_H_ */


### PR DESCRIPTION
Changed dependencies of dairlib's copy of find_resource. Since Drake's third-party spruce dependency is marked hidden, @shrenikm and I have separately run into issues using it (within bazel tests only, oddly). This PR addes spruce's source code and license to dairlib, and uses this as a dependency.