### PR TITLE
Remove context creation from DIRCON constraints

### DIFF
--- a/multibody/multibody_utils.cc
+++ b/multibody/multibody_utils.cc
@@ -35,10 +35,8 @@ std::unique_ptr<Context<T>> createContext(const MultibodyPlant<T>& plant,
   auto context = plant.CreateDefaultContext();
   plant.SetPositionsAndVelocities(context.get(), state);
 
-  // TODO(mposa) Remove > 0 check once fixed upstream in Drake
-  if (input.size() > 0) {
-    context->FixInputPort(plant.get_actuation_input_port().get_index(), input);
-  }
+  context->FixInputPort(plant.get_actuation_input_port().get_index(), input);
+
   return context;
 }
 
@@ -47,10 +45,7 @@ void setContext(const MultibodyPlant<T>& plant,
     const VectorX<T>& state, const VectorX<T>& input, Context<T>* context) {
   plant.SetPositionsAndVelocities(context, state);
 
-  // TODO(mposa) Remove > 0 check once fixed upstream in Drake
-  if (input.size() > 0) {
-    context->FixInputPort(plant.get_actuation_input_port().get_index(), input);
-  }
+  context->FixInputPort(plant.get_actuation_input_port().get_index(), input);
 }
 
 

--- a/multibody/multibody_utils.cc
+++ b/multibody/multibody_utils.cc
@@ -43,6 +43,18 @@ std::unique_ptr<Context<T>> createContext(const MultibodyPlant<T>& plant,
 }
 
 template <typename T>
+void setContext(const MultibodyPlant<T>& plant,
+    const VectorX<T>& state, const VectorX<T>& input, Context<T>* context) {
+  plant.SetPositionsAndVelocities(context, state);
+
+  // TODO(mposa) Remove > 0 check once fixed upstream in Drake
+  if (input.size() > 0) {
+    context->FixInputPort(plant.get_actuation_input_port().get_index(), input);
+  }
+}
+
+
+template <typename T>
 void addFlatTerrain(MultibodyPlant<T>* plant, SceneGraph<T>* scene_graph,
                 double mu_static, double mu_kinetic, Eigen::Vector3d normal_W) {
   if (!plant->geometry_source_is_registered()) {
@@ -277,5 +289,7 @@ template VectorX<double> getInput(const MultibodyPlant<double>& plant, const Con
 template VectorX<AutoDiffXd> getInput(const MultibodyPlant<AutoDiffXd>& plant, const Context<AutoDiffXd>& context);  // NOLINT
 template std::unique_ptr<Context<double>> createContext(const MultibodyPlant<double>& plant, const VectorX<double>& state, const VectorX<double>& input);  // NOLINT
 template std::unique_ptr<Context<AutoDiffXd>> createContext(const MultibodyPlant<AutoDiffXd>& plant, const VectorX<AutoDiffXd>& state, const VectorX<AutoDiffXd>& input);  // NOLINT
+template void setContext(const MultibodyPlant<double>& plant, const VectorX<double>& state, const VectorX<double>& input, Context<double>* context);  // NOLINT
+template void setContext(const MultibodyPlant<AutoDiffXd>& plant, const VectorX<AutoDiffXd>& state, const VectorX<AutoDiffXd>& input, Context<AutoDiffXd>* context);  // NOLINT
 }  // namespace multibody
 }  // namespace dairlib

--- a/multibody/multibody_utils.h
+++ b/multibody/multibody_utils.h
@@ -11,11 +11,15 @@ template <typename T>
 drake::VectorX<T> getInput(const drake::multibody::MultibodyPlant<T>& plant,
                            const drake::systems::Context<T>& context);
 
+/// Create a new MultibodyPlant context and set the corresponding state and
+/// input values. Note, this is potentially an expensive operation!
 template <typename T>
 std::unique_ptr<drake::systems::Context<T>> createContext(
     const drake::multibody::MultibodyPlant<T>& plant,
     const drake::VectorX<T>& state, const drake::VectorX<T>& input);
 
+/// Update an existing MultibodyPlant context, setiing corresponding state and
+/// input values.
 template <typename T>
 void setContext(const drake::multibody::MultibodyPlant<T>& plant,
     const drake::VectorX<T>& state, const drake::VectorX<T>& input,

--- a/multibody/multibody_utils.h
+++ b/multibody/multibody_utils.h
@@ -16,6 +16,11 @@ std::unique_ptr<drake::systems::Context<T>> createContext(
     const drake::multibody::MultibodyPlant<T>& plant,
     const drake::VectorX<T>& state, const drake::VectorX<T>& input);
 
+template <typename T>
+void setContext(const drake::multibody::MultibodyPlant<T>& plant,
+    const drake::VectorX<T>& state, const drake::VectorX<T>& input,
+    drake::systems::Context<T>* context);
+
 /// Add terrain to an initialized, but not finalized, MultibodyPlant
 /// and scene graph. Uses the given values for coefficients of friction.
 /// normal_W is the normal direction of the ground (pointing to z as the

--- a/systems/trajectory_optimization/dircon_opt_constraints.h
+++ b/systems/trajectory_optimization/dircon_opt_constraints.h
@@ -171,6 +171,7 @@ class DirconKinematicConstraint : public DirconAbstractConstraint<T> {
   const std::vector<bool> is_constraint_relative_;
   const int n_relative_;
   Eigen::MatrixXd relative_map_;
+  std::unique_ptr<drake::systems::Context<T>> context_;
 };
 
 /// Helper method to add a DirconDynamicConstraint to the @p prog,
@@ -225,6 +226,7 @@ class DirconImpactConstraint : public DirconAbstractConstraint<T> {
   const int num_kinematic_constraints_wo_skipping_{0};
   const int num_positions_{0};
   const int num_velocities_{0};
+  std::unique_ptr<drake::systems::Context<T>> context_;
 };
 
 // Position constraint of a point in the directions `dir` with respect to the

--- a/systems/trajectory_optimization/dircon_opt_constraints.h
+++ b/systems/trajectory_optimization/dircon_opt_constraints.h
@@ -107,6 +107,7 @@ class DirconDynamicConstraint : public DirconAbstractConstraint<T> {
   const int num_positions_{0};
   const int num_velocities_{0};
   const int num_quat_slack_{0};
+  std::unique_ptr<drake::systems::Context<T>> context_;
 };
 
 /// Implements the kinematic constraints used by Dircon


### PR DESCRIPTION
`DirconDynamicConstraint` was creating a new MultibodyPlant context inside the evaluation loop. On the Cassie squatting test, this was ~15% of total runtime. Removed this to make use of a single context.

Also added a helper function (setContext) to support this.l