### PR TITLE
Update for OSC lcm messages

### DIFF
--- a/examples/Cassie/cassie_simulation.pmd
+++ b/examples/Cassie/cassie_simulation.pmd
@@ -43,7 +43,7 @@ group "2.drake-simulator" {
         host = "localhost";
     }
     cmd "1.simulator for OSC controller" {
-        exec = "bazel-bin/examples/Cassie/multibody_sim --floating_base=true --publish_rate=200 --init_height=.85";
+        exec = "bazel-bin/examples/Cassie/multibody_sim --floating_base=true --publish_rate=200 --init_height=1.0";
         host = "localhost";
     }
 }

--- a/examples/Cassie/run_osc_jumping_controller.cc
+++ b/examples/Cassie/run_osc_jumping_controller.cc
@@ -269,8 +269,8 @@ int DoMain(int argc, char* argv[]) {
   W_com(2, 2) = 2000;
   MatrixXd K_p_com = 64 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_com = 16 * MatrixXd::Identity(3, 3);
-  ComTrackingData com_tracking_data("com_traj", 3, K_p_com, K_d_com, W_com,
-                                    &plant_w_springs, &plant_wo_springs);
+  ComTrackingData com_tracking_data("com_traj", K_p_com, K_d_com, W_com,
+                                    plant_w_springs, plant_wo_springs);
   for (FSM_STATE mode : stance_modes) {
     com_tracking_data.AddStateToTrack(mode);
   }
@@ -285,11 +285,11 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_sw_ft = 12 * MatrixXd::Identity(3, 3);
 
   TransTaskSpaceTrackingData left_foot_tracking_data(
-      "l_foot_traj", 3, K_p_sw_ft, K_d_sw_ft, W_swing_foot, &plant_w_springs,
-      &plant_wo_springs);
+      "l_foot_traj", K_p_sw_ft, K_d_sw_ft, W_swing_foot, plant_w_springs,
+      plant_wo_springs);
   TransTaskSpaceTrackingData right_foot_tracking_data(
-      "r_foot_traj", 3, K_p_sw_ft, K_d_sw_ft, W_swing_foot, &plant_w_springs,
-      &plant_wo_springs);
+      "r_foot_traj", K_p_sw_ft, K_d_sw_ft, W_swing_foot, plant_w_springs,
+      plant_wo_springs);
   left_foot_tracking_data.AddStateAndPointToTrack(FLIGHT, "toe_left");
   right_foot_tracking_data.AddStateAndPointToTrack(FLIGHT, "toe_right");
 
@@ -307,8 +307,8 @@ int DoMain(int argc, char* argv[]) {
   Matrix3d K_d_pelvis = k_d_pelvis_balance * MatrixXd::Identity(3, 3);
   K_d_pelvis(2, 2) = k_d_heading;
   RotTaskSpaceTrackingData pelvis_rot_tracking_data(
-      "pelvis_rot_tracking_data", 3, K_p_pelvis, K_d_pelvis, W_pelvis,
-      &plant_w_springs, &plant_wo_springs);
+      "pelvis_rot_tracking_data", K_p_pelvis, K_d_pelvis, W_pelvis,
+      plant_w_springs, plant_wo_springs);
 
   for (FSM_STATE mode : stance_modes) {
     pelvis_rot_tracking_data.AddStateAndFrameToTrack(mode, "pelvis");

--- a/examples/Cassie/run_osc_standing_controller.cc
+++ b/examples/Cassie/run_osc_standing_controller.cc
@@ -169,9 +169,9 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_com = xy_scale * MatrixXd::Identity(3, 3);
   K_p_com(2, 2) = 10;
   K_d_com(2, 2) = 10;
-  ComTrackingData center_of_mass_traj("com_traj", 3, K_p_com, K_d_com,
+  ComTrackingData center_of_mass_traj("com_traj", K_p_com, K_d_com,
                                       W_com * FLAGS_cost_weight_multiplier,
-                                      &plant_w_springs, &plant_wo_springs);
+                                      plant_w_springs, plant_wo_springs);
   osc->AddTrackingData(&center_of_mass_traj);
   // Pelvis rotation tracking
   double w_pelvis_balance = 200;
@@ -193,9 +193,9 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis(1, 1) = k_d_pelvis_balance;
   K_d_pelvis(2, 2) = k_d_heading;
   RotTaskSpaceTrackingData pelvis_rot_traj(
-      "pelvis_rot_traj", 3, K_p_pelvis, K_d_pelvis,
-      W_pelvis * FLAGS_cost_weight_multiplier, &plant_w_springs,
-      &plant_wo_springs);
+      "pelvis_rot_traj", K_p_pelvis, K_d_pelvis,
+      W_pelvis * FLAGS_cost_weight_multiplier, plant_w_springs,
+      plant_wo_springs);
   pelvis_rot_traj.AddFrameToTrack("pelvis");
   VectorXd pelvis_desired_quat(4);
   pelvis_desired_quat << 1, 0, 0, 0;

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -301,9 +301,9 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd W_swing_foot = 400 * MatrixXd::Identity(3, 3);
   MatrixXd K_p_sw_ft = 100 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_sw_ft = 10 * MatrixXd::Identity(3, 3);
-  TransTaskSpaceTrackingData swing_foot_traj("cp_traj", 3, K_p_sw_ft, K_d_sw_ft,
-                                             W_swing_foot, &plant_w_springs,
-                                             &plant_wo_springs);
+  TransTaskSpaceTrackingData swing_foot_traj("cp_traj", K_p_sw_ft, K_d_sw_ft,
+                                             W_swing_foot, plant_w_springs,
+                                             plant_wo_springs);
   swing_foot_traj.AddStateAndPointToTrack(left_stance_state, "toe_right");
   swing_foot_traj.AddStateAndPointToTrack(right_stance_state, "toe_left");
   osc->AddTrackingData(&swing_foot_traj);
@@ -314,8 +314,8 @@ int DoMain(int argc, char* argv[]) {
   W_com(2, 2) = 2000;
   MatrixXd K_p_com = 50 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_com = 10 * MatrixXd::Identity(3, 3);
-  ComTrackingData center_of_mass_traj("lipm_traj", 3, K_p_com, K_d_com, W_com,
-                                      &plant_w_springs, &plant_wo_springs);
+  ComTrackingData center_of_mass_traj("lipm_traj", K_p_com, K_d_com, W_com,
+                                      plant_w_springs, plant_wo_springs);
   osc->AddTrackingData(&center_of_mass_traj);
   // Pelvis rotation tracking (pitch and roll)
   double w_pelvis_balance = 200;
@@ -331,8 +331,8 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis_balance(0, 0) = k_d_pelvis_balance;
   K_d_pelvis_balance(1, 1) = k_d_pelvis_balance;
   RotTaskSpaceTrackingData pelvis_balance_traj(
-      "pelvis_balance_traj", 3, K_p_pelvis_balance, K_d_pelvis_balance,
-      W_pelvis_balance, &plant_w_springs, &plant_wo_springs);
+      "pelvis_balance_traj", K_p_pelvis_balance, K_d_pelvis_balance,
+      W_pelvis_balance, plant_w_springs, plant_wo_springs);
   pelvis_balance_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_balance_traj);
   // Pelvis rotation tracking (yaw)
