### PR TITLE
Minor DIRCON updates

### DIFF
--- a/examples/PlanarWalker/run_gait_dircon.cc
+++ b/examples/PlanarWalker/run_gait_dircon.cc
@@ -283,13 +283,14 @@ int main(int argc, char* argv[]) {
 
   plant.Finalize();
 
-  Eigen::VectorXd x0 = Eigen::VectorXd::Zero(plant.num_positions() +
-                       plant.num_velocities());
-
+  
+    int N = 10;
   Eigen::VectorXd init_l_vec(2);
   init_l_vec << 0, 20*9.81;
-  int nu = 3;
-  int N = 10;
+  int nu = plant.num_actuators();
+  int nx = plant.num_positions() + plant.num_velocities();
+
+  Eigen::VectorXd x0 = Eigen::VectorXd::Zero(nx);
 
   std::vector<MatrixXd> init_x;
   std::vector<MatrixXd> init_u;
@@ -301,7 +302,7 @@ int main(int argc, char* argv[]) {
   std::vector<double> init_time;
   for (int i = 0; i < 2*N-1; i++) {
     init_time.push_back(i*.2);
-    init_x.push_back(x0);
+    init_x.push_back(x0 + .1*VectorXd::Random(nx));
     init_u.push_back(VectorXd::Random(nu));
   }
   auto init_x_traj = PiecewisePolynomial<double>::ZeroOrderHold(init_time, init_x);

--- a/systems/trajectory_optimization/dircon_kinematic_data_set.cc
+++ b/systems/trajectory_optimization/dircon_kinematic_data_set.cc
@@ -8,6 +8,7 @@
 namespace dairlib {
 
 using std::vector;
+using Eigen::MatrixXd;
 using drake::VectorX;
 using drake::MatrixX;
 using drake::AutoDiffXd;
@@ -18,7 +19,8 @@ using drake::math::DiscardGradient;
 template <typename T>
 DirconKinematicDataSet<T>::DirconKinematicDataSet(
     const MultibodyPlant<T>& plant,
-    vector<DirconKinematicData<T>*>* constraints) :
+    vector<DirconKinematicData<T>*>* constraints,
+    vector<int> skip_constraint_inds) :
     plant_(plant),
     constraints_(constraints),
     num_positions_(plant.num_positions()),
@@ -29,11 +31,28 @@ DirconKinematicDataSet<T>::DirconKinematicDataSet(
   for (uint i=0; i < constraints_->size(); i++) {
     constraint_count_ += (*constraints_)[i]->getLength();
   }
-  c_ = VectorX<T>(constraint_count_);
-  cdot_ = VectorX<T>(constraint_count_);
-  J_ = MatrixX<T>(constraint_count_, num_velocities_);
-  Jdotv_ = VectorX<T>(constraint_count_);
-  cddot_ = VectorX<T>(constraint_count_);
+
+  int total_count = constraint_count_;  // includes skipped constraints
+
+  // We will not include indices givein in skip_constraint_inds
+  constraint_count_ -= skip_constraint_inds.size();
+  constraint_map_ = MatrixXd::Zero(constraint_count_,
+      constraint_count_ + skip_constraint_inds.size());
+  int j = 0;
+  for (int i = 0; i < constraint_count_; i++) {
+    if (std::find(skip_constraint_inds.begin(),
+        skip_constraint_inds.end(), i) == skip_constraint_inds.end()) {
+      // skip_constraint_inds does not contain i
+      constraint_map_(j, i) = 1;
+      j++;
+    }
+  }
+
+  c_ = VectorX<T>(total_count);
+  cdot_ = VectorX<T>(total_count);
+  J_ = MatrixX<T>(total_count, num_velocities_);
+  Jdotv_ = VectorX<T>(total_count);
+  cddot_ = VectorX<T>(total_count);
   vdot_ = VectorX<T>(num_velocities_);
   xdot_ = VectorX<T>(num_positions_ + num_velocities_);
   M_ = MatrixX<T>(num_velocities_, num_velocities_);
@@ -117,27 +136,27 @@ int DirconKinematicDataSet<T>::getNumConstraintObjects() {
 
 template <typename T>
 VectorX<T> DirconKinematicDataSet<T>::getC() {
-  return c_;
+  return constraint_map_ * c_;
 }
 
 template <typename T>
 VectorX<T> DirconKinematicDataSet<T>::getCDot() {
-  return cdot_;
+  return constraint_map_ * cdot_;
 }
 
 template <typename T>
 MatrixX<T> DirconKinematicDataSet<T>::getJ() {
-  return J_;
+  return constraint_map_.cast<T>() * J_;
 }
 
 template <typename T>
 VectorX<T> DirconKinematicDataSet<T>::getJdotv() {
-  return Jdotv_;
+  return constraint_map_ * Jdotv_;
 }
 
 template <typename T>
 VectorX<T> DirconKinematicDataSet<T>::getCDDot() {
-  return cddot_;
+  return constraint_map_ * cddot_;
 }
 
 template <typename T>

--- a/systems/trajectory_optimization/dircon_kinematic_data_set.h
+++ b/systems/trajectory_optimization/dircon_kinematic_data_set.h
@@ -13,7 +13,8 @@ template <typename T>
 class DirconKinematicDataSet {
  public:
   DirconKinematicDataSet(const drake::multibody::MultibodyPlant<T>& plant,
-                         std::vector<DirconKinematicData<T>*>* constraints);
+      std::vector<DirconKinematicData<T>*>* constraints,
+      std::vector<int> skip_constraint_inds = std::vector<int>());
 
   void updateData(const drake::systems::Context<T>& context,
                   const drake::VectorX<T>& forces);
@@ -128,6 +129,8 @@ class DirconKinematicDataSet {
   drake::VectorX<T> xdot_;
   drake::MatrixX<T> M_;
   drake::VectorX<T> right_hand_side_;
+
+  Eigen::MatrixXd constraint_map_;
 
   Cache cache_;
 };

--- a/systems/trajectory_optimization/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon_opt_constraints.cc
@@ -62,7 +62,7 @@ void DirconAbstractConstraint<T>::DoEval(
 template <>
 void DirconAbstractConstraint<AutoDiffXd>::DoEval(
     const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) const {
-  EvaluateConstraint(x,y);
+  EvaluateConstraint(x, y);
 }
 
 template <>
@@ -72,17 +72,19 @@ void DirconAbstractConstraint<double>::DoEval(
     double dx = 1e-8;
 
     VectorXd x_val = autoDiffToValueMatrix(x);
-    VectorXd y0,yi;
-    EvaluateConstraint(x_val,&y0);
+    VectorXd y0, yi;
+    EvaluateConstraint(x_val, &y0);
 
-    MatrixXd dy = MatrixXd(y0.size(),x_val.size());
+    MatrixXd dy = MatrixXd(y0.size(), x_val.size());
     for (int i=0; i < x_val.size(); i++) {
       x_val(i) += dx;
-      EvaluateConstraint(x_val,&yi);
+      EvaluateConstraint(x_val, &yi);
       x_val(i) -= dx;
       dy.col(i) = (yi - y0)/dx;
     }
     drake::math::initializeAutoDiffGivenGradientMatrix(y0, dy, *y);
+
+    // std::cout << dy << std::endl  << std::endl << std::endl;
 
     // // central differencing
     // double dx = 1e-8;
@@ -119,7 +121,7 @@ DirconDynamicConstraint<T>::DirconDynamicConstraint(
     int num_positions, int num_velocities, int num_inputs,
     int num_kinematic_constraints)
     : DirconAbstractConstraint<T>(num_positions + num_velocities,
-          1 + 2 *(num_positions+ num_velocities) + (2 * num_inputs) +
+          1 + 2 *(num_positions + num_velocities) + (2 * num_inputs) +
           (4 * num_kinematic_constraints),
           Eigen::VectorXd::Zero(num_positions + num_velocities),
           Eigen::VectorXd::Zero(num_positions + num_velocities)),
@@ -172,7 +174,10 @@ void DirconDynamicConstraint<T>::EvaluateConstraint(
   auto contextcol = multibody::createContext(plant_, xcol, ucol);
   constraints_->updateData(*contextcol, lc);
   auto g = constraints_->getXDot();
-  g.head(num_positions_) += constraints_->getJ().transpose()*vc;
+  VectorX<T> vc_in_qdot_space(num_positions_);
+  plant_.MapVelocityToQDot(*contextcol,
+      constraints_->getJ().transpose()*vc, &vc_in_qdot_space);
+  g.head(num_positions_) += vc_in_qdot_space;
   *y = xdotcol - g;
 }
 
@@ -245,14 +250,47 @@ DirconKinematicConstraint<T>::DirconKinematicConstraint(
       type_{type}, is_constraint_relative_{is_constraint_relative},
       n_relative_{static_cast<int>(std::count(is_constraint_relative.begin(),
       is_constraint_relative.end(), true))} {
-  relative_map_ = MatrixXd::Zero(num_kinematic_constraints_, n_relative_);
-  int j = 0;
-  for (int i=0; i < num_kinematic_constraints_; i++) {
-    if (is_constraint_relative_[i]) {
-      relative_map_(i, j) = 1;
-      j++;
+  // ***Set sparsity pattern***
+  std::vector<std::pair<int, int>> sparsity;
+  // Acceleration constraints are dense in decision variables
+  for (int i = 0; i < num_kinematic_constraints_; i++) {
+    for (int j = 0; j < this->num_vars(); j++) {
+      sparsity.push_back({i, j});
     }
   }
+
+  // Velocity constraint depends on q and v only
+  if (type_ == kAll || type == kAccelAndVel) {
+    for (int i = 0; i < num_kinematic_constraints_; i++) {
+      for (int j = 0; j < num_states_; j++) {
+        sparsity.push_back({i + num_kinematic_constraints_, j});
+      }
+    }
+  }
+
+  // Position constraint only depends on q and any offset variables
+  // Set relative map in the same loop
+  if (type == kAll) {
+    relative_map_ = MatrixXd::Zero(num_kinematic_constraints_, n_relative_);
+    int j = 0;
+
+    for (int i = 0; i < num_kinematic_constraints_; i++) {
+      for (int j = 0; j < num_positions_; j++) {
+        sparsity.push_back({i + 2* num_kinematic_constraints_, j});
+      }
+
+      if (is_constraint_relative_[i]) {
+        relative_map_(i, j) = 1;
+        // ith constraint depends on jth offset variable
+        sparsity.push_back({i + 2* num_kinematic_constraints_,
+            num_states_ + num_inputs_ + num_kinematic_constraints_ + j});
+
+        j++;
+      }
+    }
+  }
+
+  this->SetGradientSparsityPattern(sparsity);
 }
 
 template <typename T>
@@ -276,12 +314,12 @@ void DirconKinematicConstraint<T>::EvaluateConstraint(
   switch (type_) {
     case kAll:
       *y = VectorX<T>(3*num_kinematic_constraints_);
-      *y << constraints_->getC() + relative_map_*offset,
-            constraints_->getCDot(), constraints_->getCDDot();
+      *y << constraints_->getCDDot(), constraints_->getCDot(),
+            constraints_->getC() + relative_map_*offset;
       break;
     case kAccelAndVel:
       *y = VectorX<T>(2*num_kinematic_constraints_);
-      *y << constraints_->getCDot(), constraints_->getCDDot();
+      *y << constraints_->getCDDot(), constraints_->getCDot();
       break;
     case kAccelOnly:
       *y = VectorX<T>(1*num_kinematic_constraints_);

--- a/systems/trajectory_optimization/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon_opt_constraints.cc
@@ -272,7 +272,7 @@ DirconKinematicConstraint<T>::DirconKinematicConstraint(
   // Set relative map in the same loop
   if (type == kAll) {
     relative_map_ = MatrixXd::Zero(num_kinematic_constraints_, n_relative_);
-    int j = 0;
+    int k = 0;
 
     for (int i = 0; i < num_kinematic_constraints_; i++) {
       for (int j = 0; j < num_positions_; j++) {
@@ -280,12 +280,12 @@ DirconKinematicConstraint<T>::DirconKinematicConstraint(
       }
 
       if (is_constraint_relative_[i]) {
-        relative_map_(i, j) = 1;
-        // ith constraint depends on jth offset variable
+        relative_map_(i, k) = 1;
+        // ith constraint depends on kth offset variable
         sparsity.push_back({i + 2* num_kinematic_constraints_,
-            num_states_ + num_inputs_ + num_kinematic_constraints_ + j});
+            num_states_ + num_inputs_ + num_kinematic_constraints_ + k});
 
-        j++;
+        k++;
       }
     }
   }


### PR DESCRIPTION
1. Set sparsity patern of DIRCON kinematic constraints (slight performance boost).
2. Added option to DIRCON to skip constraints, but still include their associated force variables.