### PR TITLE
Update Dockerfile

### DIFF
--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -81,7 +81,7 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   double max_joint_velocity_;
 
   double input_limit_;
-  int n_consecutive_fails_index_;
+  int n_fails_index_;
   int status_index_;
   int state_input_port_;
   int command_input_port_;

--- a/install/bionic/Dockerfile
+++ b/install/bionic/Dockerfile
@@ -1,6 +1,6 @@
 FROM ros:melodic-ros-base-bionic
 WORKDIR /dairlib
-ENV DAIRLIB_DOCKER_VERSION=1
+ENV DAIRLIB_DOCKER_VERSION=2
 COPY . .
 RUN apt-get update && apt-get install -y wget lsb-release pkg-config zip g++ zlib1g-dev unzip python
 RUN set -eux \

--- a/install/bionic/ros/Dockerfile
+++ b/install/bionic/ros/Dockerfile
@@ -1,6 +1,6 @@
 FROM ros:melodic-ros-base-bionic
 WORKDIR /dairlib
-ENV DAIRLIB_DOCKER_VERSION=1
+ENV DAIRLIB_DOCKER_VERSION=2
 COPY . .
 RUN apt-get update && apt-get install -y wget lsb-release pkg-config zip g++ zlib1g-dev unzip python
 RUN apt-get install -y python-rosinstall-generator python-catkin-tools


### PR DESCRIPTION
A bug in InputSupervisor was caught by unit tests (hooray) combined with recent Drake updates. Some of our old code assumed a single discrete value (needed to use `[]` operator), but we had two declared. I updated the class to use a single, length 2, discrete value.

Also increments the Dockerfile version tag to trigger a rebuild with a fresh dependency installation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/182)
<!-- Reviewable:end -->
