### PR TITLE
ROS Publishers and Subscribers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,3 +50,6 @@ build --action_env=CCACHE_DISABLE=1
 
 # build with snopt
 build --define=WITH_SNOPT=ON
+
+# use python3 by default
+build --python_path=python3

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,33 @@ build_task:
     dockerfile: install/bionic/Dockerfile
     cpu: 8
     memory: 24
+  env:
+    DAIRLIB_WITH_ROS: ON    
+  test_script:
+    - bazel build
+      --define=WITH_SNOPT=OFF
+      --local_resources=24000,8,1.0 --jobs=8 
+      --spawn_strategy=sandboxed
+      --strategy=Javac=sandboxed
+      --genrule_strategy=sandboxed
+      --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+      //...
+    - bazel test
+      --define=WITH_SNOPT=OFF
+      --local_resources=24000,8,1.0 --jobs=8 
+      --spawn_strategy=sandboxed
+      --strategy=Javac=sandboxed
+      --genrule_strategy=sandboxed
+      --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+      //...
+build_with_ros_task:
+  timeout_in: 120m
+  container:
+    dockerfile: install/bionic/ros/Dockerfile
+    cpu: 8
+    memory: 24
+  env:
+    DAIRLIB_WITH_ROS: ON
   test_script:
     - bazel build
       --define=WITH_SNOPT=OFF

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,13 +52,18 @@ build_with_ros_task:
 drake_master_build_task:
   timeout_in: 120m
   container:
-    dockerfile: install/bionic/Dockerfile
+    dockerfile: install/bionic/ros/Dockerfile
     cpu: 8
     memory: 24
   allow_failures: true
+  env:
+    DAIRLIB_WITH_ROS: ON
   test_script:
     - git clone https://github.com/RobotLocomotion/drake.git ../drake
     - export DAIRLIB_LOCAL_DRAKE_PATH=$PWD/../drake
+    - cd tools/workspace/ros
+    - ./compile_ros_workspace.sh
+    - cd ../../../
     - bazel build
       --define=WITH_SNOPT=OFF
       --local_resources=24000,8,1.0 --jobs=8 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,8 +4,6 @@ build_task:
     dockerfile: install/bionic/Dockerfile
     cpu: 8
     memory: 24
-  env:
-    DAIRLIB_WITH_ROS: ON    
   test_script:
     - bazel build
       --define=WITH_SNOPT=OFF

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,6 +30,9 @@ build_with_ros_task:
   env:
     DAIRLIB_WITH_ROS: ON
   test_script:
+    - cd tools/workspace/ros
+    - ./compile_ros_workspace.sh
+    - cd ../../../
     - bazel build
       --define=WITH_SNOPT=OFF
       --local_resources=24000,8,1.0 --jobs=8 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,31 @@ export DAIRLIB_LOCAL_DRAKE_PATH=/home/user/my-workspace/drake
 
 ### Other dependencies
 These dependencies are necessary for some advanced visualization and process management. Many examples will work without a full installation of Director or libbot, but (for lab members), these are ultimately recommended. 
