### PR TITLE
Add utility class to simultaneously visualize multiple robot poses and DIRCON callback.

### DIFF
--- a/bindings/pydairlib/multibody/BUILD.bazel
+++ b/bindings/pydairlib/multibody/BUILD.bazel
@@ -1,0 +1,61 @@
+# -*- python -*-
+load("@drake//tools/install:install.bzl", "install")
+
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@drake//tools/skylark:pybind.bzl",
+    "drake_pybind_library",
+    "get_drake_py_installs",
+    "get_pybind_package_info",
+    "pybind_py_library",
+)
+
+pybind_py_library(
+    name = "multibody_py",
+    cc_deps = [
+        "//multibody:multipose_visualizer",
+        "@drake//:drake_shared_library",
+    ],
+    cc_so_name = "multibody",
+    cc_srcs = ["multibody_py.cc"],
+    py_deps = ["@drake//bindings/pydrake",
+               ":module_py"],
+    py_imports = ["."],
+)
+
+py_binary(
+    name = "multipose_visualizer_test",
+    srcs = ["test/multipose_visualizer_test.py"],
+    deps = [
+        ":multibody_py",
+        "//bindings/pydairlib/common",
+        ":module_py",
+    ],
+)
+
+# This determines how `PYTHONPATH` is configured, and how to install the
+# bindings.
+PACKAGE_INFO = get_pybind_package_info("//bindings")
+
+py_library(
+    name = "module_py",
+    srcs = [
+        "__init__.py",
+    ],
+    imports = PACKAGE_INFO.py_imports,
+    deps = [
+        "//bindings/pydairlib:module_py"
+    ],
+)
+
+PY_LIBRARIES = [
+    ":multibody_py",
+]
+
+# Package roll-up (for Bazel dependencies).
+py_library(
+    name = "multibody",
+    imports = PACKAGE_INFO.py_imports,
+    deps = PY_LIBRARIES,
+)

--- a/bindings/pydairlib/multibody/__init__.py
+++ b/bindings/pydairlib/multibody/__init__.py
@@ -1,0 +1,2 @@
+# Importing everything in this directory to this package
+from .multibody import *

--- a/bindings/pydairlib/multibody/multibody_py.cc
+++ b/bindings/pydairlib/multibody/multibody_py.cc
@@ -1,0 +1,22 @@
+#include <pybind11/eigen.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "multibody/multipose_visualizer.h"
+
+namespace py = pybind11;
+
+namespace dairlib  {
+namespace pydairlib {
+
+using multibody::MultiposeVisualizer;
+
+PYBIND11_MODULE(multibody, m) {
+  py::class_<MultiposeVisualizer>(m, "MultiposeVisualizer")
+      .def(py::init<std::string, int, std::string>())
+      .def("DrawPoses", &MultiposeVisualizer::DrawPoses, py::arg("poses"));
+}
+
+}  // namespace pydairlib
+}  // namespace dairlib

--- a/bindings/pydairlib/multibody/test/multipose_visualizer_test.py
+++ b/bindings/pydairlib/multibody/test/multipose_visualizer_test.py
@@ -1,0 +1,26 @@
+from pydairlib.common import FindResourceOrThrow
+from pydairlib.multibody import MultiposeVisualizer
+import pydrake.systems.framework
+import pydrake.multibody.plant
+import pydrake.multibody.parsing
+import numpy as np
+
+# Python visualization test to draw a single state
+def main():
+    num_poses = 3
+    visualizer = MultiposeVisualizer(FindResourceOrThrow(
+        "examples/Cassie/urdf/cassie_v2.urdf"), num_poses, "")
+
+    # Create a plant just to know number of positions (also as a pydrake test)
+    builder = pydrake.systems.framework.DiagramBuilder()
+    plant, scene_graph = pydrake.multibody.plant.AddMultibodyPlantSceneGraph(
+        builder, 0)
+    pydrake.multibody.parsing.Parser(plant).AddModelFromFile(
+        FindResourceOrThrow("examples/Cassie/urdf/cassie_v2.urdf"))
+    plant.Finalize()    
+
+    visualizer.DrawPoses(np.random.rand(plant.num_positions(),
+        num_poses))
+
+if __name__ == "__main__":
+    main()

