### PR TITLE
Added Cassie joint velocity shutdown

### DIFF
--- a/examples/Cassie/BUILD.bazel
+++ b/examples/Cassie/BUILD.bazel
@@ -66,6 +66,16 @@ cc_binary(
     ],
 )
 
+cc_library(
+  name = "input_supervisor",
+  srcs = ["input_supervisor.cc"],
+  hdrs = ["input_supervisor.h"],
+  deps = [
+        "//systems/primitives",
+        "@drake//:drake_shared_library",
+    ],
+)
+
 cc_binary(
     name = "run_pd_controller",
     srcs = ["run_pd_controller.cc"],
@@ -193,6 +203,7 @@ cc_binary(
           ":cassie_utils",
           ":cassie_rbt_state_estimator",
           ":cassie_urdf",
+          ":input_supervisor",
           "@gflags",
          ],
 )

--- a/examples/Cassie/cassie_test.pmd
+++ b/examples/Cassie/cassie_test.pmd
@@ -19,7 +19,7 @@ group "1.simulated-robot" {
         host = "localhost";
     }
     cmd "2.b.dispatcher-robot-out (gazebo)" {
-        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=false";
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=false --floating_base=false";
         host = "localhost";
     }
     cmd "1.simulator (dispatched)" {

--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -10,6 +10,7 @@
 
 #include "attic/multibody/rigidbody_utils.h"
 #include "systems/robot_lcm_systems.h"
+#include "examples/Cassie/input_supervisor.h"
 #include "examples/Cassie/networking/cassie_udp_publisher.h"
 #include "examples/Cassie/networking/cassie_input_translator.h"
 #include "examples/Cassie/cassie_utils.h"
@@ -30,6 +31,9 @@ using drake::systems::TriggerType;
 DEFINE_string(address, "127.0.0.1", "IPv4 address to publish to (UDP).");
 DEFINE_int64(port, 25000, "Port to publish to (UDP).");
 DEFINE_double(pub_rate, .02, "Network LCM pubishing period (s).");
+DEFINE_double(max_joint_velocity, 10, "Maximum joint velocity before error is triggered");
+DEFINE_string(state_channel_name, "CASSIE_STATE",
+    "The name of the lcm channel that sends Cassie's state");
 
 // Cassie model paramter
 DEFINE_bool(floating_base, false, "Fixed or floating base model");
@@ -56,15 +60,25 @@ int do_main(int argc, char* argv[]) {
   // Create LCM receiver for commands
   auto command_receiver = builder.AddSystem<RobotInputReceiver>(*tree);
 
-  // auto command_sub = builder.AddSystem(
-  //     LcmSubscriberSystem::Make<dairlib::lcmt_robot_input>(channel_u,
-  //         &lcm_local));
-  // builder.Connect(*command_sub, *command_receiver);
+    // Create state estimate receiver, used for safety checks
+  auto state_sub = builder.AddSystem(
+      LcmSubscriberSystem::Make<dairlib::lcmt_robot_output>(
+          FLAGS_state_channel_name, &lcm_local));
+  auto state_receiver = builder.AddSystem<systems::RobotOutputReceiver>(*tree);
+  builder.Connect(*state_sub, *state_receiver);
+
+  double input_supervisor_update_period = 1.0/100.0;
+  auto input_supervisor = builder.AddSystem<InputSupervisor>(*tree,
+      FLAGS_max_joint_velocity, input_supervisor_update_period);
+  builder.Connect(state_receiver->get_output_port(0),
+      input_supervisor->get_input_port_state());
+  builder.Connect(command_receiver->get_output_port(0),
+      input_supervisor->get_input_port_command());
 
   // Create and connect translator
   auto input_translator =
       builder.AddSystem<systems::CassieInputTranslator>(*tree);
-  builder.Connect(*command_receiver, *input_translator);
+  builder.Connect(*input_supervisor, *input_translator);
 
   // Create and connect input publisher.
   auto input_pub = builder.AddSystem(

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -1,0 +1,75 @@
+#include "examples/Cassie/input_supervisor.h"
+#include "systems/framework/output_vector.h"
+
+using drake::systems::Context;
+using drake::systems::DiscreteValues;
+
+namespace dairlib {
+using systems::TimestampedVector;
+using systems::OutputVector;
+
+
+InputSupervisor::InputSupervisor(const RigidBodyTree<double>& tree,
+    double max_joint_velocity, double update_period) :
+    tree_(tree),
+    num_actuators_(tree_.get_num_actuators()),
+    num_positions_(tree_.get_num_positions()),
+    num_velocities_(tree_.get_num_velocities()),
+    max_joint_velocity_(max_joint_velocity) {
+  // Create input ports
+  command_input_port_ = this->DeclareVectorInputPort(TimestampedVector<double>(
+      num_actuators_)).get_index();
+  state_input_port_ = this->DeclareVectorInputPort(OutputVector<double>(
+      num_positions_, num_velocities_, num_actuators_)).get_index();
+
+  // Create output port
+  this->DeclareVectorOutputPort(TimestampedVector<double>(num_actuators_),
+      &InputSupervisor::SetMotorTorques);
+
+  // Create error flag as discrete state
+  DeclareDiscreteState(1);
+
+  // Create update for error flag
+  DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
+      &InputSupervisor::UpdateErrorFlag);
+}
+
+
+void InputSupervisor::SetMotorTorques(const Context<double>& context,
+    TimestampedVector<double>* output) const {
+  const TimestampedVector<double>* command = (TimestampedVector<double>*)
+      this->EvalVectorInput(context, command_input_port_);
+
+  bool is_error = context.get_discrete_state(0)[0] == 1;
+
+  // If there has not been an error, copy over the command.
+  // If there has been an error, set the command to all zeros
+  if (!is_error) {
+    output->get_mutable_value() = command->get_value();
+  } else {
+    output->set_timestamp(command->get_timestamp());
+    output->SetDataVector(Eigen::VectorXd::Zero(num_actuators_));
+  }
+}
+
+void InputSupervisor::UpdateErrorFlag(const Context<double>& context,
+    DiscreteValues<double>* discrete_state) const {
+  const OutputVector<double>* state = (OutputVector<double>*)
+      this->EvalVectorInput(context, state_input_port_);
+
+  const Eigen::VectorXd& velocities = state->GetVelocities();
+
+  if ((*discrete_state)[0] == 0) {
+    // If any velocity is above the threshold, set the error flag
+    bool is_velocity_error = (velocities.array() > max_joint_velocity_).any() ||
+        (velocities.array() < -max_joint_velocity_).any();
+    if (is_velocity_error) {
+      (*discrete_state)[0] = 1;
+      std::cout << "Error! Velocity has exceeded the threshold of " <<
+          max_joint_velocity_ << std::endl;
+      std::cout << "Velocity vector: " << std::endl << velocities << std::endl;
+    }
+  }
+}
+
+}  // namespace dairlib

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -10,12 +10,15 @@ using systems::OutputVector;
 
 
 InputSupervisor::InputSupervisor(const RigidBodyTree<double>& tree,
-    double max_joint_velocity, double update_period) :
+    double max_joint_velocity, double update_period,
+    int min_consecutive_failures, double input_limit) :
     tree_(tree),
     num_actuators_(tree_.get_num_actuators()),
     num_positions_(tree_.get_num_positions()),
     num_velocities_(tree_.get_num_velocities()),
-    max_joint_velocity_(max_joint_velocity) {
+    min_consecutive_failures_(min_consecutive_failures),
+    max_joint_velocity_(max_joint_velocity),
+    input_limit_(input_limit) {
   // Create input ports
   command_input_port_ = this->DeclareVectorInputPort(TimestampedVector<double>(
       num_actuators_)).get_index();
@@ -40,16 +43,34 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
   const TimestampedVector<double>* command = (TimestampedVector<double>*)
       this->EvalVectorInput(context, command_input_port_);
 
-  bool is_error = context.get_discrete_state(0)[0] == 1;
+  bool is_error = context.get_discrete_state(0)[0] >= min_consecutive_failures_;
 
   // If there has not been an error, copy over the command.
   // If there has been an error, set the command to all zeros
   if (!is_error) {
-    output->get_mutable_value() = command->get_value();
+    // If input_limit_ has been set, limit inputs to
+    ///   [-input_limit_, input_limit_]
+    if (input_limit_ != std::numeric_limits<double>::max()) {
+      output->set_timestamp(command->get_timestamp());
+      for (int i = 0; i < command->get_data().size(); i++) {
+        double command_value = command->get_data()(i);
+        if (command_value > input_limit_) {
+          command_value = input_limit_;
+        } else if (command_value < -input_limit_) {
+          command_value = -input_limit_;
+        }
+        output->get_mutable_data()(i) = command_value;
+      }
+    } else {
+      // Can copy entire raw vector
+      output->get_mutable_value() = command->get_value();
+    }
   } else {
     output->set_timestamp(command->get_timestamp());
     output->SetDataVector(Eigen::VectorXd::Zero(num_actuators_));
   }
+
+
 }
 
 void InputSupervisor::UpdateErrorFlag(const Context<double>& context,
@@ -59,15 +80,22 @@ void InputSupervisor::UpdateErrorFlag(const Context<double>& context,
 
   const Eigen::VectorXd& velocities = state->GetVelocities();
 
-  if ((*discrete_state)[0] == 0) {
+  if ((*discrete_state)[0] < min_consecutive_failures_) {
     // If any velocity is above the threshold, set the error flag
     bool is_velocity_error = (velocities.array() > max_joint_velocity_).any() ||
         (velocities.array() < -max_joint_velocity_).any();
     if (is_velocity_error) {
-      (*discrete_state)[0] = 1;
+      // Increment counter
+      (*discrete_state)[0]++;
       std::cout << "Error! Velocity has exceeded the threshold of " <<
           max_joint_velocity_ << std::endl;
-      std::cout << "Velocity vector: " << std::endl << velocities << std::endl;
+      std::cout << "Consecutive error " << (*discrete_state)[0] << " of " <<
+          min_consecutive_failures_ << std::endl;
+      std::cout << "Velocity vector: " << std::endl << velocities << std::endl
+           << std::endl;
+    } else {
+      // Reset counter
+      (*discrete_state)[0] = 0;
     }
   }
 }

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <limits>
 
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -11,8 +11,10 @@ namespace dairlib {
 /// between commands from controllers and the actual robot. It's envisioned role
 /// is to (1) sanity check any inputs, (2) shut down in case of errors or
 /// instability, and (3) to mediate between multiple controllers. Of these three
-/// potential purposes, only (2) is currently implemented as a check on the
-/// current velocity of the robot. If the velocity passes a specified threshold,
+/// potential purposes, (1) and (2) are currently implemented.
+///  (1) is a simple threshold of the commands to [-input_limit, input_limit]
+///  (2) is a check on the current velocity of the robot.
+/// If the velocity passes a specified threshold,
 /// in absolute value, then an error flag (discrete state) is set and the output
 /// commands are set to zero. Note, in the presence of noise, this __might__ be
 /// a brittle check. If this is the case, we will have to low-pass filter this
@@ -24,11 +26,18 @@ namespace dairlib {
 /// should also integrate information from the Agility error list.
 class InputSupervisor : public drake::systems::LeafSystem<double> {
  public:
-  // Constructor. Takes in a tree (to be replaced with MultibodyPlant), a max
-  // velocity, and an update period. If necessary, the max velocity could be
-  // replaced with a joint-specific vector.
+  // Constructor.
+  // @param tree The RigidBodyTree in a tree (to be replaced with MBP)
+  // @param max_joint_velocity
+  // @param update_period
+  // @param min_consecutive_failures (default = 1) before failure is triggered
+  // @param input_limit (default = inf) to threshold all commands
+  // If necessary, the max_joint_velocity and input_limit could be
+  // replaced with a joint-specific vectors.
   explicit InputSupervisor(const RigidBodyTree<double>& tree,
-      double max_joint_velocity, double update_period);
+      double max_joint_velocity, double update_period,
+      int min_consecutive_failures = 1,
+      double input_limit = std::numeric_limits<double>::max());
 
   const drake::systems::InputPort<double>& get_input_port_command()
       const {
@@ -51,9 +60,12 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   const int num_actuators_;
   const int num_positions_;
   const int num_velocities_;
+  const int min_consecutive_failures_;
   double max_joint_velocity_;
+  double input_limit_;
   int state_input_port_;
   int command_input_port_;
+
 };
 
 

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -1,0 +1,60 @@
+#pragma once
+
+
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "systems/framework/timestamped_vector.h"
+
+namespace dairlib {
+
+/// The InputSupervisor is a simple Drake System that acts as an intermediary
+/// between commands from controllers and the actual robot. It's envisioned role
+/// is to (1) sanity check any inputs, (2) shut down in case of errors or
+/// instability, and (3) to mediate between multiple controllers. Of these three
+/// potential purposes, only (2) is currently implemented as a check on the
+/// current velocity of the robot. If the velocity passes a specified threshold,
+/// in absolute value, then an error flag (discrete state) is set and the output
+/// commands are set to zero. Note, in the presence of noise, this __might__ be
+/// a brittle check. If this is the case, we will have to low-pass filter this
+/// check. For instance, we could only set the flag if the threshold is reached
+/// N times in a row.
+///
+/// Other future extensions could include more detailed error checking, such as
+/// measured motor torque limits, dynamics errors, or joint limit errors. We
+/// should also integrate information from the Agility error list.
+class InputSupervisor : public drake::systems::LeafSystem<double> {
+ public:
+  // Constructor. Takes in a tree (to be replaced with MultibodyPlant), a max
+  // velocity, and an update period. If necessary, the max velocity could be
+  // replaced with a joint-specific vector.
+  explicit InputSupervisor(const RigidBodyTree<double>& tree,
+      double max_joint_velocity, double update_period);
+
+  const drake::systems::InputPort<double>& get_input_port_command()
+      const {
+    return this->get_input_port(command_input_port_);
+  }
+
+  const drake::systems::InputPort<double>& get_input_port_state()
+      const {
+    return this->get_input_port(state_input_port_);
+  }
+
+ private:
+  void SetMotorTorques(const drake::systems::Context<double>& context,
+    systems::TimestampedVector<double>* output) const;
+
+  void UpdateErrorFlag(const drake::systems::Context<double>& context,
+    drake::systems::DiscreteValues<double>* discrete_state) const;
+
+  const RigidBodyTree<double>& tree_;
+  const int num_actuators_;
+  const int num_positions_;
+  const int num_velocities_;
+  double max_joint_velocity_;
+  int state_input_port_;
+  int command_input_port_;
+};
+
+
+}  // namespace dairlib


### PR DESCRIPTION
Added a new input supervisor. Right now, this serves to shut down our controller whenever the velocity of the robot exceeds a threshold. Copied from the class  header below. I've tested this briefly against the Gazebo simulation.

/// The InputSupervisor is a simple Drake System that acts as an intermediary
/// between commands from controllers and the actual robot. It's envisioned role
/// is to (1) sanity check any inputs, (2) shut down in case of errors or
/// instability, and (3) to mediate between multiple controllers. Of these three
/// potential purposes, only (2) is currently implemented as a check on the
/// current velocity of the robot. If the velocity passes a specified threshold,
/// in absolute value, then an error flag (discrete state) is set and the output
/// commands are set to zero. Note, in the presence of noise, this __might__ be
/// a brittle check. If this is the case, we will have to low-pass filter this
/// check. For instance, we could only set the flag if the threshold is reached
/// N times in a row.