### PR TITLE
Run Drake Cassie sim with Dispatcher

### DIFF
--- a/attic/multibody/multibody_solvers.cc
+++ b/attic/multibody/multibody_solvers.cc
@@ -183,7 +183,6 @@ PositionSolver::PositionSolver(const RigidBodyTree<double>& tree)
   q_ = prog_->NewContinuousVariables(tree_.get_num_positions(), "q");
 
   // Solver setup
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
   prog_->SetSolverOption(SnoptSolver::id(), "Major feasibility tolerance",
                          major_tolerance_);
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
@@ -274,8 +273,7 @@ VectorXd PositionSolver::GetSolutionQ() {
 }
 
 void PositionSolver::set_filename(string filename) {
-  filename_ = filename;
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
+  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename);
 }
 
 void PositionSolver::set_major_tolerance(double major_tolerance) {
@@ -289,7 +287,6 @@ void PositionSolver::set_minor_tolerance(double minor_tolerance) {
                          minor_tolerance_);
 }
 
-string PositionSolver::get_filename() { return filename_; }
 
 double PositionSolver::get_major_tolerance() { return major_tolerance_; }
 
@@ -304,7 +301,6 @@ ContactSolver::ContactSolver(const RigidBodyTree<double>& tree,
   q_ = prog_->NewContinuousVariables(tree_.get_num_positions(), "q");
 
   // Solver setup
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
   prog_->SetSolverOption(SnoptSolver::id(), "Major feasibility tolerance",
                          major_tolerance_);
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
@@ -406,8 +402,7 @@ VectorXd ContactSolver::GetSolutionQ() {
 }
 
 void ContactSolver::set_filename(string filename) {
-  filename_ = filename;
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
+  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename);
 }
 
 void ContactSolver::set_major_tolerance(double major_tolerance) {
@@ -420,8 +415,6 @@ void ContactSolver::set_minor_tolerance(double minor_tolerance) {
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
                          minor_tolerance_);
 }
-
-string ContactSolver::get_filename() { return filename_; }
 
 double ContactSolver::get_major_tolerance() { return major_tolerance_; }
 