--- a/examples/Cassie/run_dircon_squatting.cc
+++ b/examples/Cassie/run_dircon_squatting.cc
@@ -633,6 +633,8 @@ void DoMain(double duration, int max_iter, string data_directory,
     }
   }
 
+  trajopt->CreateVisualizationCallback("examples/Cassie/urdf/cassie_v2.urdf");
+
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;
 

--- a/examples/Cassie/run_dircon_squatting.cc
+++ b/examples/Cassie/run_dircon_squatting.cc
@@ -634,7 +634,7 @@ void DoMain(double duration, int max_iter, string data_directory,
   }
 
   trajopt->CreateVisualizationCallback(
-      "examples/Cassie/urdf/cassie_fixed_springs.urdf");
+      "examples/Cassie/urdf/cassie_fixed_springs.urdf", 5);
 
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;

--- a/examples/Cassie/run_dircon_squatting.cc
+++ b/examples/Cassie/run_dircon_squatting.cc
@@ -633,7 +633,8 @@ void DoMain(double duration, int max_iter, string data_directory,
     }
   }
 
-  trajopt->CreateVisualizationCallback("examples/Cassie/urdf/cassie_v2.urdf");
+  trajopt->CreateVisualizationCallback(
+      "examples/Cassie/urdf/cassie_fixed_springs.urdf");
 
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;

--- a/examples/Cassie/run_dircon_walking.cc
+++ b/examples/Cassie/run_dircon_walking.cc
@@ -907,7 +907,7 @@ void DoMain(double duration, double stride_length, double ground_incline,
   }*/
 
   trajopt->CreateVisualizationCallback(
-      "examples/Cassie/urdf/cassie_fixed_springs.urdf");
+      "examples/Cassie/urdf/cassie_fixed_springs.urdf", 2);
 
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;

--- a/examples/Cassie/run_dircon_walking.cc
+++ b/examples/Cassie/run_dircon_walking.cc
@@ -906,6 +906,9 @@ void DoMain(double duration, double stride_length, double ground_incline,
     cout << endl;
   }*/
 
+  trajopt->CreateVisualizationCallback(
+      "examples/Cassie/urdf/cassie_fixed_springs.urdf");
+
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;
 

--- a/examples/Cassie/run_dircon_walking.cc
+++ b/examples/Cassie/run_dircon_walking.cc
@@ -907,7 +907,7 @@ void DoMain(double duration, double stride_length, double ground_incline,
   }*/
 
   trajopt->CreateVisualizationCallback(
-      "examples/Cassie/urdf/cassie_fixed_springs.urdf", 2);
+      "examples/Cassie/urdf/cassie_fixed_springs.urdf", 5);
 
   cout << "\nChoose the best solver: "
        << drake::solvers::ChooseBestSolver(*trajopt).name() << endl;

--- a/examples/PlanarWalker/run_gait_dircon.cc
+++ b/examples/PlanarWalker/run_gait_dircon.cc
@@ -215,7 +215,7 @@ shared_ptr<HybridDircon<T>> runDircon(
 
   trajopt->CreateVisualizationCallback(
       dairlib::FindResourceOrThrow("examples/PlanarWalker/PlanarWalker.urdf"),
-      "base");
+      1, "base");
 
   auto start = std::chrono::high_resolution_clock::now();
   const auto result = Solve(*trajopt, trajopt->initial_guess());

--- a/examples/PlanarWalker/run_gait_dircon.cc
+++ b/examples/PlanarWalker/run_gait_dircon.cc
@@ -213,9 +213,13 @@ shared_ptr<HybridDircon<T>> runDircon(
   // const double Q = 1;
   // trajopt->AddRunningCost(x.transpose()*Q*x);
 
+  std::vector<unsigned int> visualizer_poses;
+  visualizer_poses.push_back(3);
+  visualizer_poses.push_back(3);
+
   trajopt->CreateVisualizationCallback(
       dairlib::FindResourceOrThrow("examples/PlanarWalker/PlanarWalker.urdf"),
-      1, "base");
+      visualizer_poses, "base");
 
   auto start = std::chrono::high_resolution_clock::now();
   const auto result = Solve(*trajopt, trajopt->initial_guess());

