### PR TITLE
Robot output sender fix

### DIFF
--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -81,7 +81,7 @@ int do_main(int argc, char* argv[]) {
       true);
   auto state_pub = builder.AddSystem(
       LcmPublisherSystem::Make<dairlib::lcmt_robot_output>(
-          "CASSIE_STATE_TEMP", &lcm_local,
+          "CASSIE_STATE", &lcm_local,
           {TriggerType::kForced}));
 
   // Create and connect RobotOutput publisher (low-rate for the network)

--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -77,10 +77,11 @@ int do_main(int argc, char* argv[]) {
   }
 
   // Create and connect RobotOutput publisher.
-  auto state_sender = builder.AddSystem<systems::RobotOutputSender>(*tree);
+  auto robot_output_sender = builder.AddSystem<systems::RobotOutputSender>(*tree,
+      true);
   auto state_pub = builder.AddSystem(
       LcmPublisherSystem::Make<dairlib::lcmt_robot_output>(
-          "CASSIE_STATE", &lcm_local,
+          "CASSIE_STATE_TEMP", &lcm_local,
           {TriggerType::kForced}));
 
   // Create and connect RobotOutput publisher (low-rate for the network)
@@ -90,16 +91,30 @@ int do_main(int argc, char* argv[]) {
           {TriggerType::kPeriodic}, FLAGS_pub_rate));
 
   // Pass through to drop all but positions and velocities
-  auto passthrough = builder.AddSystem<systems::SubvectorPassThrough>(
+  auto state_passthrough = builder.AddSystem<systems::SubvectorPassThrough>(
     state_estimator->get_output_port(0).size(),
     0,
-    state_sender->get_input_port(0).size());
+    robot_output_sender->get_input_port_state().size());
 
-  builder.Connect(*state_estimator, *passthrough);
-  builder.Connect(*passthrough, *state_sender);
-  builder.Connect(*state_sender, *state_pub);
+  // Passthrough to pass efforts
+  auto effort_passthrough = builder.AddSystem<systems::SubvectorPassThrough>(
+      state_estimator->get_output_port(0).size(),
+      robot_output_sender->get_input_port_state().size(),
+      robot_output_sender->get_input_port_effort().size());
 
-  builder.Connect(*state_sender, *net_state_pub);
+  builder.Connect(state_estimator->get_output_port(0),
+      state_passthrough->get_input_port());
+  builder.Connect(state_passthrough->get_output_port(),
+      robot_output_sender->get_input_port_state());
+
+  builder.Connect(state_estimator->get_output_port(0),
+      effort_passthrough->get_input_port());
+  builder.Connect(effort_passthrough->get_output_port(),
+      robot_output_sender->get_input_port_effort());
+
+  builder.Connect(*robot_output_sender, *state_pub);
+
+  builder.Connect(*robot_output_sender, *net_state_pub);
 
 
 

--- a/systems/robot_lcm_systems.h
+++ b/systems/robot_lcm_systems.h
@@ -46,14 +46,21 @@ class RobotOutputReceiver : public drake::systems::LeafSystem<double> {
 /// Converts a OutputVector object to LCM type lcmt_robot_output
 class RobotOutputSender : public drake::systems::LeafSystem<double> {
  public:
-  explicit RobotOutputSender(const RigidBodyTree<double>& tree);
+  explicit RobotOutputSender(const RigidBodyTree<double>& tree,
+      const bool publish_efforts=false);
 
   explicit RobotOutputSender(
-    const drake::multibody::MultibodyPlant<double>& plant);
+    const drake::multibody::MultibodyPlant<double>& plant,
+    const bool publish_efforts=false);;
 
   const drake::systems::InputPort<double>& get_input_port_state()
       const {
     return this->get_input_port(state_input_port_);
+  }
+
+  const drake::systems::InputPort<double>& get_input_port_effort()
+      const {
+    return this->get_input_port(effort_input_port_);
   }
 
  private:
@@ -62,11 +69,16 @@ class RobotOutputSender : public drake::systems::LeafSystem<double> {
 
   int num_positions_;
   int num_velocities_;
+  int num_efforts_;
   std::vector<std::string> ordered_position_names_;
   std::vector<std::string> ordered_velocity_names_;
+  std::vector<std::string> ordered_effort_names_;
   std::map<std::string, int> positionIndexMap_;
   std::map<std::string, int> velocityIndexMap_;
+  std::map<std::string, int> effortIndexMap_;
   int state_input_port_;
+  int effort_input_port_;
+  bool publish_efforts_;
 };
 
 /// Receives the output of an LcmSubsriberSystem that subsribes to the


### PR DESCRIPTION
**What's new:**
1. Added optional input port for efforts in `RobotOutputSender`

`RobotOutputSender` has an additional input port for efforts. The input port for efforts is optional so that the existing code need not be modified to accommodate this change.

2. Modified `dispatcher_robot_out` to publish efforts to `CASSIE_STATE`