### PR TITLE
Explicitly connecting output ports in dispatcher_in

### DIFF
--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -89,7 +89,8 @@ int do_main(int argc, char* argv[]) {
   // Create and connect translator
   auto input_translator =
       builder.AddSystem<systems::CassieInputTranslator>(*tree);
-  builder.Connect(*input_supervisor, *input_translator);
+  builder.Connect(input_supervisor->get_output_port(0),
+      input_translator->get_input_port(0));
 
   // Create and connect input publisher.
   auto input_pub = builder.AddSystem(
@@ -104,7 +105,8 @@ int do_main(int argc, char* argv[]) {
           "NETWORK_CASSIE_INPUT", &lcm_network,
           {TriggerType::kPeriodic}, FLAGS_pub_rate));
 
-  builder.Connect(*input_supervisor, *net_command_sender);
+  builder.Connect(input_supervisor->get_output_port(0),
+      net_command_sender->get_input_port(0));
 
   builder.Connect(*net_command_sender, *net_command_pub);
 

--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -89,7 +89,7 @@ int do_main(int argc, char* argv[]) {
   // Create and connect translator
   auto input_translator =
       builder.AddSystem<systems::CassieInputTranslator>(*tree);
-  builder.Connect(input_supervisor->get_output_port(0),
+  builder.Connect(input_supervisor->get_output_port_command(),
       input_translator->get_input_port(0));
 
   // Create and connect input publisher.
@@ -105,7 +105,7 @@ int do_main(int argc, char* argv[]) {
           "NETWORK_CASSIE_INPUT", &lcm_network,
           {TriggerType::kPeriodic}, FLAGS_pub_rate));
 
-  builder.Connect(input_supervisor->get_output_port(0),
+  builder.Connect(input_supervisor->get_output_port_command(),
       net_command_sender->get_input_port(0));
 
   builder.Connect(*net_command_sender, *net_command_pub);

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -25,18 +25,21 @@ InputSupervisor::InputSupervisor(const RigidBodyTree<double>& tree,
   command_input_port_ =
       this->DeclareVectorInputPort(TimestampedVector<double>(num_actuators_))
           .get_index();
-  state_input_port_ = this
-                          ->DeclareVectorInputPort(OutputVector<double>(
+  state_input_port_ = this->DeclareVectorInputPort(OutputVector<double>(
                               num_positions_, num_velocities_, num_actuators_))
                           .get_index();
 
-  // Create output port
-  this->DeclareVectorOutputPort(TimestampedVector<double>(num_actuators_),
-                                &InputSupervisor::SetMotorTorques);
+  // Create output port for commands
+  command_output_port_ =
+      this->DeclareVectorOutputPort(TimestampedVector<double>(num_actuators_),
+                                    &InputSupervisor::SetMotorTorques)
+          .get_index();
 
   // Create output port for status
-  this->DeclareVectorOutputPort(TimestampedVector<double>(1),
-                                &InputSupervisor::SetStatus);
+  status_output_port_ =
+      this->DeclareVectorOutputPort(TimestampedVector<double>(1),
+                                    &InputSupervisor::SetStatus)
+          .get_index();
 
   // Create error flag as discrete state
   n_consecutive_fails_index_ = DeclareDiscreteState(1);

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -47,6 +47,15 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
     return this->get_input_port(state_input_port_);
   }
 
+  const drake::systems::OutputPort<double>& get_output_port_command() const {
+    return this->get_output_port(command_output_port_);
+  }
+
+  const drake::systems::OutputPort<double>& get_output_port_status() const {
+    return this->get_output_port(status_output_port_);
+  }
+
+
   void SetMotorTorques(const drake::systems::Context<double>& context,
                        systems::TimestampedVector<double>* output) const;
   void UpdateErrorFlag(
@@ -74,8 +83,9 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   int n_consecutive_fails_index_;
   int status_index_;
   int state_input_port_;
-
   int command_input_port_;
+  int command_output_port_;
+  int status_output_port_;
 };
 
 }  // namespace dairlib


### PR DESCRIPTION
Due to the input supervisor now outputting its status (now has 2 output ports), we must explicitly connect its output ports.

Note. The status port of the input supervisor is not connected to anything.