@@ -346,8 +346,8 @@ int DoMain(int argc, char* argv[]) {
   Matrix3d K_d_pelvis_heading = MatrixXd::Zero(3, 3);
   K_d_pelvis_heading(2, 2) = k_d_heading;
   RotTaskSpaceTrackingData pelvis_heading_traj(
-      "pelvis_heading_traj", 3, K_p_pelvis_heading, K_d_pelvis_heading,
-      W_pelvis_heading, &plant_w_springs, &plant_wo_springs);
+      "pelvis_heading_traj", K_p_pelvis_heading, K_d_pelvis_heading,
+      W_pelvis_heading, plant_w_springs, plant_wo_springs);
   pelvis_heading_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_heading_traj, 0.1);  // 0.05
   // Swing toe joint tracking (Currently use fix position)
@@ -358,7 +358,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_swing_toe = 20 * MatrixXd::Identity(1, 1);
   JointSpaceTrackingData swing_toe_traj("swing_toe_traj", K_p_swing_toe,
                                         K_d_swing_toe, W_swing_toe,
-                                        &plant_w_springs, &plant_wo_springs);
+                                        plant_w_springs, plant_wo_springs);
   swing_toe_traj.AddStateAndJointToTrack(left_stance_state, "toe_right",
                                          "toe_rightdot");
   swing_toe_traj.AddStateAndJointToTrack(right_stance_state, "toe_left",
@@ -370,7 +370,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_hip_yaw = 160 * MatrixXd::Identity(1, 1);
   JointSpaceTrackingData swing_hip_yaw_traj(
       "swing_hip_yaw_traj", K_p_hip_yaw, K_d_hip_yaw, W_hip_yaw,
-      &plant_w_springs, &plant_wo_springs);
+      plant_w_springs, plant_wo_springs);
   swing_hip_yaw_traj.AddStateAndJointToTrack(left_stance_state, "hip_yaw_right",
                                              "hip_yaw_rightdot");
   swing_hip_yaw_traj.AddStateAndJointToTrack(right_stance_state, "hip_yaw_left",

--- a/lcmtypes/lcmt_osc_output.lcm
+++ b/lcmtypes/lcmt_osc_output.lcm
@@ -8,4 +8,9 @@ struct lcmt_osc_output
 
   lcmt_osc_tracking_data tracking_data[num_tracking_data];
   string tracking_data_names[num_tracking_data];
+
+  double input_cost;
+  double acceleration_cost;
+  double soft_constraint_cost;
+  double tracking_cost [num_tracking_data];
 }

--- a/lcmtypes/lcmt_osc_tracking_data.lcm
+++ b/lcmtypes/lcmt_osc_tracking_data.lcm
@@ -3,16 +3,17 @@ package dairlib;
 struct lcmt_osc_tracking_data
 {
   int32_t y_dim;
+  int32_t ydot_dim;
   string name;
   boolean is_active;
 
   double y [y_dim];
   double y_des [y_dim];
   double error_y [y_dim];
-  double ydot [y_dim];
-  double ydot_des [y_dim];
-  double error_ydot [y_dim];
-  double yddot_des [y_dim];
-  double yddot_command [y_dim];
-  double yddot_command_sol [y_dim];
+  double ydot [ydot_dim];
+  double ydot_des [ydot_dim];
+  double error_ydot [ydot_dim];
+  double yddot_des [ydot_dim];
+  double yddot_command [ydot_dim];
+  double yddot_command_sol [ydot_dim];
 }

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -666,8 +666,10 @@ void OperationalSpaceControl::AssignOscLcmOutput(
       (BasicVector<double>*)this->EvalVectorInput(context, fsm_port_);
 
   double time_since_last_state_switch =
-      state->get_timestamp() -
-      context.get_discrete_state(prev_event_time_idx_).get_value()(0);
+      used_with_finite_state_machine_
+          ? state->get_timestamp() -
+                context.get_discrete_state(prev_event_time_idx_).get_value()(0)
+          : state->get_timestamp();
 
   output->utime = state->get_timestamp() * 1e6;
   output->fsm_state = fsm_output->get_value()(0);

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -35,7 +35,7 @@ namespace dairlib::systems::controllers {
 using multibody::makeNameToVelocitiesMap;
 using multibody::WorldPointEvaluator;
 
-static const int SPACE_DIM = 3;
+static const int kSpaceDim = 3;
 
 OperationalSpaceControl::OperationalSpaceControl(
     const MultibodyPlant<double>& plant_w_spr,
@@ -248,7 +248,7 @@ void OperationalSpaceControl::Build() {
   // Size of decision variable
   n_h_ = (kinematic_evaluators_ == nullptr)?
       0 : kinematic_evaluators_->count_full();
-  n_c_ = SPACE_DIM * all_contacts_.size();
+  n_c_ = kSpaceDim * all_contacts_.size();
   n_c_active_ = 0;
   for (auto evaluator : all_contacts_) {
     n_c_active_ += evaluator->num_active();
@@ -312,35 +312,35 @@ void OperationalSpaceControl::Build() {
       friction_constraints_.push_back(
           prog_->AddLinearConstraint(mu_neg1.transpose(), 0,
                                      numeric_limits<double>::infinity(),
-                                     {lambda_c_.segment(SPACE_DIM * j + 2, 1),
-                                      lambda_c_.segment(SPACE_DIM * j + 0, 1)})
+                                     {lambda_c_.segment(kSpaceDim * j + 2, 1),
+                                      lambda_c_.segment(kSpaceDim * j + 0, 1)})
                .evaluator()
                .get());
       friction_constraints_.push_back(
           prog_->AddLinearConstraint(mu_1.transpose(), 0,
                                      numeric_limits<double>::infinity(),
-                                     {lambda_c_.segment(SPACE_DIM * j + 2, 1),
-                                      lambda_c_.segment(SPACE_DIM * j + 0, 1)})
+                                     {lambda_c_.segment(kSpaceDim * j + 2, 1),
+                                      lambda_c_.segment(kSpaceDim * j + 0, 1)})
                .evaluator()
                .get());
       friction_constraints_.push_back(
           prog_->AddLinearConstraint(mu_neg1.transpose(), 0,
                                      numeric_limits<double>::infinity(),
-                                     {lambda_c_.segment(SPACE_DIM * j + 2, 1),
-                                      lambda_c_.segment(SPACE_DIM * j + 1, 1)})
+                                     {lambda_c_.segment(kSpaceDim * j + 2, 1),
+                                      lambda_c_.segment(kSpaceDim * j + 1, 1)})
                .evaluator()
                .get());
       friction_constraints_.push_back(
           prog_->AddLinearConstraint(mu_1.transpose(), 0,
                                      numeric_limits<double>::infinity(),
-                                     {lambda_c_.segment(SPACE_DIM * j + 2, 1),
-                                      lambda_c_.segment(SPACE_DIM * j + 1, 1)})
+                                     {lambda_c_.segment(kSpaceDim * j + 2, 1),
+                                      lambda_c_.segment(kSpaceDim * j + 1, 1)})
                .evaluator()
                .get());
       friction_constraints_.push_back(
           prog_->AddLinearConstraint(one.transpose(), 0,
                                      numeric_limits<double>::infinity(),
-                                     lambda_c_.segment(SPACE_DIM * j + 2, 1))
+                                     lambda_c_.segment(kSpaceDim * j + 2, 1))
                .evaluator()
                .get());
     }
