### PR TITLE
Updating master to work with newest version of Drake

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,8 +39,8 @@ test --test_output=errors
 test --test_summary=terse
 
 # Use C++14.
-build --cxxopt=-std=c++1y
-build --host_cxxopt=-std=c++1y
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 
 # https://github.com/bazelbuild/bazel/issues/1164
 build --action_env=CCACHE_DISABLE=1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,8 +12,8 @@ workspace(name = "dairlib")
 #  export DAIRLIB_LOCAL_DRAKE_PATH=/home/user/workspace/drake
 
 # Choose a revision of Drake to use.
-DRAKE_COMMIT = "8f915dd556d127309817bf3878d5f9cbfcd91e8e"
-DRAKE_CHECKSUM = "31418a4846368962772a8b903d1aa2af95c4bd87d8f5c3af4939249aaa39fb42"
+DRAKE_COMMIT = "097f77083908d029e98bc081b822a4a3b4951619"
+DRAKE_CHECKSUM = "34b72caad302a07332499a54406efa0d69e4d80f58fea9f60e8108edf3064494"
 # Before changing the COMMIT, temporarily uncomment the next line so that Bazel
 # displays the suggested new value for the CHECKSUM.
 # DRAKE_CHECKSUM = "0" * 64

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -14,8 +14,8 @@ using std::string;
 namespace dairlib {
 
 using Result = FindResourceResult;
-using drake::optional;
-using drake::nullopt;
+using std::optional;
+using std::nullopt;
 
 optional<string>
 Result::get_absolute_path() const {

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -2,10 +2,10 @@
 
 #include <string>
 #include <vector>
+#include <optional>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_optional.h"
 
 // Copied from drake/common/find_resource.h
 namespace dairlib {
@@ -23,7 +23,7 @@ class FindResourceResult {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FindResourceResult);
 
   /// Returns the absolute path to the resource, iff the resource was found.
-  drake::optional<std::string> get_absolute_path() const;
+  std::optional<std::string> get_absolute_path() const;
 
   /// Either returns the get_absolute_path() iff the resource was found,
   /// or else throws runtime_error.
@@ -31,7 +31,7 @@ class FindResourceResult {
 
   /// Returns the error message, iff the resource was not found.
   /// The string will never be empty; only the optional can be empty.
-  drake::optional<std::string> get_error_message() const;
+  std::optional<std::string> get_error_message() const;
 
   /// Returns the resource_path asked of FindResource.
   /// (This may be empty only in the make_empty() case.)
@@ -61,7 +61,7 @@ class FindResourceResult {
   std::string resource_path_;
 
   // The absolute path where resource_path was found, if success.
-  drake::optional<std::string> absolute_path_;
+  std::optional<std::string> absolute_path_;
 
   // An error message, permitted to be present only when base_path is empty.
   //
@@ -69,7 +69,7 @@ class FindResourceResult {
   // (e.g., a default-constructed and/or moved-from object), which represents
   // resource-not-found along with an unspecified non-empty default error
   // message from get_error_message().
-  drake::optional<std::string> error_message_;
+  std::optional<std::string> error_message_;
 };
 
 /// Adds a path in which resources are searched in a persistent variable. Paths

--- a/director/BUILD.bazel
+++ b/director/BUILD.bazel
@@ -6,17 +6,17 @@ py_binary(
     data = [
         "@drake//examples:prod_models",
         "@drake_visualizer",
-        "@drake_visualizer//:lcm_python2",
+        "@lcm//:lcm-python",
     ],
     main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
     # Python libraries to import.
     deps = [
-        "@drake//lcmtypes:lcmtypes_drake_py",
+        "//lcmtypes:lcmtypes_robot_py",
         "//tools/workspace/drake_visualizer:stub_pydrake",
+        "@drake//lcmtypes:lcmtypes_drake_py",
         "@drake//tools/workspace/drake_visualizer/plugin",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
-        "//lcmtypes:lcmtypes_robot_py",
     ],
 )
 

--- a/examples/Cassie/networking/cassie_udp_subscriber.h
+++ b/examples/Cassie/networking/cassie_udp_subscriber.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"

--- a/examples/PlanarWalker/test_contact.cc
+++ b/examples/PlanarWalker/test_contact.cc
@@ -10,7 +10,6 @@
 #include "drake/multibody/kinematics_cache.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/systems/controllers/controlUtil.h"
 
 using Eigen::VectorXd;
 using Eigen::MatrixXd;
@@ -148,13 +147,13 @@ int do_main(int argc, char* argv[]) {
   tree.get()->surfaceTangents(n_world, d_world);
 
   Eigen::Matrix<double,3,2> d;
-  surfaceTangents(normal.col(0),d);
+  //  surfaceTangents(normal.col(0),d);
 
   cout << "*********** d ***********" << endl;
-  cout << d << endl;  
+  cout << d << endl;
 
   cout << "*********** d_again ***********" << endl;
-  cout << d_world[1] << endl;  
+  cout << d_world[1] << endl;
 
   // see https://github.com/RobotLocomotion/drake/blob/master/multibody/rigid_body_constraint.cc#L1930~L1959
   // for how to generat ejacobian

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -2,9 +2,8 @@ from __future__ import print_function
 
 import argparse
 import os
-from os.path import exists, join
-import subprocess
 import sys
+from os.path import exists, join
 
 
 def resolve_path(relpath):
@@ -71,7 +70,7 @@ if sys.platform.startswith("linux"):
     prepend_path("LD_LIBRARY_PATH", "external/vtk/lib")
     # TODO(eric.cousineau): Ensure that Drake Visualizer works even when Bazel
     # uses a separate version of Python.
-    prepend_path("PYTHONPATH", "external/vtk/lib/python2.7/site-packages")
+    prepend_path("PYTHONPATH", "external/vtk/lib/python3.6/site-packages")
 elif sys.platform == "darwin":
     # Ensure that we handle DYLD_LIBRARY_PATH for @lcm.
     set_path("DYLD_LIBRARY_PATH", "external/lcm")


### PR DESCRIPTION
As every computer has been updated to Ubuntu 18.04 and because Yu-ming and I (Will) have been working with newer versions of Drake, I think we should update master to build with the newest version of Drake.

Updating only involved a few changes:
- Update .bazelrc to use c++17
- Use std versions where applicable to avoid Drake deprecations
- Update drake-visualizer to use python3.6 instead of python2

 