### PR TITLE
Connect osc debug port for the walking controller

### DIFF
--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -52,6 +52,8 @@ DEFINE_string(channel_x, "CASSIE_STATE_SIMULATION",
 DEFINE_string(channel_u, "CASSIE_INPUT",
               "The name of the channel which publishes command");
 
+DEFINE_bool(publish_osc_data, true,
+            "whether to publish lcm messages for OscTrackData");
 DEFINE_bool(print_osc, false, "whether to print the osc debug message or not");
 DEFINE_bool(is_two_phase, false,
             "true: only right/left single support"
@@ -116,6 +118,11 @@ int DoMain(int argc, char* argv[]) {
 
   builder.Connect(command_sender->get_output_port(0),
                   command_pub->get_input_port());
+
+  // Create osc debug sender.
+  auto osc_debug_pub =
+      builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_osc_output>(
+          "OSC_DEBUG", &lcm_local, TriggerTypeSet({TriggerType::kForced})));
 
   // Add emulator for floating base drift
   Eigen::VectorXd drift_mean =
@@ -390,6 +397,9 @@ int DoMain(int argc, char* argv[]) {
   builder.Connect(head_traj_gen->get_output_port(0),
                   osc->get_tracking_data_input_port("pelvis_heading_traj"));
   builder.Connect(osc->get_output_port(0), command_sender->get_input_port(0));
+  if (FLAGS_publish_osc_data) {
+    builder.Connect(osc->get_osc_debug_port(), osc_debug_pub->get_input_port());
+  }
 
   // Create the diagram
   auto owned_diagram = builder.Build();

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -119,11 +119,6 @@ int DoMain(int argc, char* argv[]) {
   builder.Connect(command_sender->get_output_port(0),
                   command_pub->get_input_port());
 
-  // Create osc debug sender.
-  auto osc_debug_pub =
-      builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_osc_output>(
-          "OSC_DEBUG", &lcm_local, TriggerTypeSet({TriggerType::kForced})));
-
   // Add emulator for floating base drift
   Eigen::VectorXd drift_mean =
       Eigen::VectorXd::Zero(plant_w_springs.num_positions());
@@ -398,6 +393,10 @@ int DoMain(int argc, char* argv[]) {
                   osc->get_tracking_data_input_port("pelvis_heading_traj"));
   builder.Connect(osc->get_output_port(0), command_sender->get_input_port(0));
   if (FLAGS_publish_osc_data) {
+    // Create osc debug sender.
+    auto osc_debug_pub =
+        builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_osc_output>(
+            "OSC_DEBUG", &lcm_local, TriggerTypeSet({TriggerType::kForced})));
     builder.Connect(osc->get_osc_debug_port(), osc_debug_pub->get_input_port());
   }
 


### PR DESCRIPTION
I connected the port so that `OscTrackingData`'s are published through lcm and Joan can potentially use this as an example for his visualization work