@@ -443,7 +443,7 @@ VectorXd OperationalSpaceControl::SolveQp(
   MatrixXd J_c = MatrixXd::Zero(n_c_, n_v_);
   for (unsigned int i = 0; i < all_contacts_.size(); i++) {
     if (active_contact_set.find(i) != active_contact_set.end()) {
-      J_c.block(SPACE_DIM * i, 0, SPACE_DIM, n_v_) =
+      J_c.block(kSpaceDim * i, 0, kSpaceDim, n_v_) =
           all_contacts_[i]->EvalFullJacobian(*context_wo_spr_);
     }
   }
@@ -459,7 +459,7 @@ VectorXd OperationalSpaceControl::SolveQp(
       // of the Jacobian. (J_c_active is just a stack of slices of J_c)
       for (int j = 0; j < contact_i->num_active(); j++) {
         J_c_active.row(row_idx + j) =
-            J_c.row(SPACE_DIM * i + contact_i->active_inds().at(j));
+            J_c.row(kSpaceDim * i + contact_i->active_inds().at(j));
       }
       JdotV_c_active.segment(row_idx, contact_i->num_active()) =
           contact_i->EvalActiveJacobianDotTimesV(*context_wo_spr_);

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -35,7 +35,7 @@ namespace dairlib::systems::controllers {
 using multibody::makeNameToVelocitiesMap;
 using multibody::WorldPointEvaluator;
 
-static const int kSpaceDim = 3;
+int kSpaceDim = OscTrackingData::kSpaceDim;
 
 OperationalSpaceControl::OperationalSpaceControl(
     const MultibodyPlant<double>& plant_w_spr,

--- a/systems/controllers/osc/operational_space_control.h
+++ b/systems/controllers/osc/operational_space_control.h
@@ -242,6 +242,13 @@ class OperationalSpaceControl : public drake::systems::LeafSystem<double> {
   std::vector<drake::solvers::LinearConstraint*> friction_constraints_;
   std::vector<drake::solvers::QuadraticCost*> tracking_cost_;
 
+  // OSC solution
+  std::unique_ptr<Eigen::VectorXd> dv_sol_;
+  std::unique_ptr<Eigen::VectorXd> u_sol_;
+  std::unique_ptr<Eigen::VectorXd> lambda_c_sol_;
+  std::unique_ptr<Eigen::VectorXd> lambda_h_sol_;
+  std::unique_ptr<Eigen::VectorXd> epsilon_sol_;
+
   // OSC cost members
   /// Using u cost would push the robot away from the fixed point, so the user
   /// could consider using acceleration cost instead.

--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -25,24 +25,26 @@ using multibody::makeNameToPositionsMap;
 using multibody::makeNameToVelocitiesMap;
 
 /**** OscTrackingData ****/
-OscTrackingData::OscTrackingData(
-    const string& name, int n_r, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
+OscTrackingData::OscTrackingData(const string& name, int n_y, int n_ydot,
+                                 const MatrixXd& K_p, const MatrixXd& K_d,
+                                 const MatrixXd& W,
+                                 const MultibodyPlant<double>& plant_w_spr,
+                                 const MultibodyPlant<double>& plant_wo_spr)
     : plant_w_spr_(plant_w_spr),
       plant_wo_spr_(plant_wo_spr),
-      world_w_spr_(plant_w_spr_->world_frame()),
-      world_wo_spr_(plant_wo_spr_->world_frame()),
+      world_w_spr_(plant_w_spr_.world_frame()),
+      world_wo_spr_(plant_wo_spr_.world_frame()),
       name_(name),
-      n_r_(n_r),
+      n_y_(n_y),
+      n_ydot_(n_ydot),
       K_p_(K_p),
       K_d_(K_d),
       W_(W) {}
 
 // Update
 bool OscTrackingData::Update(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr,
-    const VectorXd& x_wo_spr, Context<double>& context_wo_spr,
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr,
+    const VectorXd& x_wo_spr, const Context<double>& context_wo_spr,
     const drake::trajectories::Trajectory<double>& traj, double t,
     int finite_state_machine_state) {
   // Update track_at_current_state_
@@ -91,7 +93,8 @@ void OscTrackingData::PrintFeedbackAndDesiredValues(const VectorXd& dv) {
   cout << "  ydot = " << ydot_.transpose() << endl;
   cout << "  ydot_des = " << ydot_des_.transpose() << endl;
   cout << "  error_ydot_ = " << error_ydot_.transpose() << endl;
-  cout << "  yddot_des_converted = " << yddot_des_converted_.transpose() << endl;
+  cout << "  yddot_des_converted = " << yddot_des_converted_.transpose()
+       << endl;
   cout << "  yddot_command = " << yddot_command_.transpose() << endl;
   cout << "  yddot_command_sol = " << (J_ * dv + JdotV_).transpose() << endl;
 }
@@ -115,9 +118,9 @@ void OscTrackingData::CheckOscTrackingData() {
   cout << "Checking " << name_ << endl;
   CheckDerivedOscTrackingData();
 
-  DRAKE_DEMAND((K_p_.rows() == n_r_) && (K_p_.cols() == n_r_));
-  DRAKE_DEMAND((K_d_.rows() == n_r_) && (K_d_.cols() == n_r_));
-  DRAKE_DEMAND((W_.rows() == n_r_) && (W_.cols() == n_r_));
+  DRAKE_DEMAND((K_p_.rows() == n_ydot_) && (K_p_.cols() == n_ydot_));
+  DRAKE_DEMAND((K_d_.rows() == n_ydot_) && (K_d_.cols() == n_ydot_));
+  DRAKE_DEMAND((W_.rows() == n_ydot_) && (W_.cols() == n_ydot_));
 
   // State_ cannot have repeated state
   auto it = std::unique(state_.begin(), state_.end());
@@ -126,42 +129,42 @@ void OscTrackingData::CheckOscTrackingData() {
 }
 
 /**** ComTrackingData ****/
-ComTrackingData::ComTrackingData(
-    const string& name, int n_r, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
-    : OscTrackingData(name, n_r, K_p, K_d, W, plant_w_spr, plant_wo_spr) {}
+ComTrackingData::ComTrackingData(const string& name, const MatrixXd& K_p,
+                                 const MatrixXd& K_d, const MatrixXd& W,
+                                 const MultibodyPlant<double>& plant_w_spr,
+                                 const MultibodyPlant<double>& plant_wo_spr)
+    : OscTrackingData(name, 3, 3, K_p, K_d, W, plant_w_spr, plant_wo_spr) {}
 
 void ComTrackingData::AddStateToTrack(int state) { AddState(state); }
 
 void ComTrackingData::UpdateYAndError(const VectorXd& x_w_spr,
-                                         Context<double>& context_w_spr) {
-  y_ = plant_w_spr_->CalcCenterOfMassPosition(context_w_spr);
+                                      const Context<double>& context_w_spr) {
+  y_ = plant_w_spr_.CalcCenterOfMassPosition(context_w_spr);
   error_y_ = y_des_ - y_;
 }
 
 void ComTrackingData::UpdateYdotAndError(const VectorXd& x_w_spr,
-                                            Context<double>& context_w_spr) {
-  MatrixXd J_w_spr(3, plant_w_spr_->num_velocities());
-  plant_w_spr_->CalcJacobianCenterOfMassTranslationalVelocity(
+                                         const Context<double>& context_w_spr) {
+  MatrixXd J_w_spr(3, plant_w_spr_.num_velocities());
+  plant_w_spr_.CalcJacobianCenterOfMassTranslationalVelocity(
       context_w_spr, JacobianWrtVariable::kV, world_w_spr_, world_w_spr_,
       &J_w_spr);
-  ydot_ = J_w_spr * x_w_spr.tail(plant_w_spr_->num_velocities());
+  ydot_ = J_w_spr * x_w_spr.tail(plant_w_spr_.num_velocities());
   error_ydot_ = ydot_des_ - ydot_;
 }
 
 void ComTrackingData::UpdateYddotDes() { yddot_des_converted_ = yddot_des_; }
 
 void ComTrackingData::UpdateJ(const VectorXd& x_wo_spr,
-                                 Context<double>& context_wo_spr) {
-  J_ = MatrixXd::Zero(3, plant_wo_spr_->num_velocities());
-  plant_wo_spr_->CalcJacobianCenterOfMassTranslationalVelocity(
+                              const Context<double>& context_wo_spr) {
+  J_ = MatrixXd::Zero(3, plant_wo_spr_.num_velocities());
+  plant_wo_spr_.CalcJacobianCenterOfMassTranslationalVelocity(
       context_wo_spr, JacobianWrtVariable::kV, world_w_spr_, world_w_spr_, &J_);
 }
 
 void ComTrackingData::UpdateJdotV(const VectorXd& x_wo_spr,
-                                     Context<double>& context_wo_spr) {
-  JdotV_ = plant_wo_spr_->CalcBiasCenterOfMassTranslationalAcceleration(
+                                  const Context<double>& context_wo_spr) {
+  JdotV_ = plant_wo_spr_.CalcBiasCenterOfMassTranslationalAcceleration(
       context_wo_spr, JacobianWrtVariable::kV, world_wo_spr_, world_wo_spr_);
 }
 
@@ -169,29 +172,31 @@ void ComTrackingData::CheckDerivedOscTrackingData() {}
 
 /**** TaskSpaceTrackingData ****/
 TaskSpaceTrackingData::TaskSpaceTrackingData(
-    const string& name, int n_r, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
-    : OscTrackingData(name, n_r, K_p, K_d, W, plant_w_spr, plant_wo_spr) {}
+    const string& name, int n_y, int n_ydot, const MatrixXd& K_p,
+    const MatrixXd& K_d, const MatrixXd& W,
+    const MultibodyPlant<double>& plant_w_spr,
+    const MultibodyPlant<double>& plant_wo_spr)
+    : OscTrackingData(name, n_y, n_ydot, K_p, K_d, W, plant_w_spr,
+                      plant_wo_spr) {}
 
 /**** TransTaskSpaceTrackingData ****/
 TransTaskSpaceTrackingData::TransTaskSpaceTrackingData(
-    const string& name, int n_r, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
-    : TaskSpaceTrackingData(name, n_r, K_p, K_d, W, plant_w_spr,
-                               plant_wo_spr) {}
+    const string& name, const MatrixXd& K_p, const MatrixXd& K_d,
+    const MatrixXd& W, const MultibodyPlant<double>& plant_w_spr,
+    const MultibodyPlant<double>& plant_wo_spr)
+    : TaskSpaceTrackingData(name, 3, 3, K_p, K_d, W, plant_w_spr,
+                            plant_wo_spr) {}
 
-void TransTaskSpaceTrackingData::AddPointToTrack(
-    const std::string& body_name, const Vector3d& pt_on_body) {
-  DRAKE_DEMAND(plant_w_spr_->HasBodyNamed(body_name));
-  DRAKE_DEMAND(plant_wo_spr_->HasBodyNamed(body_name));
-  body_index_w_spr_.push_back(plant_w_spr_->GetBodyByName(body_name).index());
-  body_index_wo_spr_.push_back(plant_wo_spr_->GetBodyByName(body_name).index());
+void TransTaskSpaceTrackingData::AddPointToTrack(const std::string& body_name,
+                                                 const Vector3d& pt_on_body) {
+  DRAKE_DEMAND(plant_w_spr_.HasBodyNamed(body_name));
+  DRAKE_DEMAND(plant_wo_spr_.HasBodyNamed(body_name));
+  body_index_w_spr_.push_back(plant_w_spr_.GetBodyByName(body_name).index());
+  body_index_wo_spr_.push_back(plant_wo_spr_.GetBodyByName(body_name).index());
   body_frames_w_spr_.push_back(
-      &plant_w_spr_->GetBodyByName(body_name).body_frame());
+      &plant_w_spr_.GetBodyByName(body_name).body_frame());
   body_frames_wo_spr_.push_back(
-      &plant_wo_spr_->GetBodyByName(body_name).body_frame());
+      &plant_wo_spr_.GetBodyByName(body_name).body_frame());
   pts_on_body_.push_back(pt_on_body);
 }
 void TransTaskSpaceTrackingData::AddStateAndPointToTrack(
@@ -201,22 +206,22 @@ void TransTaskSpaceTrackingData::AddStateAndPointToTrack(
 }
 
 void TransTaskSpaceTrackingData::UpdateYAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
   y_ = Vector3d::Zero();
-  plant_w_spr_->CalcPointsPositions(
+  plant_w_spr_.CalcPointsPositions(
       context_w_spr, *body_frames_wo_spr_[GetStateIdx()],
       pts_on_body_[GetStateIdx()], world_w_spr_, &y_);
   error_y_ = y_des_ - y_;
 }
 
 void TransTaskSpaceTrackingData::UpdateYdotAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
-  MatrixXd J(3, plant_w_spr_->num_velocities());
-  plant_w_spr_->CalcJacobianTranslationalVelocity(
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
+  MatrixXd J(3, plant_w_spr_.num_velocities());
+  plant_w_spr_.CalcJacobianTranslationalVelocity(
       context_w_spr, JacobianWrtVariable::kV,
       *body_frames_w_spr_.at(GetStateIdx()), pts_on_body_.at(GetStateIdx()),
       world_w_spr_, world_w_spr_, &J);
-  ydot_ = J * x_w_spr.tail(plant_w_spr_->num_velocities());
+  ydot_ = J * x_w_spr.tail(plant_w_spr_.num_velocities());
   error_ydot_ = ydot_des_ - ydot_;
 }
 
@@ -224,22 +229,21 @@ void TransTaskSpaceTrackingData::UpdateYddotDes() {
   yddot_des_converted_ = yddot_des_;
 }
 
-void TransTaskSpaceTrackingData::UpdateJ(const VectorXd& x_wo_spr,
-                                            Context<double>& context_wo_spr) {
-  J_ = MatrixXd::Zero(3, plant_wo_spr_->num_velocities());
-  plant_wo_spr_->CalcJacobianTranslationalVelocity(
+void TransTaskSpaceTrackingData::UpdateJ(
+    const VectorXd& x_wo_spr, const Context<double>& context_wo_spr) {
+  J_ = MatrixXd::Zero(3, plant_wo_spr_.num_velocities());
+  plant_wo_spr_.CalcJacobianTranslationalVelocity(
       context_wo_spr, JacobianWrtVariable::kV,
       *body_frames_wo_spr_.at(GetStateIdx()), pts_on_body_.at(GetStateIdx()),
       world_wo_spr_, world_wo_spr_, &J_);
 }
 
 void TransTaskSpaceTrackingData::UpdateJdotV(
-    const VectorXd& x_wo_spr, Context<double>& context_wo_spr) {
-  JdotV_ = plant_wo_spr_
-               ->CalcBiasTranslationalAcceleration(
-                   context_wo_spr, drake::multibody::JacobianWrtVariable::kV,
-                   *body_frames_wo_spr_.at(GetStateIdx()),
-                   pts_on_body_.at(GetStateIdx()), world_wo_spr_, world_wo_spr_);
+    const VectorXd& x_wo_spr, const Context<double>& context_wo_spr) {
+  JdotV_ = plant_wo_spr_.CalcBiasTranslationalAcceleration(
+      context_wo_spr, drake::multibody::JacobianWrtVariable::kV,
+      *body_frames_wo_spr_.at(GetStateIdx()), pts_on_body_.at(GetStateIdx()),
+      world_wo_spr_, world_wo_spr_);
 }
 
 void TransTaskSpaceTrackingData::CheckDerivedOscTrackingData() {
@@ -258,22 +262,22 @@ void TransTaskSpaceTrackingData::CheckDerivedOscTrackingData() {
 
 /**** RotTaskSpaceTrackingData ****/
 RotTaskSpaceTrackingData::RotTaskSpaceTrackingData(
-    const string& name, int n_r, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
-    : TaskSpaceTrackingData(name, n_r, K_p, K_d, W, plant_w_spr,
-                               plant_wo_spr) {}
+    const string& name, const MatrixXd& K_p, const MatrixXd& K_d,
+    const MatrixXd& W, const MultibodyPlant<double>& plant_w_spr,
+    const MultibodyPlant<double>& plant_wo_spr)
+    : TaskSpaceTrackingData(name, 4, 3, K_p, K_d, W, plant_w_spr,
+                            plant_wo_spr) {}
 
-void RotTaskSpaceTrackingData::AddFrameToTrack(
-    const std::string& body_name, const Isometry3d& frame_pose) {
-  DRAKE_DEMAND(plant_w_spr_->HasBodyNamed(body_name));
-  DRAKE_DEMAND(plant_wo_spr_->HasBodyNamed(body_name));
+void RotTaskSpaceTrackingData::AddFrameToTrack(const std::string& body_name,
+                                               const Isometry3d& frame_pose) {
+  DRAKE_DEMAND(plant_w_spr_.HasBodyNamed(body_name));
+  DRAKE_DEMAND(plant_wo_spr_.HasBodyNamed(body_name));
   body_frames_w_spr_.push_back(
-      &plant_w_spr_->GetBodyByName(body_name).body_frame());
+      &plant_w_spr_.GetBodyByName(body_name).body_frame());
   body_frames_wo_spr_.push_back(
-      &plant_wo_spr_->GetBodyByName(body_name).body_frame());
-  body_index_w_spr_.push_back(plant_w_spr_->GetBodyByName(body_name).index());
-  body_index_wo_spr_.push_back(plant_wo_spr_->GetBodyByName(body_name).index());
+      &plant_wo_spr_.GetBodyByName(body_name).body_frame());
+  body_index_w_spr_.push_back(plant_w_spr_.GetBodyByName(body_name).index());
+  body_index_wo_spr_.push_back(plant_wo_spr_.GetBodyByName(body_name).index());
   frame_pose_.push_back(frame_pose);
 }
 
@@ -284,10 +288,10 @@ void RotTaskSpaceTrackingData::AddStateAndFrameToTrack(
 }
 
 void RotTaskSpaceTrackingData::UpdateYAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
-  auto transform_mat = plant_w_spr_->EvalBodyPoseInWorld(
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
+  auto transform_mat = plant_w_spr_.EvalBodyPoseInWorld(
       context_w_spr,
-      plant_w_spr_->get_body(body_index_w_spr_.at(GetStateIdx())));
+      plant_w_spr_.get_body(body_index_w_spr_.at(GetStateIdx())));
   Quaterniond y_quat(transform_mat.rotation() *
                      frame_pose_.at(GetStateIdx()).linear());
   Eigen::Vector4d y_4d;
@@ -306,18 +310,19 @@ void RotTaskSpaceTrackingData::UpdateYAndError(
 }
 
 void RotTaskSpaceTrackingData::UpdateYdotAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
-  MatrixXd J_spatial(6, plant_w_spr_->num_velocities());
-  plant_w_spr_->CalcJacobianSpatialVelocity(
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
+  MatrixXd J_spatial(6, plant_w_spr_.num_velocities());
+  plant_w_spr_.CalcJacobianSpatialVelocity(
       context_w_spr, JacobianWrtVariable::kV,
       *body_frames_w_spr_.at(GetStateIdx()),
       frame_pose_.at(GetStateIdx()).translation(), world_w_spr_, world_w_spr_,
       &J_spatial);
   ydot_ = J_spatial.block(0, 0, 3, J_spatial.cols()) *
-        x_w_spr.tail(plant_w_spr_->num_velocities());
+          x_w_spr.tail(plant_w_spr_.num_velocities());
   // Transform qdot to w
   Quaterniond y_quat_des(y_des_(0), y_des_(1), y_des_(2), y_des_(3));
-  Quaterniond dy_quat_des(ydot_des_(0), ydot_des_(1), ydot_des_(2), ydot_des_(3));
+  Quaterniond dy_quat_des(ydot_des_(0), ydot_des_(1), ydot_des_(2),
+                          ydot_des_(3));
   Vector3d w_des_ = 2 * (dy_quat_des * y_quat_des.conjugate()).vec();
   error_ydot_ = w_des_ - ydot_;
 }
@@ -326,14 +331,15 @@ void RotTaskSpaceTrackingData::UpdateYddotDes() {
   // Convert ddq into angular acceleration
   // See https://physics.stackexchange.com/q/460311
   Quaterniond y_quat_des(y_des_(0), y_des_(1), y_des_(2), y_des_(3));
-  Quaterniond yddot_quat_des(yddot_des_(0), yddot_des_(1), yddot_des_(2), yddot_des_(3));
+  Quaterniond yddot_quat_des(yddot_des_(0), yddot_des_(1), yddot_des_(2),
+                             yddot_des_(3));
   yddot_des_converted_ = 2 * (yddot_quat_des * y_quat_des.conjugate()).vec();
 }
 
 void RotTaskSpaceTrackingData::UpdateJ(const VectorXd& x_wo_spr,
-                                          Context<double>& context_wo_spr) {
-  MatrixXd J_spatial(6, plant_wo_spr_->num_velocities());
-  plant_wo_spr_->CalcJacobianSpatialVelocity(
+                                       const Context<double>& context_wo_spr) {
+  MatrixXd J_spatial(6, plant_wo_spr_.num_velocities());
+  plant_wo_spr_.CalcJacobianSpatialVelocity(
       context_wo_spr, JacobianWrtVariable::kV,
       *body_frames_wo_spr_.at(GetStateIdx()),
       frame_pose_.at(GetStateIdx()).translation(), world_wo_spr_, world_wo_spr_,
@@ -341,10 +347,10 @@ void RotTaskSpaceTrackingData::UpdateJ(const VectorXd& x_wo_spr,
   J_ = J_spatial.block(0, 0, 3, J_spatial.cols());
 }
 
-void RotTaskSpaceTrackingData::UpdateJdotV(const VectorXd& x_wo_spr,
-                                              Context<double>& context_wo_spr) {
+void RotTaskSpaceTrackingData::UpdateJdotV(
+    const VectorXd& x_wo_spr, const Context<double>& context_wo_spr) {
   JdotV_ = plant_wo_spr_
-               ->CalcBiasSpatialAcceleration(
+               .CalcBiasSpatialAcceleration(
                    context_wo_spr, JacobianWrtVariable::kV,
                    *body_frames_wo_spr_.at(GetStateIdx()),
                    frame_pose_.at(GetStateIdx()).translation(), world_wo_spr_,
@@ -369,21 +375,20 @@ void RotTaskSpaceTrackingData::CheckDerivedOscTrackingData() {
 /**** JointSpaceTrackingData ****/
 JointSpaceTrackingData::JointSpaceTrackingData(
     const string& name, const MatrixXd& K_p, const MatrixXd& K_d,
-    const MatrixXd& W, const MultibodyPlant<double>* plant_w_spr,
-    const MultibodyPlant<double>* plant_wo_spr)
-    : OscTrackingData(name, 1, K_p, K_d, W, plant_w_spr, plant_wo_spr) {
-}
+    const MatrixXd& W, const MultibodyPlant<double>& plant_w_spr,
+    const MultibodyPlant<double>& plant_wo_spr)
+    : OscTrackingData(name, 1, 1, K_p, K_d, W, plant_w_spr, plant_wo_spr) {}
 
 void JointSpaceTrackingData::AddJointToTrack(
     const std::string& joint_pos_name, const std::string& joint_vel_name) {
   joint_pos_idx_w_spr_.push_back(
-      makeNameToPositionsMap(*plant_w_spr_).at(joint_pos_name));
+      makeNameToPositionsMap(plant_w_spr_).at(joint_pos_name));
   joint_vel_idx_w_spr_.push_back(
-      makeNameToVelocitiesMap(*plant_w_spr_).at(joint_vel_name));
+      makeNameToVelocitiesMap(plant_w_spr_).at(joint_vel_name));
   joint_pos_idx_wo_spr_.push_back(
-      makeNameToPositionsMap(*plant_wo_spr_).at(joint_pos_name));
+      makeNameToPositionsMap(plant_wo_spr_).at(joint_pos_name));
   joint_vel_idx_wo_spr_.push_back(
-      makeNameToVelocitiesMap(*plant_wo_spr_).at(joint_vel_name));
+      makeNameToVelocitiesMap(plant_wo_spr_).at(joint_vel_name));
 }
 
 void JointSpaceTrackingData::AddStateAndJointToTrack(
@@ -394,16 +399,16 @@ void JointSpaceTrackingData::AddStateAndJointToTrack(
 }
 
 void JointSpaceTrackingData::UpdateYAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
   y_ = x_w_spr.segment(joint_pos_idx_w_spr_.at(GetStateIdx()), 1);
   error_y_ = y_des_ - y_;
 }
 
 void JointSpaceTrackingData::UpdateYdotAndError(
-    const VectorXd& x_w_spr, Context<double>& context_w_spr) {
-  MatrixXd J = MatrixXd::Zero(1, plant_w_spr_->num_velocities());
+    const VectorXd& x_w_spr, const Context<double>& context_w_spr) {
+  MatrixXd J = MatrixXd::Zero(1, plant_w_spr_.num_velocities());
   J(0, joint_vel_idx_w_spr_.at(GetStateIdx())) = 1;
-  ydot_ = J * x_w_spr.tail(plant_w_spr_->num_velocities());
+  ydot_ = J * x_w_spr.tail(plant_w_spr_.num_velocities());
   error_ydot_ = ydot_des_ - ydot_;
 }
 
@@ -412,13 +417,13 @@ void JointSpaceTrackingData::UpdateYddotDes() {
 }
 
 void JointSpaceTrackingData::UpdateJ(const VectorXd& x_wo_spr,
-                                        Context<double>& context_wo_spr) {
-  J_ = MatrixXd::Zero(1, plant_wo_spr_->num_velocities());
+                                     const Context<double>& context_wo_spr) {
+  J_ = MatrixXd::Zero(1, plant_wo_spr_.num_velocities());
   J_(0, joint_vel_idx_wo_spr_.at(GetStateIdx())) = 1;
 }
 
-void JointSpaceTrackingData::UpdateJdotV(const VectorXd& x_wo_spr,
-                                            Context<double>& context_wo_spr) {
+void JointSpaceTrackingData::UpdateJdotV(
+    const VectorXd& x_wo_spr, const Context<double>& context_wo_spr) {
   JdotV_ = VectorXd::Zero(1);
 }
 

--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -24,9 +24,6 @@ namespace dairlib::systems::controllers {
 using multibody::makeNameToPositionsMap;
 using multibody::makeNameToVelocitiesMap;
 
-static const int kSpaceDim = 3;
-static const int kQuaternionDim = 4;
-
 /**** OscTrackingData ****/
 OscTrackingData::OscTrackingData(const string& name, int n_y, int n_ydot,
                                  const MatrixXd& K_p, const MatrixXd& K_d,

--- a/systems/controllers/osc/osc_tracking_data.h
+++ b/systems/controllers/osc/osc_tracking_data.h
@@ -62,6 +62,9 @@ namespace controllers {
 
 class OscTrackingData {
  public:
+  static constexpr int kSpaceDim = 3;
+  static constexpr int kQuaternionDim = 4;
+
   OscTrackingData(const std::string& name, int n_y, int n_ydot,
                   const Eigen::MatrixXd& K_p, const Eigen::MatrixXd& K_d,
                   const Eigen::MatrixXd& W,

--- a/systems/controllers/osc/osc_tracking_data.h
+++ b/systems/controllers/osc/osc_tracking_data.h
@@ -89,27 +89,31 @@ class OscTrackingData {
               int finite_state_machine_state);
 
   // Getters for debugging
-  Eigen::VectorXd GetY() { return y_; }
-  Eigen::VectorXd GetYDes() { return y_des_; }
-  Eigen::VectorXd GetErrorY() { return error_y_; }
-  Eigen::VectorXd GetYdot() { return ydot_; }
-  Eigen::VectorXd GetYdotDes() { return ydot_des_; }
-  Eigen::VectorXd GetErrorYdot() { return error_ydot_; }
-  Eigen::VectorXd GetYddotDes() { return yddot_des_; }
-  Eigen::VectorXd GetYddotDesConverted() { return yddot_des_converted_; }
-  Eigen::VectorXd GetYddotCommandSol() { return yddot_command_sol_; }
+  const Eigen::VectorXd& GetY() const { return y_; }
+  const Eigen::VectorXd& GetYDes() const { return y_des_; }
+  const Eigen::VectorXd& GetErrorY() const { return error_y_; }
+  const Eigen::VectorXd& GetYdot() const { return ydot_; }
+  const Eigen::VectorXd& GetYdotDes() const { return ydot_des_; }
+  const Eigen::VectorXd& GetErrorYdot() const { return error_ydot_; }
+  const Eigen::VectorXd& GetYddotDes() const { return yddot_des_; }
+  const Eigen::VectorXd& GetYddotDesConverted() const {
+    return yddot_des_converted_;
+  }
+  const Eigen::VectorXd& GetYddotCommandSol() const {
+    return yddot_command_sol_;
+  }
 
   // Getters used by osc block
-  const Eigen::MatrixXd& GetJ() { return J_; }
-  const Eigen::VectorXd& GetJdotTimesV() { return JdotV_; }
-  const Eigen::VectorXd& GetYddotCommand() { return yddot_command_; }
-  const Eigen::MatrixXd& GetWeight() { return W_; }
+  const Eigen::MatrixXd& GetJ() const { return J_; }
+  const Eigen::VectorXd& GetJdotTimesV() const { return JdotV_; }
+  const Eigen::VectorXd& GetYddotCommand() const { return yddot_command_; }
+  const Eigen::MatrixXd& GetWeight() const { return W_; }
 
   // Getters
-  const std::string& GetName() { return name_; };
-  int GetYDim() { return n_y_; };
-  int GetYdotDim() { return n_ydot_; };
-  bool IsActive() { return track_at_current_state_; }
+  const std::string& GetName() const { return name_; };
+  int GetYDim() const { return n_y_; };
+  int GetYdotDim() const { return n_ydot_; };
+  bool IsActive() const { return track_at_current_state_; }
 
   void SaveYddotCommandSol(const Eigen::VectorXd& dv);
 
@@ -121,7 +125,7 @@ class OscTrackingData {
   void CheckOscTrackingData();
 
  protected:
-  int GetStateIdx() { return state_idx_; };
+  int GetStateIdx() const { return state_idx_; };
   void AddState(int state);
 
   // Feedback output, Jacobian and dJ/dt * v

--- a/systems/controllers/osc/osc_tracking_data.h
+++ b/systems/controllers/osc/osc_tracking_data.h
@@ -3,8 +3,8 @@
 #include <string>
 #include <vector>
 #include <Eigen/Dense>
-#include <drake/multibody/plant/multibody_plant.h>
 #include <drake/common/trajectories/trajectory.h>
+#include <drake/multibody/plant/multibody_plant.h>
 
 #include "systems/framework/output_vector.h"
 
@@ -15,12 +15,10 @@ namespace controllers {
 /// OscTrackingData is a virtual class
 
 /// Input of the constructor:
-/// - dimension of the output/trajectory
+/// - dimension of the trajectory (need to specify both position and velocity
+///   dimension, because they are different in the case of quaternion)
 /// - gains of PD controller
 /// - cost weight
-/// - a flag indicating the trajectory is a constant
-/// - a flag indicating the trajectory has exponential term (that is, the traj
-///   is of ExponentialPlusPiecewisePolynomial class)
 
 /// In OSC, the position and the velocity of the robot are given. The goal is to
 /// find the optimal
@@ -30,7 +28,8 @@ namespace controllers {
 /// with which the controller can track the trajectory the best.
 /// In this class, we let
 ///   - y_ (ydot_) be the position (velocity) output of the robot
-///   - y_des_ (ydot_des_) be the desired value of the position (velocity) output
+///   - y_des_ (ydot_des_) be the desired value of the position (velocity)
+///   output
 ///   - error_y_ (error_ydot_) be the error between the desired and the real
 ///     value of the position (velocity) output
 /// Additionally, we let yddot_des_ be the desired acceleration for the output
@@ -41,7 +40,7 @@ namespace controllers {
 /// the rotational acceleration.
 
 /// In OSC, the cost function used for tracking a trajectory is
-///   (J_*dv + JdotV - yddot_command)^T * W_ * (J_*dv + JdotV - yddot_command) / 2,
+///   (J_*dv+JdotV - yddot_command)^T * W_ * (J_*dv+JdotV - yddot_command) / 2,
 ///   where
 ///   dv is the decision variable of QP, and
 ///   yddot_command = K_p_ * error_y_ + K_d_ * error_ydot_ + yddot_des_ with
@@ -63,11 +62,11 @@ namespace controllers {
 
 class OscTrackingData {
  public:
-  OscTrackingData(
-      const std::string& name, int n_r, const Eigen::MatrixXd& K_p,
-      const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+  OscTrackingData(const std::string& name, int n_y, int n_ydot,
+                  const Eigen::MatrixXd& K_p, const Eigen::MatrixXd& K_d,
+                  const Eigen::MatrixXd& W,
+                  const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+                  const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
   // Update() updates the caches. It does the following things in order:
   //  - update track_at_current_state_
@@ -83,9 +82,9 @@ class OscTrackingData {
   //  - `t`, current time
   //  - `finite_state_machine_state`, current finite state machine state
   bool Update(const Eigen::VectorXd& x_w_spr,
-              drake::systems::Context<double>& context_w_spr,
+              const drake::systems::Context<double>& context_w_spr,
               const Eigen::VectorXd& x_wo_spr,
-              drake::systems::Context<double>& context_wo_spr,
+              const drake::systems::Context<double>& context_wo_spr,
               const drake::trajectories::Trajectory<double>& traj, double t,
               int finite_state_machine_state);
 
@@ -101,15 +100,15 @@ class OscTrackingData {
   Eigen::VectorXd GetYddotCommandSol() { return yddot_command_sol_; }
 
   // Getters used by osc block
-  Eigen::VectorXd GetOutput() { return y_; }
-  Eigen::MatrixXd GetJ() { return J_; }
-  Eigen::VectorXd GetJdotTimesV() { return JdotV_; }
-  Eigen::VectorXd GetYddotCommand() { return yddot_command_; }
-  Eigen::MatrixXd GetWeight() { return W_; }
+  const Eigen::MatrixXd& GetJ() { return J_; }
+  const Eigen::VectorXd& GetJdotTimesV() { return JdotV_; }
+  const Eigen::VectorXd& GetYddotCommand() { return yddot_command_; }
+  const Eigen::MatrixXd& GetWeight() { return W_; }
 
   // Getters
-  std::string GetName() { return name_; };
-  int GetTrajDim() { return n_r_; };
+  const std::string& GetName() { return name_; };
+  int GetYDim() { return n_y_; };
+  int GetYdotDim() { return n_ydot_; };
   bool IsActive() { return track_at_current_state_; }
 
   void SaveYddotCommandSol(const Eigen::VectorXd& dv);
@@ -152,8 +151,8 @@ class OscTrackingData {
   /// but in the optimization it uses `plant_wo_spr_`. The reason of using
   /// MultibodyPlant without springs is that the OSC cannot track desired
   /// acceleration instantaneously when springs exist. (relative degrees of 4)
-  const drake::multibody::MultibodyPlant<double>* plant_w_spr_;
-  const drake::multibody::MultibodyPlant<double>* plant_wo_spr_;
+  const drake::multibody::MultibodyPlant<double>& plant_w_spr_;
+  const drake::multibody::MultibodyPlant<double>& plant_wo_spr_;
 
   // World frames
   const drake::multibody::BodyFrame<double>& world_w_spr_;
@@ -166,15 +165,17 @@ class OscTrackingData {
   // Updaters of feedback output, jacobian and dJ/dt * v
   virtual void UpdateYAndError(
       const Eigen::VectorXd& x_w_spr,
-      drake::systems::Context<double>& context_w_spr) = 0;
+      const drake::systems::Context<double>& context_w_spr) = 0;
   virtual void UpdateYdotAndError(
       const Eigen::VectorXd& x_w_spr,
-      drake::systems::Context<double>& context_w_spr) = 0;
+      const drake::systems::Context<double>& context_w_spr) = 0;
   virtual void UpdateYddotDes() = 0;
-  virtual void UpdateJ(const Eigen::VectorXd& x_wo_spr,
-                       drake::systems::Context<double>& context_wo_spr) = 0;
-  virtual void UpdateJdotV(const Eigen::VectorXd& x_wo_spr,
-                           drake::systems::Context<double>& context_wo_spr) = 0;
+  virtual void UpdateJ(
+      const Eigen::VectorXd& x_wo_spr,
+      const drake::systems::Context<double>& context_wo_spr) = 0;
+  virtual void UpdateJdotV(
+      const Eigen::VectorXd& x_wo_spr,
+      const drake::systems::Context<double>& context_wo_spr) = 0;
 
   // Finalize and ensure that users construct OscTrackingData derived class
   // correctly.
@@ -184,7 +185,8 @@ class OscTrackingData {
   std::string name_;
 
   // Dimension of the traj
-  int n_r_;
+  int n_y_;
+  int n_ydot_;
 
   // PD control gains
   Eigen::MatrixXd K_p_;
@@ -201,11 +203,10 @@ class OscTrackingData {
 /// ComTrackingData is used when we want to track center of mass trajectory.
 class ComTrackingData final : public OscTrackingData {
  public:
-  ComTrackingData(
-      const std::string& name, int n_r, const Eigen::MatrixXd& K_p,
-      const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+  ComTrackingData(const std::string& name, const Eigen::MatrixXd& K_p,
+                  const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
+                  const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+                  const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
   //  ComTrackingData() {}  // Default constructor
 
@@ -213,15 +214,17 @@ class ComTrackingData final : public OscTrackingData {
   void AddStateToTrack(int state);
 
  private:
-  void UpdateYAndError(const Eigen::VectorXd& x_w_spr,
-                       drake::systems::Context<double>& context_w_spr) final;
-  void UpdateYdotAndError(const Eigen::VectorXd& x_w_spr,
-                          drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYdotAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
   void UpdateYddotDes() final;
   void UpdateJ(const Eigen::VectorXd& x_wo_spr,
-               drake::systems::Context<double>& context_wo_spr) final;
+               const drake::systems::Context<double>& context_wo_spr) final;
   void UpdateJdotV(const Eigen::VectorXd& x_wo_spr,
-                   drake::systems::Context<double>& context_wo_spr) final;
+                   const drake::systems::Context<double>& context_wo_spr) final;
 
   void CheckDerivedOscTrackingData() final;
 };
@@ -230,10 +233,10 @@ class ComTrackingData final : public OscTrackingData {
 class TaskSpaceTrackingData : public OscTrackingData {
  public:
   TaskSpaceTrackingData(
-      const std::string& name, int n_r, const Eigen::MatrixXd& K_p,
+      const std::string& name, int n_y, int n_ydot, const Eigen::MatrixXd& K_p,
       const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+      const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+      const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
  protected:
   // `body_index_w_spr` is the index of the body
@@ -261,10 +264,10 @@ class TaskSpaceTrackingData : public OscTrackingData {
 class TransTaskSpaceTrackingData final : public TaskSpaceTrackingData {
  public:
   TransTaskSpaceTrackingData(
-      const std::string& name, int n_r, const Eigen::MatrixXd& K_p,
+      const std::string& name, const Eigen::MatrixXd& K_p,
       const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+      const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+      const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
   void AddPointToTrack(
       const std::string& body_name,
@@ -274,15 +277,17 @@ class TransTaskSpaceTrackingData final : public TaskSpaceTrackingData {
       const Eigen::Vector3d& pt_on_body = Eigen::Vector3d::Zero());
 
  private:
-  void UpdateYAndError(const Eigen::VectorXd& x_w_spr,
-                       drake::systems::Context<double>& context_w_spr) final;
-  void UpdateYdotAndError(const Eigen::VectorXd& x_w_spr,
-                          drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYdotAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
   void UpdateYddotDes() final;
   void UpdateJ(const Eigen::VectorXd& x_wo_spr,
-               drake::systems::Context<double>& context_wo_spr) final;
+               const drake::systems::Context<double>& context_wo_spr) final;
   void UpdateJdotV(const Eigen::VectorXd& x_wo_spr,
-                   drake::systems::Context<double>& context_wo_spr) final;
+                   const drake::systems::Context<double>& context_wo_spr) final;
 
   void CheckDerivedOscTrackingData() final;
 
@@ -307,10 +312,10 @@ class TransTaskSpaceTrackingData final : public TaskSpaceTrackingData {
 class RotTaskSpaceTrackingData final : public TaskSpaceTrackingData {
  public:
   RotTaskSpaceTrackingData(
-      const std::string& name, int n_r, const Eigen::MatrixXd& K_p,
+      const std::string& name, const Eigen::MatrixXd& K_p,
       const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+      const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+      const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
   void AddFrameToTrack(
       const std::string& body_name,
@@ -320,15 +325,17 @@ class RotTaskSpaceTrackingData final : public TaskSpaceTrackingData {
       const Eigen::Isometry3d& frame_pose = Eigen::Isometry3d::Identity());
 
  private:
-  void UpdateYAndError(const Eigen::VectorXd& x_w_spr,
-                       drake::systems::Context<double>& context_w_spr) final;
-  void UpdateYdotAndError(const Eigen::VectorXd& x_w_spr,
-                          drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYdotAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
   void UpdateYddotDes() final;
   void UpdateJ(const Eigen::VectorXd& x_wo_spr,
-               drake::systems::Context<double>& context_wo_spr) final;
+               const drake::systems::Context<double>& context_wo_spr) final;
   void UpdateJdotV(const Eigen::VectorXd& x_wo_spr,
-                   drake::systems::Context<double>& context_wo_spr) final;
+                   const drake::systems::Context<double>& context_wo_spr) final;
 
   void CheckDerivedOscTrackingData() final;
 
@@ -355,8 +362,8 @@ class JointSpaceTrackingData final : public OscTrackingData {
   JointSpaceTrackingData(
       const std::string& name, const Eigen::MatrixXd& K_p,
       const Eigen::MatrixXd& K_d, const Eigen::MatrixXd& W,
-      const drake::multibody::MultibodyPlant<double>* plant_w_spr,
-      const drake::multibody::MultibodyPlant<double>* plant_wo_spr);
+      const drake::multibody::MultibodyPlant<double>& plant_w_spr,
+      const drake::multibody::MultibodyPlant<double>& plant_wo_spr);
 
   void AddJointToTrack(const std::string& joint_pos_name,
                        const std::string& joint_vel_name);
@@ -364,15 +371,17 @@ class JointSpaceTrackingData final : public OscTrackingData {
                                const std::string& joint_vel_name);
 
  private:
-  void UpdateYAndError(const Eigen::VectorXd& x_w_spr,
-                       drake::systems::Context<double>& context_w_spr) final;
-  void UpdateYdotAndError(const Eigen::VectorXd& x_w_spr,
-                          drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
+  void UpdateYdotAndError(
+      const Eigen::VectorXd& x_w_spr,
+      const drake::systems::Context<double>& context_w_spr) final;
   void UpdateYddotDes() final;
   void UpdateJ(const Eigen::VectorXd& x_wo_spr,
-               drake::systems::Context<double>& context_wo_spr) final;
+               const drake::systems::Context<double>& context_wo_spr) final;
   void UpdateJdotV(const Eigen::VectorXd& x_wo_spr,
-                   drake::systems::Context<double>& context_wo_spr) final;
+                   const drake::systems::Context<double>& context_wo_spr) final;
 
   void CheckDerivedOscTrackingData() final;
 


### PR DESCRIPTION
Add both OSC costs and `n_ydot` to `lcmt_osc_tracking_data`. The latter was added to account for quaternion tracking where the desired position doesn't have the same dimension as desired velocity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/183)
<!-- Reviewable:end -->
