### PR TITLE
Remove construction of gravity fields, since it is added by default.

### DIFF
--- a/examples/Cassie/run_dircon_walking.cc
+++ b/examples/Cassie/run_dircon_walking.cc
@@ -176,8 +176,6 @@ vector<VectorXd> GetInitGuessForQ(int N, double stride_length,
       string full_name =
           FindResourceOrThrow("examples/Cassie/urdf/cassie_fixed_springs.urdf");
       parser.AddModelFromFile(full_name);
-      plant_ik.mutable_gravity_field().set_gravity_vector(
-          -9.81 * Eigen::Vector3d::UnitZ());
       plant_ik.Finalize();
 
       // Visualize
@@ -270,8 +268,6 @@ void DoMain(double duration, double stride_length, double ground_incline,
   string full_name =
       FindResourceOrThrow("examples/Cassie/urdf/cassie_fixed_springs.urdf");
   parser.AddModelFromFile(full_name);
-  plant.mutable_gravity_field().set_gravity_vector(-9.81 *
-                                                   Eigen::Vector3d::UnitZ());
   plant.Finalize();
 
   // Create maps for joints

--- a/examples/Cassie/test/benchmark_dynamics.cc
+++ b/examples/Cassie/test/benchmark_dynamics.cc
@@ -83,9 +83,6 @@ int do_main() {
   parser.AddModelFromFile(dairlib::FindResourceOrThrow(
       "examples/Cassie/urdf/cassie_v2.urdf"));
 
-  multibody_plant.mutable_gravity_field().set_gravity_vector(
-      -9.81 * Eigen::Vector3d::UnitZ());
-
   multibody_plant.WeldFrames(
     multibody_plant.world_frame(), multibody_plant.GetFrameByName("pelvis"));
   multibody_plant.Finalize();

--- a/examples/Cassie/test/min_deps_mbt_sim.cc
+++ b/examples/Cassie/test/min_deps_mbt_sim.cc
@@ -53,9 +53,6 @@ int do_main(int argc, char* argv[]) {
   Parser parser(&plant, &scene_graph);
   parser.AddModelFromFile(full_name);
 
-  plant.AddForceElement<drake::multibody::UniformGravityFieldElement>(
-      -9.81 * Eigen::Vector3d::UnitZ());
-
   plant.WeldFrames(
     plant.world_frame(), plant.GetFrameByName("pelvis"),
     drake::math::RigidTransform<double>(Eigen::Vector3d::Zero()).GetAsIsometry3());

--- a/multibody/kinematic/test/kinematic_evaluator_caching_test.cc
+++ b/multibody/kinematic/test/kinematic_evaluator_caching_test.cc
@@ -225,8 +225,6 @@ int DoMain(int argc, char* argv[]) {
   drake::multibody::Parser parser(&plant);
   std::string full_name = FindResourceOrThrow(filename);
   parser.AddModelFromFile(full_name);
-  plant.mutable_gravity_field().set_gravity_vector(-9.81 *
-                                                   Eigen::Vector3d::UnitZ());
   plant.Finalize();
 
   multibody::KinematicEvaluatorSet<double> evaluators(plant);

--- a/systems/trajectory_optimization/test/passive_constrained_pendulum_dircon.cc
+++ b/systems/trajectory_optimization/test/passive_constrained_pendulum_dircon.cc
@@ -58,9 +58,6 @@ void runDircon() {
 
   parser.AddModelFromFile(sdf_path);
 
-  plant.mutable_gravity_field().set_gravity_vector(
-      -9.81 * Eigen::Vector3d::UnitZ());
-
   plant.WeldFrames(
       plant.world_frame(), plant.GetFrameByName("base_link"),
       drake::math::RigidTransform<double>());


### PR DESCRIPTION
Per an older upstream Drake change, we no longer need to add -9.81z for gravity, as this is the default setting.