-1. Install a local copy of `lcm` and `libbot2` using `sudo apt install lcm libbot2'. The prerequisites installation from Drake should add the proper repo for these. (This likely require's Drake's prerequisites to be installed from a source copy).
+
+#### LCM and libbot
+Install a local copy of `lcm` and `libbot2` using `sudo apt install lcm libbot2`. The prerequisites installation from Drake should add the proper repo for these. (This likely require's Drake's prerequisites to be installed from a source copy).
+
+#### ROS
+To integrate with ROS (tested on ROS Melodic), the following steps are required.
+1. Install ROS http://wiki.ros.org/ROS/Installation
+2. Do not forget to setup your environment. For instance, add these lines to `~/.bashrc`
+```
+export ROS_MASTER_URI=http://localhost:11311
+source /opt/ros/melodic/setup.bash 
+```
+3. Install additional dependencies
+```
+sudo apt install python-rosinstall-generator python-catkin-tools
+```
+4. Build the ROS workspace using catkin. From `dairlib/`,
+```
+cd tools/workspace/ros
+./compile_ros_workspace.sh
+```
+5. Set the environment variable `DAIRLIB_WITH_ROS` to `ON`. For instance, add to `~/.bashrc`
+```
+export DAIRLIB_WITH_ROS=ON
+```
 
 ### Notes for macOS
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,3 +57,30 @@ add_default_repositories()
 
 load("@dairlib//tools/workspace/signal_scope:repository.bzl", "signal_scope_repository")
 signal_scope_repository(name = "signal_scope")
+
+
+# Prebuilt ROS workspace
+new_local_repository(
+    name='ros',
+    path='tools/workspace/ros/bundle_ws/install',
+    build_file='tools/workspace/ros/ros.bazel',
+)
+
+# Other catkin packages from source
+# TODO: generate this automatically from rosinstall_generator
+
+http_archive(
+    name='genmsg_repo',
+    build_file='@//tools/workspace/ros/bazel:genmsg.BUILD',
+    sha256='d7627a2df169e4e8208347d9215e47c723a015b67ef3ed8cda8b61b6cfbf94d2',
+    urls = ['https://github.com/ros/genmsg/archive/0.5.8.tar.gz'],
+    strip_prefix='genmsg-0.5.8',
+)
+
+http_archive(
+    name='genpy_repo',
+    build_file='@//tools/workspace/ros/bazel:genpy.BUILD',
+    sha256='35e5cd2032f52a1f77190df5c31c02134dc460bfeda3f28b5a860a95309342b9',
+    urls = ['https://github.com/ros/genpy/archive/0.6.5.tar.gz'],
+    strip_prefix='genpy-0.6.5',
+)

--- a/install/bionic/ros/Dockerfile
+++ b/install/bionic/ros/Dockerfile
@@ -1,0 +1,21 @@
+FROM ros:melodic-ros-base-bionic
+WORKDIR /dairlib
+COPY . .
+RUN apt update && apt install -y wget lsb-release pkg-config zip g++ zlib1g-dev unzip python
+RUN set -eux \
+  && apt-get install --no-install-recommends  locales \
+  && locale-gen en_US.UTF-8
+RUN if type sudo 2>/dev/null; then \ 
+     echo "The sudo command already exists... Skipping."; \
+    else \
+     echo -e "#!/bin/sh\n\${@}" > /usr/sbin/sudo; \
+     chmod +x /usr/sbin/sudo; \
+    fi
+RUN  set -eux \
+  && wget https://github.com/bazelbuild/bazel/releases/download/0.28.0/bazel-0.28.0-installer-linux-x86_64.sh  \
+  && chmod +x bazel-0.28.0-installer-linux-x86_64.sh \
+  && ./bazel-0.28.0-installer-linux-x86_64.sh 
+RUN set -eux \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && yes | install/install_prereqs_ubuntu.sh \
+  && rm -rf /var/lib/apt/lists/*

--- a/install/bionic/ros/Dockerfile
+++ b/install/bionic/ros/Dockerfile
@@ -2,7 +2,7 @@ FROM ros:melodic-ros-base-bionic
 WORKDIR /dairlib
 COPY . .
 RUN apt update && apt install -y wget lsb-release pkg-config zip g++ zlib1g-dev unzip python
-RUN apt install python-rosinstall-generator python-catkin-tools
+RUN apt install -y python-rosinstall-generator python-catkin-tools
 RUN set -eux \
   && apt-get install --no-install-recommends  locales \
   && locale-gen en_US.UTF-8

--- a/install/bionic/ros/Dockerfile
+++ b/install/bionic/ros/Dockerfile
@@ -2,6 +2,7 @@ FROM ros:melodic-ros-base-bionic
 WORKDIR /dairlib
 COPY . .
 RUN apt update && apt install -y wget lsb-release pkg-config zip g++ zlib1g-dev unzip python
+RUN apt install python-rosinstall-generator python-catkin-tools
 RUN set -eux \
   && apt-get install --no-install-recommends  locales \
   && locale-gen en_US.UTF-8

--- a/noros.bazelrc
+++ b/noros.bazelrc
@@ -1,0 +1,2 @@
+# build without ros
+build --build_tag_filters="-ros"

--- a/systems/ros/BUILD.bazel
+++ b/systems/ros/BUILD.bazel
@@ -7,17 +7,20 @@ cc_library(
   deps=[
     "@ros",
     "@drake//:drake_shared_library",
-  ]
+  ],
+  tags=["ros"],
 )
 
 cc_binary(
   name = "test_ros_publisher_system",
   srcs = ["test/test_ros_publisher_system.cc"],
   deps = [":ros_pubsub_systems"],
+  tags=["ros"],
 )
 
 cc_binary(
   name = "test_ros_subscriber_system",
   srcs = ["test/test_ros_subscriber_system.cc"],
   deps = [":ros_pubsub_systems"],
+  tags=["ros"],
 )

--- a/systems/ros/BUILD.bazel
+++ b/systems/ros/BUILD.bazel
@@ -1,0 +1,23 @@
+# -*- python -*-
+
+cc_library(
+  name="ros_pubsub_systems",
+  hdrs=["ros_publisher_system.h",
+        "ros_subscriber_system.h"],
+  deps=[
+    "@ros",
+    "@drake//:drake_shared_library",
+  ]
+)
+
+cc_binary(
+  name = "test_ros_publisher_system",
+  srcs = ["test/test_ros_publisher_system.cc"],
+  deps = [":ros_pubsub_systems"],
+)
+
+cc_binary(
+  name = "test_ros_subscriber_system",
+  srcs = ["test/test_ros_subscriber_system.cc"],
+  deps = [":ros_pubsub_systems"],
+)

--- a/systems/ros/LICENSE_drake_ros_systems
+++ b/systems/ros/LICENSE_drake_ros_systems
@@ -1,9 +1,9 @@
-Original versions of //tools/workspace/ros are from 
-https://github.com/nicolov/ros-bazel
+Original versions of ros_publisher_system.h and ros_subscriber_system.h are from
+https://github.com/gizatt/drake_ros_systems
 
 MIT License
 
-Copyright (c) 2017 Nicolo Valigi
+Copyright (c) 2017 Gregory Izatt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/systems/ros/ros_publisher_system.h
+++ b/systems/ros/ros_publisher_system.h
@@ -101,7 +101,10 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
         (trigger == TriggerType::kPerStep));
     }
 
+    // Outgoing queue size chosen to be small, but 5 is arbitrary
     publisher_ = node_handle->advertise<RosMessage>(topic, 5);
+    // check that publisher is not empty
+    DRAKE_THROW_UNLESS(publisher_);
 
     DeclareAbstractInputPort("ros_message", drake::Value<RosMessage>());
     set_name(make_name(topic_));

--- a/systems/ros/ros_publisher_system.h
+++ b/systems/ros/ros_publisher_system.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/framework/leaf_system.h"
+
+#include "ros/ros.h"
+
+namespace drake_ros_systems {
+
+using namespace drake;
+
+/**
+ * Publishes an ROS message containing information from its input port.
+ *
+ * @ingroup message_passing
+ */
+template <typename RosMessage>
+class RosPublisherSystem : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RosPublisherSystem)
+
+  /**
+   * A factory method that returns an %RosPublisherSystem that takes
+   * Value<RosMessage> message objects on its sole abstract-valued input port.
+   *
+   * @tparam RosMessage message type to serialize.
+   *
+   * @param[in] topic The ROS topic on which to publish.
+   *
+   * @param node_handle The ROS context.
+   */
+  static std::unique_ptr<RosPublisherSystem<RosMessage>> Make(
+      const std::string& topic, ros::NodeHandle* node_handle) {
+    return std::make_unique<RosPublisherSystem<RosMessage>>(topic, node_handle);
+  }
+
+  // TODO(gizatt): add multiple DrakeRosInterface, so you can publish to a log
+  // and real lcm at the same time. (TODO cloned from LCM publisher system,
+  // originally attributed to Siyuan.)
+
+  /**
+   * A constructor for an %RosPublisherSystem that takes ROS message objects on
+   * its sole abstract-valued input port. The ROS message type is determined by
+   * the template type.
+   *
+   * @param[in] topic The ROS topic on which to publish.
+   *
+   * @param node_handle The ROS context.
+   */
+  RosPublisherSystem(const std::string& topic, ros::NodeHandle* node_handle)
+      : topic_(topic), node_handle_(node_handle) {
+    DRAKE_DEMAND(node_handle_ != nullptr);
+
+    publisher_ = node_handle->advertise<RosMessage>(topic, 5);
+
+    DeclareAbstractInputPort("ros_message", Value<RosMessage>());
+    set_name(make_name(topic_));
+  }
+
+  ~RosPublisherSystem() override{};
+
+  const std::string& get_topic_name() const { return topic_; }
+
+  /// Returns the default name for a system that publishes @p topic.
+  static std::string make_name(const std::string& topic) {
+    return "RosPublisherSystem(" + topic + ")";
+  }
+
+  /**
+   * Sets the publishing period of this system. See
+   * LeafSystem::DeclarePublishPeriodSec() for details about the semantics of
+   * parameter `period`.
+   */
+  void set_publish_period(double period) {
+    LeafSystem<double>::DeclarePeriodicPublish(period);
+  }
+
+  /**
+   * Takes the VectorBase from the input port of the context and publishes
+   * it onto an ROS topic.
+   */
+  void DoPublish(
+      const systems::Context<double>& context,
+      const std::vector<const systems::PublishEvent<double>*>&) const override {
+    SPDLOG_TRACE(drake::log(), "Publishing ROS {} message", topic_);
+
+    const AbstractValue* const input_value =
+        this->EvalAbstractInput(context, kPortIndex);
+    DRAKE_ASSERT(input_value != nullptr);
+
+    publisher_.publish(input_value->get_value<RosMessage>());
+  }
+
+ private:
+  // The topic on which to publish ROS messages.
+  const std::string topic_;
+
+  ros::NodeHandle* const node_handle_{};
+  ros::Publisher publisher_;
+
+  const int kPortIndex = 0;
+};
+
+}  // namespace drake_ros_systems

--- a/systems/ros/ros_publisher_system.h
+++ b/systems/ros/ros_publisher_system.h
@@ -10,9 +10,8 @@
 
 #include "ros/ros.h"
 
-namespace drake_ros_systems {
-
-using namespace drake;
+namespace dairlib {
+namespace systems {
 
 /**
  * Publishes an ROS message containing information from its input port.
@@ -20,7 +19,7 @@ using namespace drake;
  * @ingroup message_passing
  */
 template <typename RosMessage>
-class RosPublisherSystem : public systems::LeafSystem<double> {
+class RosPublisherSystem : public drake::systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RosPublisherSystem)
 
@@ -58,7 +57,7 @@ class RosPublisherSystem : public systems::LeafSystem<double> {
 
     publisher_ = node_handle->advertise<RosMessage>(topic, 5);
 
-    DeclareAbstractInputPort("ros_message", Value<RosMessage>());
+    DeclareAbstractInputPort("ros_message", drake::Value<RosMessage>());
     set_name(make_name(topic_));
   }
 
@@ -85,11 +84,12 @@ class RosPublisherSystem : public systems::LeafSystem<double> {
    * it onto an ROS topic.
    */
   void DoPublish(
-      const systems::Context<double>& context,
-      const std::vector<const systems::PublishEvent<double>*>&) const override {
+      const drake::systems::Context<double>& context,
+      const std::vector<const drake::systems::PublishEvent<double>*>&)
+      const override {
     SPDLOG_TRACE(drake::log(), "Publishing ROS {} message", topic_);
 
-    const AbstractValue* const input_value =
+    const drake::AbstractValue* const input_value =
         this->EvalAbstractInput(context, kPortIndex);
     DRAKE_ASSERT(input_value != nullptr);
 
@@ -106,4 +106,5 @@ class RosPublisherSystem : public systems::LeafSystem<double> {
   const int kPortIndex = 0;
 };
 
-}  // namespace drake_ros_systems
+}  // namespace systems
+}  // namespace dairlib

--- a/systems/ros/ros_publisher_system.h
+++ b/systems/ros/ros_publisher_system.h
@@ -3,15 +3,18 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/leaf_system.h"
 
 #include "ros/ros.h"
 
 namespace dairlib {
 namespace systems {
+
+using TriggerTypeSet =
+    std::unordered_set<drake::systems::TriggerType, drake::DefaultHash>;
 
 /**
  * Publishes an ROS message containing information from its input port.
@@ -27,20 +30,43 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
    * A factory method that returns an %RosPublisherSystem that takes
    * Value<RosMessage> message objects on its sole abstract-valued input port.
    *
-   * @tparam RosMessage message type to serialize.
+   * @param[in] topic The ROS topic on which to publish.
+   *
+   * @param node_handle The ROS context.
+   *
+   * @param publish_triggers Set of triggers that determine when messages will
+   * be published. Supported TriggerTypes are {kForced, kPeriodic, kPerStep}.
+   * Will throw an error if empty or if unsupported types are provided.
+   *
+   * @param publish_period Period that messages will be published (optional).
+   * publish_period should only be non-zero if one of the publish_triggers is
+   * kPeriodic.
+   */
+  static std::unique_ptr<RosPublisherSystem<RosMessage>> Make(
+      const std::string& topic, ros::NodeHandle* node_handle,
+      double publish_period = 0.0) {
+    return std::make_unique<RosPublisherSystem<RosMessage>>(topic, node_handle,
+      publish_period);
+  }
+
+  /**
+   * A factory method that returns an %RosPublisherSystem that takes
+   * Value<RosMessage> message objects on its sole abstract-valued input port.
    *
    * @param[in] topic The ROS topic on which to publish.
    *
    * @param node_handle The ROS context.
+   *
+   * @param publish_period Period that messages will be published (optional).
+   * If the publish period is zero, RosPublisherSystem will use per-step
+   * publishing instead; see LeafSystem::DeclarePerStepPublishEvent().
    */
   static std::unique_ptr<RosPublisherSystem<RosMessage>> Make(
-      const std::string& topic, ros::NodeHandle* node_handle) {
-    return std::make_unique<RosPublisherSystem<RosMessage>>(topic, node_handle);
+      const std::string& topic, ros::NodeHandle* node_handle,
+      const TriggerTypeSet& publish_triggers, double publish_period = 0.0) {
+    return std::make_unique<RosPublisherSystem<RosMessage>>(topic, node_handle,
+      publish_triggers, publish_period);
   }
-
-  // TODO(gizatt): add multiple DrakeRosInterface, so you can publish to a log
-  // and real lcm at the same time. (TODO cloned from LCM publisher system,
-  // originally attributed to Siyuan.)
 
   /**
    * A constructor for an %RosPublisherSystem that takes ROS message objects on
@@ -50,16 +76,87 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
    * @param[in] topic The ROS topic on which to publish.
    *
    * @param node_handle The ROS context.
+   *
+   * @param publish_triggers Set of triggers that determine when messages will
+   * be published. Supported TriggerTypes are {kForced, kPeriodic, kPerStep}.
+   * Will throw an error if empty or if unsupported types are provided.
+   *
+   * @param publish_period Period that messages will be published (optional).
+   * publish_period should only be non-zero if one of the publish_triggers is
+   * kPeriodic.
    */
-  RosPublisherSystem(const std::string& topic, ros::NodeHandle* node_handle)
+  RosPublisherSystem(const std::string& topic, ros::NodeHandle* node_handle,
+      const TriggerTypeSet& publish_triggers, double publish_period = 0.0)
       : topic_(topic), node_handle_(node_handle) {
     DRAKE_DEMAND(node_handle_ != nullptr);
+    DRAKE_DEMAND(publish_period >= 0.0);
+    DRAKE_DEMAND(!publish_triggers.empty());
+
+    using drake::systems::TriggerType;
+
+    // Check that publish_triggers does not contain an unsupported trigger.
+    for (const auto& trigger : publish_triggers) {
+      DRAKE_THROW_UNLESS((trigger == TriggerType::kForced) ||
+        (trigger == TriggerType::kPeriodic) ||
+        (trigger == TriggerType::kPerStep));
+    }
 
     publisher_ = node_handle->advertise<RosMessage>(topic, 5);
 
     DeclareAbstractInputPort("ros_message", drake::Value<RosMessage>());
     set_name(make_name(topic_));
+
+    // Declare a forced publish so that any time Publish(.) is called on this
+    // system (or a Diagram containing it), a message is emitted.
+    if (publish_triggers.find(TriggerType::kForced) != publish_triggers.end()) {
+      this->DeclareForcedPublishEvent(&RosPublisherSystem::PublishToRosTopic);
+    }
+
+    if (publish_triggers.find(TriggerType::kPeriodic) !=
+        publish_triggers.end()) {
+      DRAKE_THROW_UNLESS(publish_period > 0.0);
+      const double offset = 0.0;
+      this->DeclarePeriodicPublishEvent(publish_period, offset,
+          &RosPublisherSystem::PublishToRosTopic);
+    } else {
+      // publish_period > 0 without TriggerType::kPeriodic has no meaning and is
+      // likely a mistake.
+      DRAKE_THROW_UNLESS(publish_period == 0.0);
+    }
+
+    if (publish_triggers.find(TriggerType::kPerStep) !=
+        publish_triggers.end()) {
+      this->DeclarePerStepEvent(
+      drake::systems::PublishEvent<double>([this](
+          const drake::systems::Context<double>& context,
+          const drake::systems::PublishEvent<double>&) {
+        this->PublishToRosTopic(context);
+      }));
+    }
   }
+
+  /**
+   * A constructor for an %RosPublisherSystem that takes ROS message objects on
+   * its sole abstract-valued input port. The ROS message type is determined by
+   * the template type.
+   *
+   * @param[in] topic The ROS topic on which to publish.
+   *
+   * @param node_handle The ROS context.
+   *
+   * @param publish_period Period that messages will be published (optional).
+   * If the publish period is zero, RosPublisherSystem will use per-step
+   * publishing instead; see LeafSystem::DeclarePerStepPublishEvent().
+   */
+  RosPublisherSystem(const std::string& topic, ros::NodeHandle* node_handle,
+      double publish_period = 0.0)
+      : RosPublisherSystem(topic, node_handle,
+          (publish_period > 0.0) ?
+          TriggerTypeSet({drake::systems::TriggerType::kForced,
+                          drake::systems::TriggerType::kPeriodic}) :
+          TriggerTypeSet({drake::systems::TriggerType::kForced,
+                          drake::systems::TriggerType::kPerStep}),
+          publish_period) {}
 
   ~RosPublisherSystem() override{};
 
@@ -71,22 +168,11 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
   }
 
   /**
-   * Sets the publishing period of this system. See
-   * LeafSystem::DeclarePublishPeriodSec() for details about the semantics of
-   * parameter `period`.
-   */
-  void set_publish_period(double period) {
-    LeafSystem<double>::DeclarePeriodicPublish(period);
-  }
-
-  /**
    * Takes the VectorBase from the input port of the context and publishes
    * it onto an ROS topic.
    */
-  void DoPublish(
-      const drake::systems::Context<double>& context,
-      const std::vector<const drake::systems::PublishEvent<double>*>&)
-      const override {
+  drake::systems::EventStatus PublishToRosTopic(
+      const drake::systems::Context<double>& context) const {
     SPDLOG_TRACE(drake::log(), "Publishing ROS {} message", topic_);
 
     const drake::AbstractValue* const input_value =
@@ -94,6 +180,8 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
     DRAKE_ASSERT(input_value != nullptr);
 
     publisher_.publish(input_value->get_value<RosMessage>());
+
+    return drake::systems::EventStatus::Succeeded();
   }
 
  private:

--- a/systems/ros/ros_subscriber_system.h
+++ b/systems/ros/ros_subscriber_system.h
@@ -65,8 +65,9 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
       : topic_(topic), node_handle_(node_handle) {
     DRAKE_DEMAND(node_handle_);
 
+
     subscriber_ = node_handle->subscribe(
-        topic, 100, &RosSubscriberSystem<RosMessage>::HandleMessage, this);
+        topic, 1, &RosSubscriberSystem<RosMessage>::HandleMessage, this);
 
     DeclareAbstractOutputPort(
         [this]() {
@@ -186,10 +187,9 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
         .get_mutable_value<RosMessage>() = received_message_;
     abstract_state->get_mutable_value(kStateIndexMessageCount)
         .get_mutable_value<int>() = received_message_count_;
-  };
+  }
 
-  // Callback entry point from ROS into this class. Also wakes up one thread
-  // block on notification_ if it's not nullptr.
+  // Callback entry point from ROS into this class.
   void HandleMessage(const RosMessage& message) {
     SPDLOG_TRACE(drake::log(), "Receiving ROS {} message", topic_);
     std::lock_guard<std::mutex> lock(received_message_mutex_);

--- a/systems/ros/ros_subscriber_system.h
+++ b/systems/ros/ros_subscriber_system.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+
+#include "ros/ros.h"
+
+namespace drake_ros_systems {
+
+using namespace drake;
+
+/**
+ * Receives ROS messages from a given topic and outputs them to a
+ * System<double>'s port. This class stores the most recently processed ROS
+ * message in the State. When a ROS message arrives asynchronously, an update
+ * event is scheduled to process the message and store it in the State at the
+ * earliest possible simulation time. The output is always consistent with the
+ * State.
+ *
+ * To process a ROS message, CalcNextUpdateTime() needs to be called first to
+ * check for new messages and schedule a callback event if a new ROS message
+ * has arrived. The message is then processed and stored in the Context by
+ * CalcDiscreteVariableUpdates() or CalcUnrestrictedUpdate() depending on the
+ * output type. When this system is evaluated by the Simulator, all these
+ * operations are taken care of by the Simulator. On the other hand, the user
+ * needs to manually replicate this process without the Simulator.
+ *
+ * (Direct clone of LcmSubscriberSystem with pared-down features.)
+ */
+template <typename RosMessage>
+class RosSubscriberSystem : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RosSubscriberSystem)
+
+  /**
+   * A factory method that returns an %RosSubscriberSystem that takes
+   * Value<RosMessage> message objects on its sole abstract-valued input port.
+   *
+   * @tparam RosMessage message type to serialize.
+   *
+   * @param[in] topic The ROS topic to subscribe to.
+   *
+   * @param node_handle ROS node handle for context (to make the subscriber).
+   */
+  static std::unique_ptr<RosSubscriberSystem<RosMessage>> Make(
+      const std::string& topic, ros::NodeHandle* node_handle) {
+    return std::make_unique<RosSubscriberSystem<RosMessage>>(topic,
+                                                             node_handle);
+  }
+
+  /**
+   * Constructor that returns a subscriber System that provides message objects
+   * on its sole abstract-valued output port.  The type of the message object is
+   * determined by the @p serializer.
+   *
+   * @param[in] channel The ROS topic on which to subscribe.
+   *
+   * @param node_handle The ROS context.
+   */
+  RosSubscriberSystem(const std::string& topic, ros::NodeHandle* node_handle)
+      : topic_(topic), node_handle_(node_handle) {
+    DRAKE_DEMAND(node_handle_);
+
+    subscriber_ = node_handle->subscribe(
+        topic, 100, &RosSubscriberSystem<RosMessage>::HandleMessage, this);
+
+    DeclareAbstractOutputPort(
+        [this]() {
+          return this->AllocateOutputValue();
+        },
+        [this](const systems::Context<double>& context, AbstractValue* out) {
+          this->CalcOutputValue(context, out);
+        });
+
+    set_name(make_name(topic_));
+  }
+
+  ~RosSubscriberSystem() override{};
+
+  const std::string& get_topic_name() const { return topic_; }
+
+  /// Returns the default name for a system that publishes @p topic.
+  static std::string make_name(const std::string& topic) {
+    return "RosSubscriberSystem(" + topic + ")";
+  }
+
+  /**
+   * Blocks the caller until @p old_message_count is different from the
+   * internal message counter, and the internal message counter is returned.
+   */
+  int WaitForMessage(int old_message_count) const {
+    // The message buffer and counter are updated in HandleMessage(), which is
+    // a callback function invoked by a potentially different thread. Thus,
+    // for thread safety, these need to be properly protected by a mutex.
+    std::unique_lock<std::mutex> lock(received_message_mutex_);
+
+    // This while loop is necessary to guard for spurious wakeup:
+    // https://en.wikipedia.org/wiki/Spurious_wakeup
+    while (old_message_count == received_message_count_)
+      // When wait returns, lock is atomically acquired. So it's thread safe to
+      // read received_message_count_.
+      received_message_condition_variable_.wait(lock);
+    int new_message_count = received_message_count_;
+    lock.unlock();
+
+    return new_message_count;
+  }
+
+  /**
+   * Returns the message counter stored in @p context.
+   */
+  int GetMessageCount(const systems::Context<double>& context) const {
+    // Gets the last message count from abstract state.
+    return context.get_abstract_state<int>(kStateIndexMessageCount);
+  }
+
+ protected:
+  void DoCalcNextUpdateTime(const systems::Context<double>& context,
+                            systems::CompositeEventCollection<double>* events,
+                            double* time) const override {
+    const int last_message_count = GetMessageCount(context);
+
+    const int received_message_count = [this]() {
+      std::unique_lock<std::mutex> lock(received_message_mutex_);
+      return received_message_count_;
+    }();
+
+    // Has a new message. Schedule an update event.
+    if (last_message_count != received_message_count) {
+      // TODO(siyuan): should be context.get_time() once #5725 is resolved.
+      *time = context.get_time() + 0.0001;
+
+      systems::EventCollection<systems::UnrestrictedUpdateEvent<double>>&
+          uu_events = events->get_mutable_unrestricted_update_events();
+      uu_events.add_event(
+          std::make_unique<systems::UnrestrictedUpdateEvent<double>>(
+              systems::Event<double>::TriggerType::kTimed));
+    }
+  }
+
+  void DoCalcUnrestrictedUpdate(
+      const systems::Context<double>&,
+      const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
+      systems::State<double>* state) const override {
+    ProcessMessageAndStoreToAbstractState(&state->get_mutable_abstract_state());
+  }
+
+  std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
+      const override {
+    std::vector<std::unique_ptr<AbstractValue>> abstract_vals(2);
+    abstract_vals[kStateIndexMessage] =
+        this->RosSubscriberSystem::AllocateOutputValue();
+    abstract_vals[kStateIndexMessageCount] =
+        AbstractValue::Make<int>(0);
+    return std::make_unique<systems::AbstractValues>(std::move(abstract_vals));
+  }
+
+  void SetDefaultState(const systems::Context<double>& context,
+                       systems::State<double>* state) const override {
+    ProcessMessageAndStoreToAbstractState(&state->get_mutable_abstract_state());
+  };
+
+ private:
+  void ProcessMessageAndStoreToAbstractState(
+      systems::AbstractValues* abstract_state) const {
+    std::lock_guard<std::mutex> lock(received_message_mutex_);
+    abstract_state->get_mutable_value(kStateIndexMessage)
+        .get_mutable_value<RosMessage>() = received_message_;
+    abstract_state->get_mutable_value(kStateIndexMessageCount)
+        .get_mutable_value<int>() = received_message_count_;
+  };
+
+  // Callback entry point from ROS into this class. Also wakes up one thread
+  // block on notification_ if it's not nullptr.
+  void HandleMessage(const RosMessage& message) {
+    SPDLOG_TRACE(drake::log(), "Receiving ROS {} message", topic_);
+    std::lock_guard<std::mutex> lock(received_message_mutex_);
+    received_message_ = message;
+    received_message_count_++;
+    received_message_condition_variable_.notify_all();
+  }
+
+  // This pair of methods is used for the output port when we're using a
+  // serializer.
+  std::unique_ptr<AbstractValue> AllocateOutputValue() const {
+    return std::make_unique<Value<RosMessage>>(RosMessage{});
+  }
+  void CalcOutputValue(const systems::Context<double>& context,
+                       AbstractValue* output_value) const {
+    output_value->SetFrom(
+        context.get_abstract_state().get_value(kStateIndexMessage));
+  }
+
+  // The topic on which to receive ROS messages.
+  const std::string topic_;
+
+  // The mutex that guards received_message_ and received_message_count_.
+  mutable std::mutex received_message_mutex_;
+
+  // A condition variable that's signaled every time the handler is called.
+  mutable std::condition_variable received_message_condition_variable_;
+
+  // The most recently received ROS message.
+  RosMessage received_message_{};
+
+  // A message counter that's incremented every time the handler is called.
+  int received_message_count_{0};
+
+  ros::NodeHandle* const node_handle_{};
+  ros::Subscriber subscriber_;
+
+  constexpr static int kStateIndexMessage = 0;
+  constexpr static int kStateIndexMessageCount = 1;
+};
+
+}  // namespace drake_ros_systems

--- a/systems/ros/test/test_ros_publisher_system.cc
+++ b/systems/ros/test/test_ros_publisher_system.cc
@@ -25,8 +25,7 @@ int DoMain(ros::NodeHandle& node_handle) {
   DiagramBuilder<double> builder;
 
   auto msg_publisher = builder.AddSystem(
-      RosPublisherSystem<std_msgs::String>::Make("chatter", &node_handle));
-  msg_publisher->set_publish_period(0.25);
+      RosPublisherSystem<std_msgs::String>::Make("chatter", &node_handle, .25));
 
   std_msgs::String msg;
   msg.data = "Hello world!";

--- a/systems/ros/test/test_ros_publisher_system.cc
+++ b/systems/ros/test/test_ros_publisher_system.cc
@@ -1,0 +1,65 @@
+#include <memory>
+#include <signal.h>
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/primitives/constant_value_source.h"
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+
+#include "systems/ros/ros_publisher_system.h"
+
+using drake::AbstractValue;
+using drake::systems::ConstantValueSource;
+using drake::systems::Context;
+using drake::systems::Diagram;
+using drake::systems::DiagramBuilder;
+using drake::systems::InputPort;
+using drake::systems::OutputPort;
+using drake::systems::Simulator;
+
+using namespace drake_ros_systems;
+
+// Shutdown ROS gracefully and then exit
+void SigintHandler(int sig) {
+  ros::shutdown();
+  exit(sig);
+}
+
+int DoMain(ros::NodeHandle& node_handle) {
+  DiagramBuilder<double> builder;
+
+  auto msg_publisher = builder.AddSystem(
+      RosPublisherSystem<std_msgs::String>::Make("chatter", &node_handle));
+  msg_publisher->set_publish_period(0.25);
+
+  std_msgs::String msg;
+  msg.data = "Hello world!";
+
+  auto msg_source =
+      builder.AddSystem(std::make_unique<ConstantValueSource<double>>(
+          Value<std_msgs::String>(msg)));
+
+  builder.Connect(msg_source->get_output_port(0),
+                  msg_publisher->get_input_port(0));
+
+  auto sys = builder.Build();
+  Simulator<double> simulator(*sys);
+
+  simulator.Initialize();
+  simulator.set_target_realtime_rate(1.0);
+
+  signal(SIGINT, SigintHandler);
+
+  simulator.StepTo(std::numeric_limits<double>::infinity());
+
+  return 0;
+}
+
+int main(int argc, char* argv[]) {
+  ros::init(argc, argv, "test_ros_publisher_system");
+  ros::NodeHandle node_handle;
+
+  return DoMain(node_handle);
+}

--- a/systems/ros/test/test_ros_publisher_system.cc
+++ b/systems/ros/test/test_ros_publisher_system.cc
@@ -1,25 +1,19 @@
 #include <memory>
 #include <signal.h>
 #include "drake/systems/analysis/simulator.h"
-#include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/primitives/constant_value_source.h"
 #include "ros/ros.h"
 #include "std_msgs/String.h"
 
 #include "systems/ros/ros_publisher_system.h"
 
-using drake::AbstractValue;
+using drake::Value;
 using drake::systems::ConstantValueSource;
-using drake::systems::Context;
-using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
-using drake::systems::InputPort;
-using drake::systems::OutputPort;
 using drake::systems::Simulator;
 
-using namespace drake_ros_systems;
+using dairlib::systems::RosPublisherSystem;
 
 // Shutdown ROS gracefully and then exit
 void SigintHandler(int sig) {

--- a/systems/ros/test/test_ros_subscriber_system.cc
+++ b/systems/ros/test/test_ros_subscriber_system.cc
@@ -28,8 +28,7 @@ int DoMain(ros::NodeHandle& node_handle) {
           "chatter", &node_handle));
 
   auto msg_publisher = builder.AddSystem(
-      RosPublisherSystem<std_msgs::String>::Make("echo", &node_handle));
-  msg_publisher->set_publish_period(0.25);
+      RosPublisherSystem<std_msgs::String>::Make("echo", &node_handle, .25));
 
   builder.Connect(*msg_subscriber, *msg_publisher);
 

--- a/systems/ros/test/test_ros_subscriber_system.cc
+++ b/systems/ros/test/test_ros_subscriber_system.cc
@@ -1,27 +1,18 @@
 #include <memory>
 #include <signal.h>
 #include "drake/systems/analysis/simulator.h"
-#include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port.h"
-#include "drake/systems/primitives/constant_value_source.h"
 #include "ros/ros.h"
 #include "std_msgs/String.h"
 
 #include "systems/ros/ros_subscriber_system.h"
 #include "systems/ros/ros_publisher_system.h"
 
-using drake::AbstractValue;
-using drake::systems::ConstantValueSource;
-using drake::systems::Context;
-using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
-using drake::systems::InputPort;
-using drake::systems::OutputPort;
 using drake::systems::Simulator;
 
-using namespace drake_ros_systems;
+using dairlib::systems::RosSubscriberSystem;
+using dairlib::systems::RosPublisherSystem;
 
 // Shutdown ROS gracefully and then exit
 void SigintHandler(int sig) {

--- a/systems/ros/test/test_ros_subscriber_system.cc
+++ b/systems/ros/test/test_ros_subscriber_system.cc
@@ -1,0 +1,65 @@
+#include <memory>
+#include <signal.h>
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/output_port.h"
+#include "drake/systems/primitives/constant_value_source.h"
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+
+#include "systems/ros/ros_subscriber_system.h"
+#include "systems/ros/ros_publisher_system.h"
+
+using drake::AbstractValue;
+using drake::systems::ConstantValueSource;
+using drake::systems::Context;
+using drake::systems::Diagram;
+using drake::systems::DiagramBuilder;
+using drake::systems::InputPort;
+using drake::systems::OutputPort;
+using drake::systems::Simulator;
+
+using namespace drake_ros_systems;
+
+// Shutdown ROS gracefully and then exit
+void SigintHandler(int sig) {
+  ros::shutdown();
+  exit(sig);
+}
+
+int DoMain(ros::NodeHandle& node_handle) {
+  DiagramBuilder<double> builder;
+
+  auto msg_subscriber =
+      builder.AddSystem(RosSubscriberSystem<std_msgs::String>::Make(
+          "chatter", &node_handle));
+
+  auto msg_publisher = builder.AddSystem(
+      RosPublisherSystem<std_msgs::String>::Make("echo", &node_handle));
+  msg_publisher->set_publish_period(0.25);
+
+  builder.Connect(*msg_subscriber, *msg_publisher);
+
+  auto sys = builder.Build();
+  Simulator<double> simulator(*sys);
+
+  simulator.Initialize();
+  simulator.set_target_realtime_rate(1.0);
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  signal(SIGINT, SigintHandler);
+
+  simulator.StepTo(std::numeric_limits<double>::infinity());
+
+  return 0;
+}
+
+int main(int argc, char* argv[]) {
+  ros::init(argc, argv, "test_ros_subscriber_system");
+  ros::NodeHandle node_handle;
+
+  return DoMain(node_handle);
+}

--- a/tools/bazel
+++ b/tools/bazel
@@ -7,8 +7,6 @@ while [[ "${WORKSPACE_DIR}" != / ]]; do
 done
 readonly WORKSPACE_DIR
 
-ls -l ${WORKSPACE_DIR}/noros.bazelrc
-
 if [ "${DAIRLIB_WITH_ROS}" == "ON" ] ; then
   exec -a "$0" "${BAZEL_REAL}" "$@"
 else

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,0 +1,16 @@
+WORKSPACE_DIR="${PWD}"
+while [[ "${WORKSPACE_DIR}" != / ]]; do
+    if [[ -e "${WORKSPACE_DIR}/WORKSPACE" ]]; then
+      break;
+    fi
+    WORKSPACE_DIR="$(dirname "${WORKSPACE_DIR}")"
+done
+readonly WORKSPACE_DIR
+
+ls -l ${WORKSPACE_DIR}/noros.bazelrc
+
+if [ "${DAIRLIB_WITH_ROS}" == "ON" ] ; then
+  exec -a "$0" "${BAZEL_REAL}" "$@"
+else
+  exec -a "$0" "${BAZEL_REAL}" "--bazelrc=${WORKSPACE_DIR}/noros.bazelrc" "$@"
+fi

--- a/tools/workspace/ros/.gitignore
+++ b/tools/workspace/ros/.gitignore
@@ -1,0 +1,1 @@
+/bundle_ws/

--- a/tools/workspace/ros/BUILD.bazel
+++ b/tools/workspace/ros/BUILD.bazel
@@ -1,0 +1,27 @@
+# -*- python -*-
+
+# ROS packages built with Bazel
+
+cc_binary(
+    name='main',
+    srcs=['test/main.cpp'],
+    deps=[
+        '@ros',
+    ],
+)
+
+py_binary(
+    name='main_python',
+    srcs=['test/main_python.py'],
+    deps=[
+        '@ros//:ros_python',
+    ],
+)
+
+py_binary(
+    name='genmsg_test',
+    srcs=['test/genmsg_test.py'],
+    deps=[
+        '@genpy_repo//:genpy',
+    ],
+)

--- a/tools/workspace/ros/BUILD.bazel
+++ b/tools/workspace/ros/BUILD.bazel
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-# ROS packages built with Bazel
+# Demo programs
 
 cc_binary(
     name='main',
@@ -8,6 +8,7 @@ cc_binary(
     deps=[
         '@ros',
     ],
+    tags=["ros"],
 )
 
 py_binary(
@@ -16,6 +17,7 @@ py_binary(
     deps=[
         '@ros//:ros_python',
     ],
+    tags=["ros"],
 )
 
 py_binary(
@@ -24,4 +26,5 @@ py_binary(
     deps=[
         '@genpy_repo//:genpy',
     ],
+    tags=["ros"],
 )

--- a/tools/workspace/ros/LICENSE_ros-bazel
+++ b/tools/workspace/ros/LICENSE_ros-bazel
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Nicolo Valigi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/workspace/ros/bazel/genmsg.BUILD
+++ b/tools/workspace/ros/bazel/genmsg.BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name='genmsg',
+    srcs=glob(['src/**/*.py']),
+    imports=['src'],
+)

--- a/tools/workspace/ros/bazel/genpy.BUILD
+++ b/tools/workspace/ros/bazel/genpy.BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+
+py_library(
+    name='genpy',
+    srcs=glob(['src/**/*.py']),
+    imports=['src'],
+    deps=[
+    	'@genmsg_repo//:genmsg'
+    ],
+)
+
+
+py_binary(
+	name='genmsg_py',
+	srcs=['scripts/genmsg_py.py'],
+	deps=[
+		':genpy'
+	],
+)

--- a/tools/workspace/ros/bazel/message_generation.bzl
+++ b/tools/workspace/ros/bazel/message_generation.bzl
@@ -45,7 +45,7 @@ def _genpy_impl(ctx):
     outpath = ctx.outputs.outs[0].dirname
 
     # Generate __init__.py for package
-    ctx.file_action(
+    ctx.actions.write(
         output=ctx.outputs.outs[-1],
         content='',
     )

--- a/tools/workspace/ros/bazel/message_generation.bzl
+++ b/tools/workspace/ros/bazel/message_generation.bzl
@@ -51,7 +51,7 @@ def _genpy_impl(ctx):
     )
 
     # Generate the actual messages
-    ctx.action(
+    ctx.action.run(
         inputs=ctx.files.srcs,
         outputs=ctx.outputs.outs[:-2],
         executable=ctx.executable._gen_script,
@@ -69,7 +69,7 @@ def _genpy_impl(ctx):
     # Generate __init__.py for msg module
     # NOTE: it looks at the .py files in its output path, so it also
     # needs to depend on the previous step.
-    ctx.action(
+    ctx.action.run(
         inputs=ctx.files.srcs + ctx.outputs.outs[:-2],
         outputs=[ctx.outputs.outs[-2]],
         executable=ctx.executable._gen_script,

--- a/tools/workspace/ros/bazel/message_generation.bzl
+++ b/tools/workspace/ros/bazel/message_generation.bzl
@@ -1,0 +1,130 @@
+# Reference:
+# https://docs.bazel.build/versions/master/skylark/cookbook.html
+# https://github.com/RobotLocomotion/drake/blob/eefddbee62439156b6faaf3b0cecdd0c57e704d7/tools/lcm.bzl
+
+load('//tools/workspace/ros/bazel:path_utils.bzl', 'basename', 'dirname', 'join_paths')
+
+
+def _genmsg_outs(srcs, ros_package_name, extension):
+    """ Given a list of *.msg files, return the expected paths
+    to the generated code with that extension. """
+
+    (extension in ['.py', '.h']
+        or fail('Unknown extension %s' % extension))
+
+    msg_names = []
+    for item in srcs:
+        if not item.endswith('.msg'):
+            fail('%s does not end in .msg' % item)
+        item_name = basename(item)[:-len('.msg')]
+
+        if extension == '.py':
+            item_name = '_' + item_name
+
+        msg_names.append(item_name)
+
+    outs = [
+        join_paths(ros_package_name, 'msg', msg_name + extension)
+        for msg_name in msg_names
+    ]
+
+    if extension == '.py':
+        outs += [
+            join_paths(ros_package_name, 'msg', '__init__.py'),
+            join_paths(ros_package_name, '__init__.py'),
+        ]
+
+    return outs
+
+
+def _genpy_impl(ctx):
+    """Implementation for the genpy rule. Shells out to the scripts
+    shipped with genpy."""
+
+    srcpath = ctx.files.srcs[0].dirname
+    outpath = ctx.outputs.outs[0].dirname
+
+    # Generate __init__.py for package
+    ctx.file_action(
+        output=ctx.outputs.outs[-1],
+        content='',
+    )
+
+    # Generate the actual messages
+    ctx.action(
+        inputs=ctx.files.srcs,
+        outputs=ctx.outputs.outs[:-2],
+        executable=ctx.executable._gen_script,
+        arguments=[
+            '-o', outpath,
+            '-p', ctx.attr.ros_package_name,
+            # Include path for the current package
+            '-I', '%s:%s' % (ctx.attr.ros_package_name, srcpath),
+            # TODO: include paths of dependent packages
+        ] + [
+            f.path for f in ctx.files.srcs
+        ],
+    )
+
+    # Generate __init__.py for msg module
+    # NOTE: it looks at the .py files in its output path, so it also
+    # needs to depend on the previous step.
+    ctx.action(
+        inputs=ctx.files.srcs + ctx.outputs.outs[:-2],
+        outputs=[ctx.outputs.outs[-2]],
+        executable=ctx.executable._gen_script,
+        arguments=[
+            '--initpy',
+            '-o', outpath,
+            '-p', ctx.attr.ros_package_name,
+        ],
+    )
+
+    return struct()
+
+
+_genpy = rule(
+    implementation=_genpy_impl,
+    output_to_genfiles=True,
+    attrs={
+        'srcs': attr.label_list(allow_files=True),
+        'ros_package_name': attr.string(),
+        '_gen_script': attr.label(
+            default=Label('@genpy_repo//:genmsg_py'),
+            executable=True,
+            cfg='host'),
+        'outs': attr.output_list(),
+    },
+)
+
+
+def generate_messages(srcs=None,
+                      ros_package_name=None):
+    """ Wraps all message generation functionality. Uses the _genpy
+    and _gencpp to shell out to the code generation scripts, then wraps
+    the resulting files into Python and C++ libraries.
+    We use macros to hide some of the book-keeping of input & output
+    files. """
+
+    if not srcs:
+        fail('srcs is required (*.msg files).')
+    if not ros_package_name:
+        fail('ros_package_name is required.')
+
+    outs = _genmsg_outs(srcs, ros_package_name, '.py')
+
+    _genpy(
+        name='lkfjaklsjfklasd',
+        srcs=srcs,
+        ros_package_name=ros_package_name,
+        outs=outs,
+    )
+
+    native.py_library(
+        name='msgs_py',
+        srcs=outs,
+        imports=['.'],
+        deps=[
+            '@genpy_repo//:genpy'
+        ],
+    )

--- a/tools/workspace/ros/bazel/message_generation.bzl
+++ b/tools/workspace/ros/bazel/message_generation.bzl
@@ -51,7 +51,7 @@ def _genpy_impl(ctx):
     )
 
     # Generate the actual messages
-    ctx.action.run(
+    ctx.actions.run(
         inputs=ctx.files.srcs,
         outputs=ctx.outputs.outs[:-2],
         executable=ctx.executable._gen_script,
@@ -69,7 +69,7 @@ def _genpy_impl(ctx):
     # Generate __init__.py for msg module
     # NOTE: it looks at the .py files in its output path, so it also
     # needs to depend on the previous step.
-    ctx.action.run(
+    ctx.actions.run(
         inputs=ctx.files.srcs + ctx.outputs.outs[:-2],
         outputs=[ctx.outputs.outs[-2]],
         executable=ctx.executable._gen_script,

--- a/tools/workspace/ros/bazel/path_utils.bzl
+++ b/tools/workspace/ros/bazel/path_utils.bzl
@@ -1,0 +1,41 @@
+# Lifted from:
+# https://github.com/RobotLocomotion/drake/blob/eefddbee62439156b6faaf3b0cecdd0c57e704d7/tools/pathutils.bzl
+
+def basename(path):
+    """Return the file name portion of a file path."""
+    return path.split("/")[-1]
+
+
+def dirname(path):
+    """Return the directory portion of a file path."""
+    if path == "/":
+        return "/"
+
+    parts = path.split("/")
+
+    if len(parts) > 1:
+        return "/".join(parts[:-1])
+
+    return "."
+
+
+def join_paths(*args):
+    """Join paths without duplicating separators.
+    This is roughly equivalent to Python's `os.path.join`.
+    Args:
+        \*args (:obj:`list` of :obj:`str`): Path components to be joined.
+    Returns:
+        :obj:`str`: The concatenation of the input path components.
+    """
+    result = ""
+
+    for part in args:
+        if part.endswith("/"):
+            part = part[-1]
+
+        if part == "" or part == ".":
+            continue
+
+        result += part + "/"
+
+    return result[:-1]

--- a/tools/workspace/ros/bazel/pypi.bzl
+++ b/tools/workspace/ros/bazel/pypi.bzl
@@ -1,0 +1,54 @@
+_BUILD_FILE = """
+py_library(
+    name = 'libraries',
+    srcs = glob(
+        include = ['bin/**/*.py', 'site-packages/**/*.py'],
+    ),
+    data = glob(
+        include = ['bin/**/*', 'site-packages/**/*'],
+        exclude = ['**/*.py', '**/*.pyc']
+    ),
+    imports=['site-packages'],
+    visibility = ['//visibility:public']
+)
+"""
+
+
+def pip_package_impl(ctx):
+    getpip = ctx.path(ctx.attr._getpip)
+    path = ctx.path('site-packages')
+
+    command = ['python', str(getpip)]
+    command += list(ctx.attr.packages)
+    command += ['--target', str(path)]
+    command += ['--install-option', '--install-scripts=%s' % ctx.path('bin')]
+    command += ['--no-cache-dir']
+
+    print(command)
+    result = ctx.execute(command)
+    if result.return_code != 0:
+      fail('Failed to execute %s.\n%s\n%s' % (
+          ' '.join(command), result.stdout, result.stderr))
+    ctx.file('BUILD', _BUILD_FILE, False)
+
+
+pip_requirements = repository_rule(
+    pip_package_impl,
+    attrs={
+        'packages': attr.string_list(),
+        '_getpip': attr.label(
+            default=Label('@pip//file:get-pip.py'),
+            allow_single_file=True,
+            executable=True,
+            cfg='host'
+        )
+    }
+)
+
+
+def pip():
+  native.http_file(
+      name="pip",
+      url="https://bootstrap.pypa.io/get-pip.py",
+      sha256="19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c"
+  )

--- a/tools/workspace/ros/compile_ros_workspace.sh
+++ b/tools/workspace/ros/compile_ros_workspace.sh
@@ -9,7 +9,6 @@ mkdir bundle_ws
 pushd bundle_ws
 
 rosinstall_generator \
-    --rosdistro melodic \
     --deps \
     --tar \
     --flat \

--- a/tools/workspace/ros/compile_ros_workspace.sh
+++ b/tools/workspace/ros/compile_ros_workspace.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+BASE_DIR="$PWD"
+
+cd $(dirname "$BASH_SOURCE")
 
 set -e
 
@@ -26,3 +29,5 @@ catkin config \
     --no-extend
 
 catkin build
+
+cd $BASE_DIR

--- a/tools/workspace/ros/compile_ros_workspace.sh
+++ b/tools/workspace/ros/compile_ros_workspace.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+PACKAGES="roscpp rospy"
+
+rm -rf bundle_ws
+mkdir bundle_ws
+pushd bundle_ws
+
+rosinstall_generator \
+    --rosdistro melodic \
+    --deps \
+    --tar \
+    --flat \
+    $PACKAGES > ws.rosinstall
+wstool init -j1 src ws.rosinstall
+
+catkin config \
+    --install \
+    --source-space src \
+    --build-space build \
+    --devel-space devel \
+    --log-space log \
+    --install-space install \
+    --isolate-devel \
+    --no-extend
+
+catkin build

--- a/tools/workspace/ros/ros.bazel
+++ b/tools/workspace/ros/ros.bazel
@@ -1,0 +1,18 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+# Prebuilt C++ and Python ROS libraries
+
+cc_library(
+    name='ros',
+    srcs=glob(['lib/*.so']),
+    hdrs=glob(['include/**/*.h', 'include/**/*.hpp']),
+    strip_include_prefix='include'
+)
+
+py_library(
+    name='ros_python',
+    srcs=glob(['lib/python2.7/dist-packages/**/*.py']),
+    imports=['lib/python2.7/dist-packages/']
+)

--- a/tools/workspace/ros/test/genmsg_test.py
+++ b/tools/workspace/ros/test/genmsg_test.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import genpy
+
+import genpy.generator
+
+def main():
+	pass
+
+if __name__ == '__main__':
+	main()

--- a/tools/workspace/ros/test/main.cpp
+++ b/tools/workspace/ros/test/main.cpp
@@ -1,0 +1,33 @@
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+#include <sstream>
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "talker");
+
+  ros::NodeHandle n;
+  ros::Publisher chatter_pub = n.advertise<std_msgs::String>("chatter", 1000);
+
+  ros::Rate loop_rate(10);
+
+  int count = 0;
+  while (ros::ok()) {
+    std_msgs::String msg;
+
+    std::stringstream ss;
+    ss << "hello world " << count;
+    msg.data = ss.str();
+
+    ROS_INFO("%s", msg.data.c_str());
+
+    chatter_pub.publish(msg);
+
+    ros::spinOnce();
+
+    loop_rate.sleep();
+    ++count;
+  }
+
+  return 0;
+}

--- a/tools/workspace/ros/test/main_python.py
+++ b/tools/workspace/ros/test/main_python.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+"""
+Simple node for testing the Python ROS libraries.
+"""
+
+import rospy
+from std_msgs.msg import String
+
+def talker():
+    pub = rospy.Publisher('chatter', String, queue_size=10)
+    rospy.init_node('talker', anonymous=True)
+    rate = rospy.Rate(10) # 10hz
+    while not rospy.is_shutdown():
+        hello_str = "hello world %s" % rospy.get_time()
+        rospy.loginfo(hello_str)
+        pub.publish(hello_str)
+        rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        talker()
+    except rospy.ROSInterruptException:
+        pass

--- a/tools/workspace/ros/test/test_msgs/BUILD
+++ b/tools/workspace/ros/test/test_msgs/BUILD
@@ -12,4 +12,5 @@ py_binary(
     deps=[
         ':msgs_py',
     ],
+    tags=["ros"],
 )

--- a/tools/workspace/ros/test/test_msgs/BUILD
+++ b/tools/workspace/ros/test/test_msgs/BUILD
@@ -1,0 +1,15 @@
+load('//tools/workspace/ros/bazel:message_generation.bzl', 'generate_messages')
+
+# Implicitly creates a msgs_py target in the current scope
+generate_messages(
+    srcs=glob(['msg/*.msg']),
+    ros_package_name='test_msgs',
+)
+
+py_binary(
+    name='main',
+    srcs=['scripts/main.py'],
+    deps=[
+        ':msgs_py',
+    ],
+)

--- a/tools/workspace/ros/test/test_msgs/msg/Message1.msg
+++ b/tools/workspace/ros/test/test_msgs/msg/Message1.msg
@@ -1,0 +1,1 @@
+uint64 auint64

--- a/tools/workspace/ros/test/test_msgs/msg/Message2.msg
+++ b/tools/workspace/ros/test/test_msgs/msg/Message2.msg
@@ -1,0 +1,2 @@
+string     astr
+Message1   amsg1

--- a/tools/workspace/ros/test/test_msgs/scripts/main.py
+++ b/tools/workspace/ros/test/test_msgs/scripts/main.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from test_msgs.msg import (
+	Message1,
+	Message2,
+)
+
+
+def main():
+    m1 = Message1()
+    print(m1)
+
+    m2 = Message2()
+    print(m2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
~~This is a work in progress, and is not yet meant to be merged.~~

This PR is a port of two other projects:

1. https://github.com/nicolov/ros-bazel
2. https://github.com/gizatt/drake_ros_systems

**ros-bazel** builds ROS within bazel using catkin. Currently, this requires running an installation script.
**drake_ros_systems** is an implementation of ROS pub/sub systems.

Neither of these libraries are currently in use, and both required updating to work with the latest versions of bazel and drake.

As a goal, dairlib should not *require* ROS. The library should build and run properly, though ROS-specific libraries will not function without an installation.

## Tasks for this PR
- [x]  Port of **ros-bazel**
- [x]  Port of **drake_ros_systems**
- [x] Create unified installation documentation
- [x] Gracefully skip ROS code if it is not enabled
- [x] CI integration both with and without ROS

## Installation
1. install ROS, and don't forget add to `.bashrc`
```
export ROS_MASTER_URI=http://localhost:11311
source /opt/ros/melodic/setup.bash 
```
2. Install some dependencies
```
sudo apt install python-rosinstall-generator python-catkin-tools
```
2. In `dairlib/tools/workspace/ros`, build the ros workspace using catkin
```
./compile_ros_workspace.sh
```

## Notes
- Environments that require ROS should be marked with the tag `ros`, e.g.
```
cc_library(
...
  tags=["ros"],
)
```
-The environment variable `DAIRLIB_WTH_ROS` must be set to `ON`. If it is not, then all environments with the tag `ros` will be skipped, by default, during a build or test. This can be done by adding to `~/.bashrc`
```
export DAIRLIB_WITH_ROS=ON
```