@@ -439,7 +432,6 @@ FixedPointSolver::FixedPointSolver(const RigidBodyTree<double>& tree)
                                           "lambda");
 
   // Solver setup
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
   prog_->SetSolverOption(SnoptSolver::id(), "Major feasibility tolerance",
                          major_tolerance_);
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
@@ -496,7 +488,6 @@ FixedPointSolver::FixedPointSolver(const RigidBodyTree<double>& tree,
       "lambda");
 
   // Solver setup
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
   prog_->SetSolverOption(SnoptSolver::id(), "Major feasibility tolerance",
                          major_tolerance_);
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
@@ -710,8 +701,7 @@ VectorXd FixedPointSolver::GetSolutionLambda() {
 }
 
 void FixedPointSolver::set_filename(string filename) {
-  filename_ = filename;
-  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename_);
+  prog_->SetSolverOption(SnoptSolver::id(), "Print file", filename);
 }
 
 void FixedPointSolver::set_major_tolerance(double major_tolerance) {
@@ -724,8 +714,6 @@ void FixedPointSolver::set_minor_tolerance(double minor_tolerance) {
   prog_->SetSolverOption(SnoptSolver::id(), "Minor feasibility tolerance",
                          minor_tolerance_);
 }
-
-string FixedPointSolver::get_filename() { return filename_; }
 
 double FixedPointSolver::get_major_tolerance() { return major_tolerance_; }
 

--- a/attic/multibody/multibody_solvers.h
+++ b/attic/multibody/multibody_solvers.h
@@ -208,7 +208,6 @@ class PositionSolver {
   void set_major_tolerance(double major_tolerance);
   void set_minor_tolerance(double minor_tolerance);
 
-  std::string get_filename();
   double get_major_tolerance();
   double get_minor_tolerance();
 
@@ -217,7 +216,7 @@ class PositionSolver {
   std::shared_ptr<drake::solvers::MathematicalProgram> prog_;
   drake::solvers::VectorXDecisionVariable q_;
   drake::solvers::MathematicalProgramResult program_result_;
-  std::string filename_ = "attic/multibody/solver_log/position_solver.log";
+
   double major_tolerance_ = 1.0e-13;
   double minor_tolerance_ = 1.0e-13;
 };
@@ -318,7 +317,6 @@ class ContactSolver {
   void set_major_tolerance(double major_tolerance);
   void set_minor_tolerance(double minor_tolerance);
 
-  std::string get_filename();
   double get_major_tolerance();
   double get_minor_tolerance();
 
@@ -328,7 +326,6 @@ class ContactSolver {
   std::shared_ptr<drake::solvers::MathematicalProgram> prog_;
   drake::solvers::VectorXDecisionVariable q_;
   drake::solvers::MathematicalProgramResult program_result_;
-  std::string filename_ = "attic/multibody/solver_log/contact_solver.log";
   double major_tolerance_ = 1.0e-13;
   double minor_tolerance_ = 1.0e-13;
 };
@@ -506,7 +503,6 @@ class FixedPointSolver {
   void set_major_tolerance(double major_tolerance);
   void set_minor_tolerance(double minor_tolerance);
 
-  std::string get_filename();
   double get_major_tolerance();
   double get_minor_tolerance();
 
@@ -518,7 +514,6 @@ class FixedPointSolver {
   drake::solvers::VectorXDecisionVariable u_;
   drake::solvers::VectorXDecisionVariable lambda_;
   drake::solvers::MathematicalProgramResult program_result_;
-  std::string filename_ = "attic/multibody/solver_log/fixed_point_solver.log";
   double major_tolerance_ = 1.0e-13;
   double minor_tolerance_ = 1.0e-13;
 };

--- a/attic/multibody/test/multibody_solvers_test.cc
+++ b/attic/multibody/test/multibody_solvers_test.cc
@@ -228,7 +228,6 @@ TEST_F(MultibodySolversTest, TestPositionSolverBasic) {
   shared_ptr<MathematicalProgram> prog_position_fixed1 =
       position_solver_fixed1.get_program();
 
-  ASSERT_EQ(position_solver_fixed1.get_filename(), "position_log");
   ASSERT_EQ(position_solver_fixed1.get_major_tolerance(), 0.001);
   ASSERT_EQ(position_solver_fixed1.get_minor_tolerance(), 0.01);
 
@@ -242,7 +241,6 @@ TEST_F(MultibodySolversTest, TestPositionSolverBasic) {
   shared_ptr<MathematicalProgram> prog_position_fixed2 =
       position_solver_fixed1.get_program();
 
-  ASSERT_EQ(position_solver_fixed2.get_filename(), "position_log");
   ASSERT_EQ(position_solver_fixed2.get_major_tolerance(), 0.001);
   ASSERT_EQ(position_solver_fixed2.get_minor_tolerance(), 0.01);
 
@@ -255,7 +253,6 @@ TEST_F(MultibodySolversTest, TestPositionSolverBasic) {
   shared_ptr<MathematicalProgram> prog_position_floating =
       position_solver_floating.get_program();
 
-  ASSERT_EQ(position_solver_floating.get_filename(), "position_log");
   ASSERT_EQ(position_solver_floating.get_major_tolerance(), 0.001);
   ASSERT_EQ(position_solver_floating.get_minor_tolerance(), 0.01);
 }
@@ -269,7 +266,6 @@ TEST_F(MultibodySolversTest, TestContactSolverBasic) {
   contact_solver1.set_major_tolerance(0.002);
   contact_solver1.set_minor_tolerance(0.02);
 
-  ASSERT_EQ(contact_solver1.get_filename(), "contact_log");
   ASSERT_EQ(contact_solver1.get_major_tolerance(), 0.002);
   ASSERT_EQ(contact_solver1.get_minor_tolerance(), 0.02);
 
@@ -284,7 +280,6 @@ TEST_F(MultibodySolversTest, TestContactSolverBasic) {
   contact_solver2.set_major_tolerance(0.002);
   contact_solver2.set_minor_tolerance(0.02);
 
-  ASSERT_EQ(contact_solver2.get_filename(), "contact_log");
   ASSERT_EQ(contact_solver2.get_major_tolerance(), 0.002);
   ASSERT_EQ(contact_solver2.get_minor_tolerance(), 0.02);
 
@@ -297,7 +292,6 @@ TEST_F(MultibodySolversTest, TestContactSolverBasic) {
   contact_solver3.set_major_tolerance(0.002);
   contact_solver3.set_minor_tolerance(0.02);
 
-  ASSERT_EQ(contact_solver3.get_filename(), "contact_log");
   ASSERT_EQ(contact_solver3.get_major_tolerance(), 0.002);
   ASSERT_EQ(contact_solver3.get_minor_tolerance(), 0.02);
 
@@ -317,7 +311,6 @@ TEST_F(MultibodySolversTest, TestFixedPointSolverBasic) {
   shared_ptr<MathematicalProgram> prog_fp_fixed1 =
       fp_solver_fixed1.get_program();
 
-  ASSERT_EQ(fp_solver_fixed1.get_filename(), "fp_log");
   ASSERT_EQ(fp_solver_fixed1.get_major_tolerance(), 0.003);
   ASSERT_EQ(fp_solver_fixed1.get_minor_tolerance(), 0.03);
 
@@ -332,7 +325,6 @@ TEST_F(MultibodySolversTest, TestFixedPointSolverBasic) {
   shared_ptr<MathematicalProgram> prog_fp_fixed2 =
       fp_solver_fixed2.get_program();
 
-  ASSERT_EQ(fp_solver_fixed2.get_filename(), "fp_log");
   ASSERT_EQ(fp_solver_fixed2.get_major_tolerance(), 0.003);
   ASSERT_EQ(fp_solver_fixed2.get_minor_tolerance(), 0.03);
 
@@ -355,7 +347,6 @@ TEST_F(MultibodySolversTest, TestFixedPointSolverBasic) {
   shared_ptr<MathematicalProgram> prog_fp_floating1 =
       fp_solver_floating1.get_program();
 
-  ASSERT_EQ(fp_solver_floating1.get_filename(), "fp_log");
   ASSERT_EQ(fp_solver_floating1.get_major_tolerance(), 0.003);
   ASSERT_EQ(fp_solver_floating1.get_minor_tolerance(), 0.03);
 
@@ -371,7 +362,6 @@ TEST_F(MultibodySolversTest, TestFixedPointSolverBasic) {
   shared_ptr<MathematicalProgram> prog_fp_floating2 =
       fp_solver_floating2.get_program();
 
-  ASSERT_EQ(fp_solver_floating2.get_filename(), "fp_log");
   ASSERT_EQ(fp_solver_floating2.get_major_tolerance(), 0.003);
   ASSERT_EQ(fp_solver_floating2.get_minor_tolerance(), 0.03);
 
@@ -385,7 +375,6 @@ TEST_F(MultibodySolversTest, TestFixedPointSolverBasic) {
   shared_ptr<MathematicalProgram> prog_fp_floating3 =
       fp_solver_floating3.get_program();
 
-  ASSERT_EQ(fp_solver_floating3.get_filename(), "fp_log");
   ASSERT_EQ(fp_solver_floating3.get_major_tolerance(), 0.003);
   ASSERT_EQ(fp_solver_floating3.get_minor_tolerance(), 0.03);
 }

--- a/examples/Cassie/BUILD.bazel
+++ b/examples/Cassie/BUILD.bazel
@@ -196,6 +196,7 @@ cc_binary(
   deps = ["//examples/Cassie/networking:udp_driven_loop",
           "//examples/Cassie/networking:cassie_udp_pub_sub",
           "@drake//lcm",
+          "@drake//systems/lcm:lcm_driven_loop",
           "//lcmtypes:lcmt_robot",
           "//systems:robot_lcm_systems",
           ":cassie_utils",

--- a/examples/Cassie/cassie_test.pmd
+++ b/examples/Cassie/cassie_test.pmd
@@ -14,8 +14,12 @@ group "1.simulated-robot" {
         exec = "bazel-bin/examples/Cassie/run_pd_controller";
         host = "localhost";
     }
-    cmd "2.dispatcher-robot-out" {
-        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001";
+    cmd "2.a.dispatcher-robot-out (drake)" {
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=true";
+        host = "localhost";
+    }
+    cmd "2.b.dispatcher-robot-out (gazebo)" {
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=true";
         host = "localhost";
     }
     cmd "1.simulator" {
@@ -77,10 +81,17 @@ script "start-operator" {
     start cmd "1.state-visualizer";
 }
 
+script "run-drake-pd-control" {
+    run_script "start-operator";
+    start cmd "1.simulator";
+    start cmd "2.a.dispatcher-robot-out (drake)";
+    start cmd "0.pd-controller";
+}
+
 script "run-gazebo-pd-control" {
     run_script "start-operator";
     start cmd "0.launch-gazebo";
-    start cmd "2.dispatcher-robot-out";
+    start cmd "2.b.dispatcher-robot-out (gazebo)";
     start cmd "3.dispatcher-robot-in";
     start cmd "0.pd-controller";
 }

--- a/examples/Cassie/cassie_test.pmd
+++ b/examples/Cassie/cassie_test.pmd
@@ -22,8 +22,12 @@ group "1.simulated-robot" {
         exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=false";
         host = "localhost";
     }
-    cmd "1.simulator" {
-        exec = "bazel-bin/examples/Cassie/run_simple_sim --floating_base=false";
+    cmd "1.simulator (dispatched)" {
+        exec = "bazel-bin/examples/Cassie/run_simple_sim --floating_base=false --publish_state=false";
+        host = "localhost";
+    }
+    cmd "1.simulator (no dispatcher)" {
+        exec = "bazel-bin/examples/Cassie/run_simple_sim --floating_base=false --publish_state=true";
         host = "localhost";
     }
     cmd "3.dispatcher-robot-in" {
@@ -83,7 +87,7 @@ script "start-operator" {
 
 script "run-drake-pd-control" {
     run_script "start-operator";
-    start cmd "1.simulator";
+    start cmd "1.simulator (dispatched)";
     start cmd "2.a.dispatcher-robot-out (drake)";
     start cmd "0.pd-controller";
 }

--- a/examples/Cassie/cassie_test.pmd
+++ b/examples/Cassie/cassie_test.pmd
@@ -19,7 +19,7 @@ group "1.simulated-robot" {
         host = "localhost";
     }
     cmd "2.b.dispatcher-robot-out (gazebo)" {
-        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=true";
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=false";
         host = "localhost";
     }
     cmd "1.simulator" {

--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -2,6 +2,7 @@
 
 #include <gflags/gflags.h>
 #include "drake/lcm/drake_lcm.h"
+#include "drake/systems/lcm/lcm_driven_loop.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/analysis/simulator.h"
@@ -13,6 +14,7 @@
 #include "systems/primitives/subvector_pass_through.h"
 #include "examples/Cassie/networking/cassie_udp_subscriber.h"
 #include "examples/Cassie/networking/cassie_output_sender.h"
+#include "examples/Cassie/networking/cassie_output_receiver.h"
 #include "examples/Cassie/networking/udp_driven_loop.h"
 #include "examples/Cassie/cassie_rbt_state_estimator.h"
 #include "examples/Cassie/cassie_utils.h"
@@ -25,12 +27,15 @@ using drake::systems::Simulator;
 using drake::systems::Context;
 using drake::systems::lcm::LcmSubscriberSystem;
 using drake::systems::lcm::LcmPublisherSystem;
+using drake::systems::lcm::UtimeMessageToSeconds;
 using drake::systems::TriggerType;
 
 // Simulation parameters.
 DEFINE_string(address, "127.0.0.1", "IPv4 address to receive from.");
 DEFINE_int64(port, 25001, "Port to receive on.");
 DEFINE_double(pub_rate, 0.02, "Network LCM pubishing period (s).");
+DEFINE_bool(simulation, false,
+    "Simulated or real robot (default=false, real robot)");
 
 /// Runs UDP driven loop for 10 seconds
 /// Re-publishes any received messages as LCM
@@ -43,26 +48,40 @@ int do_main(int argc, char* argv[]) {
 
   std::unique_ptr<RigidBodyTree<double>> tree = makeCassieTreePointer();
 
-  // Create input receiver.
-  auto input_sub = builder.AddSystem(
-      systems::CassieUDPSubscriber::Make(FLAGS_address, FLAGS_port));
+  // Create state estimator
+  auto state_estimator =
+      builder.AddSystem<systems::CassieRbtStateEstimator>(*tree);
 
   // Create and connect CassieOutputSender publisher (low-rate for the network)
   // This echoes the messages from the robot
   auto output_sender = builder.AddSystem<systems::CassieOutputSender>();
   auto output_pub = builder.AddSystem(
-      LcmPublisherSystem::Make<dairlib::lcmt_cassie_out>("CASSIE_OUTPUT",
+      LcmPublisherSystem::Make<dairlib::lcmt_cassie_out>("CASSIE_OUTPUT_ECHO",
       &lcm_network, {TriggerType::kPeriodic}, FLAGS_pub_rate));
-
   // connect cassie_out publisher
-  builder.Connect(*input_sub, *output_sender);
-
   builder.Connect(*output_sender, *output_pub);
 
-  // Create and connect state estimator
-  auto state_estimator =
-      builder.AddSystem<systems::CassieRbtStateEstimator>(*tree);
-  builder.Connect(*input_sub, *state_estimator);
+  // Connect appropriate input receiver, for simlation or the real robot
+
+  LcmSubscriberSystem* sim_input_sub = nullptr;
+  systems::CassieUDPSubscriber* udp_input_sub = nullptr;
+
+  if (FLAGS_simulation) {
+    sim_input_sub = builder.AddSystem(
+      LcmSubscriberSystem::Make<dairlib::lcmt_cassie_out>("CASSIE_OUTPUT",
+          &lcm_local));
+    auto input_receiver =
+        builder.AddSystem<systems::CassieOutputReceiver>();
+    builder.Connect(*sim_input_sub, *input_receiver);
+    builder.Connect(*input_receiver, *output_sender);
+    builder.Connect(*input_receiver, *state_estimator);
+  } else {
+    // Create input receiver.
+    udp_input_sub = builder.AddSystem(
+        systems::CassieUDPSubscriber::Make(FLAGS_address, FLAGS_port));
+    builder.Connect(*udp_input_sub, *output_sender);
+    builder.Connect(*udp_input_sub, *state_estimator);
+  }
 
   // Create and connect RobotOutput publisher.
   auto state_sender = builder.AddSystem<systems::RobotOutputSender>(*tree);
@@ -91,15 +110,27 @@ int do_main(int argc, char* argv[]) {
 
   auto diagram = builder.Build();
 
-  systems::UDPDrivenLoop loop(*diagram, *input_sub, nullptr);
+  if (FLAGS_simulation) {
+    drake::systems::lcm::LcmDrivenLoop loop(*diagram, *sim_input_sub, nullptr,
+        &lcm_local,
+        std::make_unique<UtimeMessageToSeconds<dairlib::lcmt_cassie_out>>());
 
-  // caused an extra publish call?
-  loop.set_publish_on_every_received_message(true);
+    // caused an extra publish call?
+    loop.set_publish_on_every_received_message(true);
 
-  // Starts the loop.
-  loop.RunToSecondsAssumingInitialized(1e6);
+    // Starts the loop.
+    loop.RunToSecondsAssumingInitialized(1e6);
+  } else {
+    systems::UDPDrivenLoop loop(*diagram, *udp_input_sub, nullptr);
 
-  input_sub->StopPolling();
+    // caused an extra publish call?
+    loop.set_publish_on_every_received_message(true);
+
+    // Starts the loop.
+    loop.RunToSecondsAssumingInitialized(1e6);
+
+    udp_input_sub->StopPolling();
+  }
   return 0;
 }
 

--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -115,7 +115,6 @@ int do_main(int argc, char* argv[]) {
         &lcm_local,
         std::make_unique<UtimeMessageToSeconds<dairlib::lcmt_cassie_out>>());
 
-    // caused an extra publish call?
     loop.set_publish_on_every_received_message(true);
 
     // Starts the loop.
@@ -123,7 +122,6 @@ int do_main(int argc, char* argv[]) {
   } else {
     systems::UDPDrivenLoop loop(*diagram, *udp_input_sub, nullptr);
 
-    // caused an extra publish call?
     loop.set_publish_on_every_received_message(true);
 
     // Starts the loop.

--- a/examples/Cassie/run_simple_sim.cc
+++ b/examples/Cassie/run_simple_sim.cc
@@ -54,6 +54,7 @@ DEFINE_double(dt, 1e-3,
               "The step size to use for "
               "'simulation_type=timestepping' (ignored for "
               "'simulation_type=compliant'");
+DEFINE_double(publish_rate, 1000, "Publishing frequency (Hz)");
 
 // Cassie model paramter
 DEFINE_bool(floating_base, false, "Fixed or floating base model");
@@ -111,7 +112,7 @@ int do_main(int argc, char* argv[]) {
       plant->get_rigid_body_tree());
   auto state_pub =
       builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_robot_output>(
-          "CASSIE_STATE", &lcm, 1.0 / 200.0));
+          "CASSIE_STATE", &lcm, 1.0 / FLAGS_publish_rate));
   builder.Connect(plant->state_output_port(),
                   state_sender->get_input_port_state());
   builder.Connect(state_sender->get_output_port(0),
@@ -123,7 +124,7 @@ int do_main(int argc, char* argv[]) {
         addImuAndAggregatorToSimulation(builder, plant, passthrough);
     auto cassie_sensor_pub =
         builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_cassie_out>(
-            "CASSIE_OUTPUT", &lcm, 1.0 / 200.0));
+            "CASSIE_OUTPUT", &lcm, 1.0 / FLAGS_publish_rate));
     builder.Connect(cassie_sensor_aggregator->get_output_port(0),
                     cassie_sensor_pub->get_input_port());
   }
@@ -144,9 +145,9 @@ int do_main(int argc, char* argv[]) {
 
   drake::systems::Context<double>& sim_context =
       simulator.get_mutable_context();
-  auto integrator =
-      simulator.reset_integrator<drake::systems::RungeKutta2Integrator<double>>(
-          *diagram, FLAGS_timestep, &sim_context);
+  // auto integrator =
+  //     simulator.reset_integrator<drake::systems::RungeKutta2Integrator<double>>(
+  //         *diagram, FLAGS_timestep, &sim_context);
   // auto integrator =
   //   simulator.reset_integrator<drake::systems::RungeKutta3Integrator<double>>
   //   (*diagram, &sim_context);


### PR DESCRIPTION
-Update dispatcher to use simulated sensors.
-Added procman script to run Cassie PD demo with Drake simulation and dispatcher
-Removed default use of logfiles from multibody solvers, to avoid generating unused logs
-Reverted integration scheme for run_simple_sim to default value

Builds off of #41 to resolve #4 