--- a/examples/PlanarWalker/run_gait_dircon.cc
+++ b/examples/PlanarWalker/run_gait_dircon.cc
@@ -213,6 +213,10 @@ shared_ptr<HybridDircon<T>> runDircon(
   // const double Q = 1;
   // trajopt->AddRunningCost(x.transpose()*Q*x);
 
+  trajopt->CreateVisualizationCallback(
+      dairlib::FindResourceOrThrow("examples/PlanarWalker/PlanarWalker.urdf"),
+      "base");
+
   auto start = std::chrono::high_resolution_clock::now();
   const auto result = Solve(*trajopt, trajopt->initial_guess());
   auto finish = std::chrono::high_resolution_clock::now();

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -35,6 +35,29 @@ cc_library(
 )
 
 cc_library(
+    name = "multipose_visualizer",
+    srcs = [
+        "multipose_visualizer.cc"
+    ],
+    hdrs = [
+        "multipose_visualizer.h",
+    ],
+    deps = [
+        "@drake//:drake_shared_library",
+    ],
+)
+
+
+cc_binary(
+    name = "multipose_visualizer_test",
+    srcs = ["test/multipose_visualizer_test.cc"],
+    deps = [
+        ":multipose_visualizer",
+        "//common",
+    ],
+)
+
+cc_library(
     name = "contact_toolkit",
     srcs = [
         "contact_toolkit.cc",
@@ -48,7 +71,6 @@ cc_library(
     ],
 )
 
-
 cc_test(
     name = "multibody_utils_test",
     srcs = ["test/multibody_utils_test.cc"],
@@ -61,7 +83,6 @@ cc_test(
             ],
     size = "small"
 )
-
 
 cc_test(
     name = "contact_toolkit_test",

--- a/multibody/multipose_visualizer.cc
+++ b/multibody/multipose_visualizer.cc
@@ -15,7 +15,8 @@ using drake::multibody::MultibodyPlant;
 namespace dairlib {
 namespace multibody {
 
-MultiposeVisualizer::MultiposeVisualizer(string model_file, int num_poses) : 
+MultiposeVisualizer::MultiposeVisualizer(string model_file, int num_poses,
+    string weld_frame_to_world) : 
     num_poses_(num_poses) {
   DiagramBuilder<double> builder;
 
@@ -30,7 +31,12 @@ MultiposeVisualizer::MultiposeVisualizer(string model_file, int num_poses) :
   for (int i = 0; i < num_poses_; i++) {
     auto index = 
         parser.AddModelFromFile(model_file, "model[" + std::to_string(i) + "]");
-    model_indices_.push_back(index);
+    model_indices_.push_back(index);  
+    if (!weld_frame_to_world.empty()) {
+      plant_->WeldFrames(plant_->world_frame(),
+          plant_->GetFrameByName(weld_frame_to_world, model_indices_.at(i)),
+          drake::math::RigidTransform<double>(Eigen::Vector3d::Zero()));
+    }
   }
 
   plant_->Finalize();

--- a/multibody/multipose_visualizer.cc
+++ b/multibody/multipose_visualizer.cc
@@ -1,0 +1,58 @@
+#include "multibody/multipose_visualizer.h"
+
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_interface_system.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/scene_graph.h"
+
+using std::string;
+using Eigen::MatrixXd;
+using drake::systems::DiagramBuilder;
+using drake::geometry::SceneGraph;
+using drake::multibody::Parser;
+using drake::multibody::MultibodyPlant;
+
+namespace dairlib {
+namespace multibody {
+
+MultiposeVisualizer::MultiposeVisualizer(string model_file, int num_poses) : 
+    num_poses_(num_poses) {
+  DiagramBuilder<double> builder;
+
+  SceneGraph<double>* scene_graph{};
+  std::tie(plant_, scene_graph) =
+    drake::multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
+
+  auto lcm = builder.AddSystem<drake::systems::lcm::LcmInterfaceSystem>();
+  Parser parser(plant_, scene_graph);
+
+  // Add num_poses copies of the plant, giving each a unique name
+  for (int i = 0; i < num_poses_; i++) {
+    auto index = 
+        parser.AddModelFromFile(model_file, "model[" + std::to_string(i) + "]");
+    model_indices_.push_back(index);
+  }
+
+  plant_->Finalize();
+  drake::geometry::ConnectDrakeVisualizer(&builder, *scene_graph, lcm);
+  diagram_ = builder.Build();
+  diagram_context_ = diagram_->CreateDefaultContext();
+  drake::geometry::DispatchLoadMessage(*scene_graph, lcm);
+}
+
+void MultiposeVisualizer::DrawPoses(MatrixXd poses) {
+
+  // Set positions for individual instances
+  auto& plant_context = diagram_->GetMutableSubsystemContext(*plant_,
+      diagram_context_.get());
+  for (int i = 0; i < num_poses_; i++) {
+    plant_->SetPositions(&plant_context, model_indices_.at(i),
+        poses.block(0, i, plant_->num_positions(model_indices_.at(i)), 1));
+  }
+
+  // Publish diagram
+  diagram_->Publish(*diagram_context_);
+}
+
+}  // namespace multibody
+}  // namespace dairlib

--- a/multibody/multipose_visualizer.h
+++ b/multibody/multipose_visualizer.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram.h"
+
+namespace dairlib {
+namespace multibody {
+
+/// Class for using Drake Visualizer to draw multiple poses of the same robot.
+/// Basic use:
+///   MultiposeVisualizer visualizer = MultiposeVisualizer(URDF_file, num_poses);
+///   visualizer.DrawPoses(poses);
+///
+/// where poses is an Eigen matrix (num_positions x num_poses)
+/// 
+/// Since this uses Drake Visualizer, it can be the only currently running
+/// such use case. Does not currently support additional objects, though these
+/// could be added at a later date.
+class MultiposeVisualizer {
+ public:
+
+  /// Constructor
+  /// @param model_file A full path to model (e.g. through FindResourceOrThrow)
+  /// @param num_poses The number of simultaneous poses to draw (fixed)
+  explicit MultiposeVisualizer(std::string model_file, int num_poses);
+
+  /// Draws the poses in the given (num_positions x num_poses) matrix
+  /// Note: the matrix can have extra rows (e.g. velocities), which will be
+  /// ignored.
+  void DrawPoses(Eigen::MatrixXd poses);
+
+ private:
+  int num_poses_;
+  drake::multibody::MultibodyPlant<double>* plant_;
+  std::unique_ptr<drake::systems::Diagram<double>> diagram_;
+  std::unique_ptr<drake::systems::Context<double>> diagram_context_;
+  std::vector<drake::multibody::ModelInstanceIndex> model_indices_;
+};
+
+}  // namespace multibody
+}  // namespace dairlib

--- a/multibody/multipose_visualizer.h
+++ b/multibody/multipose_visualizer.h
@@ -27,7 +27,8 @@ class MultiposeVisualizer {
   /// Constructor
   /// @param model_file A full path to model (e.g. through FindResourceOrThrow)
   /// @param num_poses The number of simultaneous poses to draw (fixed)
-  explicit MultiposeVisualizer(std::string model_file, int num_poses);
+  explicit MultiposeVisualizer(std::string model_file, int num_poses,
+      std::string weld_frame_to_world = "");
 
   /// Draws the poses in the given (num_positions x num_poses) matrix
   /// Note: the matrix can have extra rows (e.g. velocities), which will be

--- a/multibody/test/multipose_visualizer_test.cc
+++ b/multibody/test/multipose_visualizer_test.cc
@@ -1,0 +1,11 @@
+#include "multibody/multipose_visualizer.h"
+#include "common/find_resource.h"
+
+int main(int argc, char* argv[]) { 
+  std::srand((unsigned int) time(0));
+  auto visualizer = dairlib::multibody::MultiposeVisualizer(
+      dairlib::FindResourceOrThrow("examples/Cassie/urdf/cassie_v2.urdf"), 8);
+
+  Eigen::MatrixXd poses = Eigen::MatrixXd::Random(30, 8);
+  visualizer.DrawPoses(poses);
+}

--- a/multibody/test/multipose_visualizer_test.cc
+++ b/multibody/test/multipose_visualizer_test.cc
@@ -4,7 +4,7 @@
 int main(int argc, char* argv[]) { 
   std::srand((unsigned int) time(0));
   auto visualizer = dairlib::multibody::MultiposeVisualizer(
-      dairlib::FindResourceOrThrow("examples/Cassie/urdf/cassie_v2.urdf"), 8);
+      dairlib::FindResourceOrThrow("examples/Cassie/urdf/cassie_v2.urdf"), 8, "pelvis");
 
   Eigen::MatrixXd poses = Eigen::MatrixXd::Random(30, 8);
   visualizer.DrawPoses(poses);

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -21,6 +21,7 @@ cc_library(
         ":dircon_kinematic_data",
         "//solvers:optimization_utils",
         "//systems/goldilocks_models",
+        "//multibody:multipose_visualizer",
         "@drake//:drake_shared_library",
     ],
 )

--- a/systems/trajectory_optimization/hybrid_dircon.cc
+++ b/systems/trajectory_optimization/hybrid_dircon.cc
@@ -548,6 +548,28 @@ void HybridDircon<T>::ScaleKinConstraintSlackVariables(
   }
 }
 
+template <typename T>
+void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
+    std::string weld_frame_to_world) {
+  DRAKE_ASSERT(!callback_visualizer_);  // Cannot be set twice
+
+  // Create visualizer
+  callback_visualizer_ = std::make_unique<multibody::MultiposeVisualizer>(
+    model_file, N(), weld_frame_to_world);
+
+  // Callback lambda function
+  auto my_callback = [this](const Eigen::Ref<const VectorXd>& vars) {
+    VectorXd vars_copy = vars;
+    Eigen::Map<MatrixXd> states(vars_copy.data(),
+        this->plant_.num_positions() + plant_.num_velocities(), this->N());
+
+    this->callback_visualizer_->DrawPoses(
+        states.block(0, 0, plant_.num_positions(), this->N()));
+  };
+
+  auto binding = AddVisualizationCallback(my_callback, x_vars());
+}
+
 template class HybridDircon<double>;
 template class HybridDircon<AutoDiffXd>;
 

--- a/systems/trajectory_optimization/hybrid_dircon.cc
+++ b/systems/trajectory_optimization/hybrid_dircon.cc
@@ -567,7 +567,7 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
         states.block(0, 0, plant_.num_positions(), this->N()));
   };
 
-  auto binding = AddVisualizationCallback(my_callback, x_vars());
+  AddVisualizationCallback(my_callback, x_vars());
 }
 
 template class HybridDircon<double>;

--- a/systems/trajectory_optimization/hybrid_dircon.cc
+++ b/systems/trajectory_optimization/hybrid_dircon.cc
@@ -550,31 +550,45 @@ void HybridDircon<T>::ScaleKinConstraintSlackVariables(
 
 template <typename T>
 void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
-    int knot_period, std::string weld_frame_to_world) {
-  DRAKE_ASSERT(!callback_visualizer_);  // Cannot be set twice
+    std::vector<unsigned int> poses_per_mode, std::string weld_frame_to_world) {
+  DRAKE_DEMAND(!callback_visualizer_);  // Cannot be set twice
+  DRAKE_DEMAND(poses_per_mode.size() == (uint) num_modes_);
 
-  // Pose count, adding final pose if necessary
-  int num_poses = 1 + (N() - 1) / knot_period;
-  if ((num_poses - 1) * knot_period != N() - 1) {
-    num_poses++;
+  // Count number of total poses
+  int num_poses = num_modes_ + 1; // start and finish of every mode
+  for (int i = 0; i < num_modes_; i++) {
+    DRAKE_DEMAND(poses_per_mode.at(i) == 0 || 
+        (poses_per_mode.at(i) + 2 <= (uint) mode_lengths_.at(i)));
+    num_poses += poses_per_mode.at(i);
   }
 
   // Assemble variable list
   drake::solvers::VectorXDecisionVariable vars(
       num_poses * plant_.num_positions());
 
-  for (int i = 0; i < num_poses; i++) {
-    int state_index = i * knot_period;
-
-    // Reset if this is actually the final pose
-    if (state_index >= N()) {
-      state_index = N() - 1;
-    }
-
+  int index = 0;
+  for (int i = 0; i < num_modes_; i++) {
     // Set variable block, extracting positions only
-    vars.segment(i * plant_.num_positions(), plant_.num_positions()) = 
-      state(state_index).head(plant_.num_positions());
+    vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
+      state_vars_by_mode(i, 0).head(plant_.num_positions());
+    index++;
+
+    for (uint j = 0; j < poses_per_mode.at(i); j++) {
+
+      // The jth element in mode i, counting in between the start/end poses
+      int modei_index =
+          (j + 1) * (mode_lengths_.at(i) - 1)/(poses_per_mode.at(i) + 1);
+
+      vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
+          state_vars_by_mode(i, modei_index).head(plant_.num_positions());
+      index++;
+    } 
   }
+
+  // Final state
+  vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
+      state_vars_by_mode(num_modes_ - 1, mode_lengths_.at(num_modes_ - 1) - 1).
+          head(plant_.num_positions());
 
   // Create visualizer
   callback_visualizer_ = std::make_unique<multibody::MultiposeVisualizer>(
@@ -590,6 +604,71 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
   };
 
   AddVisualizationCallback(my_callback, vars);
+}
+
+template <typename T>
+void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
+      unsigned int num_poses, std::string weld_frame_to_world) {
+  // Check that there is an appropriate number of poses
+  DRAKE_DEMAND(num_poses >= (uint) num_modes_ + 1);
+  DRAKE_DEMAND(num_poses <= (uint) N());
+
+  // sum of mode lengths, excluding ends
+  int mode_sum = 0;
+  for (auto& n : mode_lengths_) {
+    if (n > 2) {
+      mode_sum += n - 2;
+    }
+  }
+
+  // Split up num_poses per modes, rounding down
+  // If NP is the total number of  poses to visualize, excluding ends (interior)
+  //   S is mode_sum, the total number of the interior knot points
+  //   and N the number of interior knot points for a particular mode, then 
+  //
+  //   poses = (NP * N )/S
+  unsigned int num_poses_without_ends = num_poses - num_modes_ - 1;
+  unsigned int assigned_sum = 0;
+  std::vector<unsigned int> num_poses_per_mode;
+  for (auto& n : mode_lengths_) {
+    if (n > 2) {
+      unsigned int mode_count = (num_poses_without_ends * (n - 2)) / mode_sum;
+      num_poses_per_mode.push_back(mode_count);
+      assigned_sum += mode_count;
+    } else {
+      num_poses_per_mode.push_back(0);
+    }
+  }
+
+  // Need to add back in the fractional bits, using the largest fractions
+  while (assigned_sum < num_poses_without_ends) {
+    int largest_mode = -1;
+    double value = 0;
+    for (int i = 0; i < num_modes_; i++) {
+      double fractional_value =
+          num_poses_without_ends * (mode_lengths_.at(i) - 2) - 
+              num_poses_per_mode.at(i) * mode_sum;
+
+      if (fractional_value > value) {
+        value = fractional_value;
+        largest_mode = i;
+      }
+    }
+
+    num_poses_per_mode.at(largest_mode)++;
+    assigned_sum++;
+  }
+
+  for (auto& n : num_poses_per_mode)
+    std::cout << n << std::endl;
+  CreateVisualizationCallback(model_file, num_poses_per_mode,
+      weld_frame_to_world);
+}
+
+template <typename T>
+void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
+      std::string weld_frame_to_world) {
+  CreateVisualizationCallback(model_file, N(), weld_frame_to_world);
 }
 
 template class HybridDircon<double>;

--- a/systems/trajectory_optimization/hybrid_dircon.h
+++ b/systems/trajectory_optimization/hybrid_dircon.h
@@ -69,7 +69,12 @@ class HybridDircon
   /// Adds a default visualization callback that will visualize knot points
   /// without transparency. Cannot be called twice
   /// @param model_name The path of a URDF/SDF model name for visualization
-  void CreateVisualizationCallback(std::string model_file, 
+  /// @param knot_period Regulates how many knot points are visualized. For
+  ///   period of T, displays knot points (1, 1+T, 1+2T, ..., N). Note how the
+  ///   last knot point will always be shown, regardless of period. Default = 1
+  /// @param weld_frame_to_world The name of a frame to weld to the world frame
+  ///   when parsing the model. Defaults to blank, which will not perform a weld
+  void CreateVisualizationCallback(std::string model_file, int knot_period = 1,
       std::string weld_frame_to_world = "");
 
   /// Set the initial guess for the force variables for a specific mode

--- a/systems/trajectory_optimization/hybrid_dircon.h
+++ b/systems/trajectory_optimization/hybrid_dircon.h
@@ -15,6 +15,7 @@
 #include "systems/trajectory_optimization/dircon_kinematic_data_set.h"
 #include "systems/trajectory_optimization/dircon_opt_constraints.h"
 #include "systems/trajectory_optimization/dircon_options.h"
+#include "multibody/multipose_visualizer.h"
 
 namespace dairlib {
 namespace systems {
@@ -64,6 +65,12 @@ class HybridDircon
   /// %drake::trajectories::PiecewisePolynomialTrajectory%.
   drake::trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory(
       const drake::solvers::MathematicalProgramResult& result) const override;
+
+  /// Adds a default visualization callback that will visualize knot points
+  /// without transparency. Cannot be called twice
+  /// @param model_name The path of a URDF/SDF model name for visualization
+  void CreateVisualizationCallback(std::string model_file, 
+      std::string weld_frame_to_world = "");
 
   /// Set the initial guess for the force variables for a specific mode
   /// @param mode the mode index
@@ -178,6 +185,8 @@ class HybridDircon
   std::vector<drake::solvers::VectorXDecisionVariable> quaternion_slack_vars_;
   std::vector<int> num_kinematic_constraints_;
   std::vector<int> num_kinematic_constraints_wo_skipping_;
+
+  std::unique_ptr<multibody::MultiposeVisualizer> callback_visualizer_;
 };
 
 }  // namespace trajectory_optimization

--- a/systems/trajectory_optimization/hybrid_dircon.h
+++ b/systems/trajectory_optimization/hybrid_dircon.h
@@ -66,15 +66,36 @@ class HybridDircon
   drake::trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory(
       const drake::solvers::MathematicalProgramResult& result) const override;
 
-  /// Adds a default visualization callback that will visualize knot points
+  /// Adds a visualization callback that will visualize knot points
   /// without transparency. Cannot be called twice
   /// @param model_name The path of a URDF/SDF model name for visualization
-  /// @param knot_period Regulates how many knot points are visualized. For
-  ///   period of T, displays knot points (1, 1+T, 1+2T, ..., N). Note how the
-  ///   last knot point will always be shown, regardless of period. Default = 1
+  /// @param poses_per_mode Regulates how many knot points are visualized. A
+  ///   vector containing the nubmer of poses to show per mode. This is in
+  ///   addition to the start/end poses of every mode! The total number of poses
+  ///   is therefore [sum(poses_per_mode) + num_modes + 1]
   /// @param weld_frame_to_world The name of a frame to weld to the world frame
   ///   when parsing the model. Defaults to blank, which will not perform a weld
-  void CreateVisualizationCallback(std::string model_file, int knot_period = 1,
+  void CreateVisualizationCallback(std::string model_file,
+      std::vector<unsigned int> poses_per_mode,
+      std::string weld_frame_to_world = "");
+
+  /// See CreateVisualizationCallback(std::string model_file,
+  ///    std::vector<unsigned int> poses_per_mode,
+  ///    std::string weld_frame_to_world)
+  ///
+  /// Creates a callback using a single pose count parameter, num_poses
+  /// Evenly divides the poses among the different modes, weighting by number
+  /// of frames in that mode. Since start/end poses per mdoe are required, must
+  /// have num_poses >= num_modes + 1
+  void CreateVisualizationCallback(std::string model_file,
+      unsigned int num_poses, std::string weld_frame_to_world = "");
+
+  /// See CreateVisualizationCallback(std::string model_file,
+  ///    unsigned int poses_per_mode,
+  ///    std::string weld_frame_to_world)
+  ///
+  /// Creates a visualization callback that shows all knot points.
+  void CreateVisualizationCallback(std::string model_file,
       std::string weld_frame_to_world = "");
 
   /// Set the initial guess for the force variables for a specific mode


### PR DESCRIPTION
Related to #103 

Visualizes multiple states simultaneously, also wraps into a DIRCON callback function.

Parses a URDF multiple times to achieve this, with the only option of welding one frame to the world. It would probably be better to simple work off of an existing MBP, if that were possible.