### PR TITLE
Sharing common plant context between leaf systems

### DIFF
--- a/examples/Cassie/osc/deviation_from_cp.cc
+++ b/examples/Cassie/osc/deviation_from_cp.cc
@@ -30,8 +30,10 @@ namespace cassie {
 namespace osc {
 
 DeviationFromCapturePoint::DeviationFromCapturePoint(
-    const drake::multibody::MultibodyPlant<double>& plant)
+    const drake::multibody::MultibodyPlant<double>& plant,
+    drake::systems::Context<double>& context)
     : plant_(plant),
+    context_(context),
       world_(plant_.world_frame()),
       pelvis_(plant_.GetBodyByName("pelvis")) {
   // Input/Output Setup
@@ -44,8 +46,6 @@ DeviationFromCapturePoint::DeviationFromCapturePoint(
   this->DeclareVectorOutputPort(BasicVector<double>(2),
                                 &DeviationFromCapturePoint::CalcFootPlacement);
 
-  // Create context
-  context_ = plant_.CreateDefaultContext();
 }
 
 void DeviationFromCapturePoint::CalcFootPlacement(
@@ -61,12 +61,12 @@ void DeviationFromCapturePoint::CalcFootPlacement(
   VectorXd q = robot_output->GetPositions();
   VectorXd v = robot_output->GetVelocities();
 
-  plant_.SetPositions(context_.get(), q);
+  plant_.SetPositions(&context_, q);
 
   // Get center of mass position and velocity
   MatrixXd J(3, plant_.num_velocities());
   plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-      *context_, JacobianWrtVariable::kV, world_, world_, &J);
+      context_, JacobianWrtVariable::kV, world_, world_, &J);
   Vector3d com_vel = J * v;
 
   // Extract quaternion from floating base position

--- a/examples/Cassie/osc/deviation_from_cp.cc
+++ b/examples/Cassie/osc/deviation_from_cp.cc
@@ -31,7 +31,7 @@ namespace osc {
 
 DeviationFromCapturePoint::DeviationFromCapturePoint(
     const drake::multibody::MultibodyPlant<double>& plant,
-    drake::systems::Context<double>& context)
+    Context<double>* context)
     : plant_(plant),
     context_(context),
       world_(plant_.world_frame()),
@@ -61,12 +61,12 @@ void DeviationFromCapturePoint::CalcFootPlacement(
   VectorXd q = robot_output->GetPositions();
   VectorXd v = robot_output->GetVelocities();
 
-  plant_.SetPositions(&context_, q);
+  plant_.SetPositions(context_, q);
 
   // Get center of mass position and velocity
   MatrixXd J(3, plant_.num_velocities());
   plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-      context_, JacobianWrtVariable::kV, world_, world_, &J);
+      *context_, JacobianWrtVariable::kV, world_, world_, &J);
   Vector3d com_vel = J * v;
 
   // Extract quaternion from floating base position

--- a/examples/Cassie/osc/deviation_from_cp.h
+++ b/examples/Cassie/osc/deviation_from_cp.h
@@ -48,7 +48,8 @@ namespace osc {
 class DeviationFromCapturePoint : public drake::systems::LeafSystem<double> {
  public:
   DeviationFromCapturePoint(
-      const drake::multibody::MultibodyPlant<double>& plant);
+      const drake::multibody::MultibodyPlant<double>& plant,
+      drake::systems::Context<double>& context);
 
   const drake::systems::InputPort<double>& get_input_port_state() const {
     return this->get_input_port(state_port_);
@@ -62,12 +63,12 @@ class DeviationFromCapturePoint : public drake::systems::LeafSystem<double> {
                          drake::systems::BasicVector<double>* output) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
   Eigen::Vector2d global_target_position_;
-  Eigen::Vector2d params_of_no_turning_;
 
-  std::unique_ptr<drake::systems::Context<double>> context_;
+  Eigen::Vector2d params_of_no_turning_;
 
   int state_port_;
   int xy_port_;

--- a/examples/Cassie/osc/deviation_from_cp.h
+++ b/examples/Cassie/osc/deviation_from_cp.h
@@ -49,7 +49,7 @@ class DeviationFromCapturePoint : public drake::systems::LeafSystem<double> {
  public:
   DeviationFromCapturePoint(
       const drake::multibody::MultibodyPlant<double>& plant,
-      drake::systems::Context<double>& context);
+      drake::systems::Context<double>* context);
 
   const drake::systems::InputPort<double>& get_input_port_state() const {
     return this->get_input_port(state_port_);
@@ -63,7 +63,7 @@ class DeviationFromCapturePoint : public drake::systems::LeafSystem<double> {
                          drake::systems::BasicVector<double>* output) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
-  drake::systems::Context<double>& context_;
+  drake::systems::Context<double>* context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
   Eigen::Vector2d global_target_position_;

--- a/examples/Cassie/osc/heading_traj_generator.cc
+++ b/examples/Cassie/osc/heading_traj_generator.cc
@@ -1,6 +1,7 @@
 #include "examples/Cassie/osc/heading_traj_generator.h"
 
 #include <math.h>
+
 #include <string>
 
 #include "multibody/multibody_utils.h"
@@ -27,8 +28,10 @@ namespace cassie {
 namespace osc {
 
 HeadingTrajGenerator::HeadingTrajGenerator(
-    const drake::multibody::MultibodyPlant<double>& plant)
+    const drake::multibody::MultibodyPlant<double>& plant,
+    drake::systems::Context<double>& context)
     : plant_(plant),
+      context_(context),
       world_(plant_.world_frame()),
       pelvis_(plant_.GetBodyByName("pelvis")) {
   // Input/Output Setup
@@ -44,9 +47,6 @@ HeadingTrajGenerator::HeadingTrajGenerator(
   drake::trajectories::Trajectory<double>& traj_inst = pp;
   this->DeclareAbstractOutputPort("heading_traj", traj_inst,
                                   &HeadingTrajGenerator::CalcHeadingTraj);
-
-  // Create context
-  context_ = plant_.CreateDefaultContext();
 }
 
 void HeadingTrajGenerator::CalcHeadingTraj(
@@ -62,11 +62,11 @@ void HeadingTrajGenerator::CalcHeadingTraj(
       (OutputVector<double>*)this->EvalVectorInput(context, state_port_);
   VectorXd q = robotOutput->GetPositions();
 
-  plant_.SetPositions(context_.get(), q);
+  plant_.SetPositions(&context_, q);
 
   // Get approximated heading angle of pelvis
   Vector3d pelvis_heading_vec =
-      plant_.EvalBodyPoseInWorld(*context_, pelvis_).rotation().col(0);
+      plant_.EvalBodyPoseInWorld(context_, pelvis_).rotation().col(0);
   double approx_pelvis_yaw_i =
       atan2(pelvis_heading_vec(1), pelvis_heading_vec(0));
 
@@ -91,7 +91,7 @@ void HeadingTrajGenerator::CalcHeadingTraj(
   const auto pp = PiecewisePolynomial<double>::FirstOrderHold(breaks, knots);
 
   // Assign traj
-  PiecewisePolynomial<double>* pp_traj =
+  auto* pp_traj =
       (PiecewisePolynomial<double>*)dynamic_cast<PiecewisePolynomial<double>*>(
           traj);
   *pp_traj = pp;

--- a/examples/Cassie/osc/heading_traj_generator.cc
+++ b/examples/Cassie/osc/heading_traj_generator.cc
@@ -29,7 +29,7 @@ namespace osc {
 
 HeadingTrajGenerator::HeadingTrajGenerator(
     const drake::multibody::MultibodyPlant<double>& plant,
-    drake::systems::Context<double>& context)
+    drake::systems::Context<double>* context)
     : plant_(plant),
       context_(context),
       world_(plant_.world_frame()),
@@ -62,11 +62,11 @@ void HeadingTrajGenerator::CalcHeadingTraj(
       (OutputVector<double>*)this->EvalVectorInput(context, state_port_);
   VectorXd q = robotOutput->GetPositions();
 
-  plant_.SetPositions(&context_, q);
+  plant_.SetPositions(context_, q);
 
   // Get approximated heading angle of pelvis
   Vector3d pelvis_heading_vec =
-      plant_.EvalBodyPoseInWorld(context_, pelvis_).rotation().col(0);
+      plant_.EvalBodyPoseInWorld(*context_, pelvis_).rotation().col(0);
   double approx_pelvis_yaw_i =
       atan2(pelvis_heading_vec(1), pelvis_heading_vec(0));
 

--- a/examples/Cassie/osc/heading_traj_generator.h
+++ b/examples/Cassie/osc/heading_traj_generator.h
@@ -24,7 +24,8 @@ namespace osc {
 /// Requirement: quaternion floating-based Cassie only
 class HeadingTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
-  HeadingTrajGenerator(const drake::multibody::MultibodyPlant<double>& plant);
+  HeadingTrajGenerator(const drake::multibody::MultibodyPlant<double>& plant,
+      drake::systems::Context<double>& context);
 
   // Input/output ports
   const drake::systems::InputPort<double>& get_state_input_port() const {
@@ -39,9 +40,9 @@ class HeadingTrajGenerator : public drake::systems::LeafSystem<double> {
                        drake::trajectories::Trajectory<double>* traj) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
-  std::unique_ptr<drake::systems::Context<double>> context_;
 
   int state_port_;
   int des_yaw_port_;

--- a/examples/Cassie/osc/heading_traj_generator.h
+++ b/examples/Cassie/osc/heading_traj_generator.h
@@ -25,7 +25,7 @@ namespace osc {
 class HeadingTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
   HeadingTrajGenerator(const drake::multibody::MultibodyPlant<double>& plant,
-      drake::systems::Context<double>& context);
+      drake::systems::Context<double>* context);
 
   // Input/output ports
   const drake::systems::InputPort<double>& get_state_input_port() const {
@@ -40,7 +40,7 @@ class HeadingTrajGenerator : public drake::systems::LeafSystem<double> {
                        drake::trajectories::Trajectory<double>* traj) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
-  drake::systems::Context<double>& context_;
+  drake::systems::Context<double>* context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
 

--- a/examples/Cassie/osc/high_level_command.cc
+++ b/examples/Cassie/osc/high_level_command.cc
@@ -1,9 +1,11 @@
 #include "examples/Cassie/osc/high_level_command.h"
 
 #include <math.h>
+
 #include <string>
 
 #include "multibody/multibody_utils.h"
+
 #include "drake/math/quaternion.h"
 
 using std::cout;
@@ -36,11 +38,11 @@ namespace osc {
 
 HighLevelCommand::HighLevelCommand(
     const drake::multibody::MultibodyPlant<double>& plant,
-    drake::systems::Context<double>& context,
+    drake::systems::Context<double>* context,
     const Vector2d& global_target_position,
     const Vector2d& params_of_no_turning)
     : plant_(plant),
-    context_(context),
+      context_(context),
       world_(plant_.world_frame()),
       pelvis_(plant_.GetBodyByName("pelvis")),
       global_target_position_(global_target_position),
@@ -70,7 +72,6 @@ HighLevelCommand::HighLevelCommand(
 
   // Discrete state which stores the desired horizontal velocity
   des_horizontal_vel_idx_ = DeclareDiscreteState(VectorXd::Zero(2));
-
 }
 
 EventStatus HighLevelCommand::DiscreteVariableUpdate(
@@ -89,19 +90,19 @@ EventStatus HighLevelCommand::DiscreteVariableUpdate(
     VectorXd q = robotOutput->GetPositions();
     VectorXd v = robotOutput->GetVelocities();
 
-    plant_.SetPositions(&context_, q);
+    plant_.SetPositions(context_, q);
 
     // Get center of mass position and velocity
-    Vector3d com_pos = plant_.CalcCenterOfMassPosition(context_);
+    Vector3d com_pos = plant_.CalcCenterOfMassPosition(*context_);
     MatrixXd J(3, plant_.num_velocities());
     plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-        context_, JacobianWrtVariable::kV, world_, world_, &J);
+        *context_, JacobianWrtVariable::kV, world_, world_, &J);
     Vector3d com_vel = J * v;
 
     //////////// Get desired yaw velocity ////////////
     // Get approximated heading angle of pelvis
     Vector3d pelvis_heading_vec =
-        plant_.EvalBodyPoseInWorld(context_, pelvis_).rotation().col(0);
+        plant_.EvalBodyPoseInWorld(*context_, pelvis_).rotation().col(0);
     double approx_pelvis_yaw =
         atan2(pelvis_heading_vec(1), pelvis_heading_vec(0));
 

--- a/examples/Cassie/osc/high_level_command.h
+++ b/examples/Cassie/osc/high_level_command.h
@@ -40,7 +40,7 @@ namespace osc {
 class HighLevelCommand : public drake::systems::LeafSystem<double> {
  public:
   HighLevelCommand(const drake::multibody::MultibodyPlant<double>& plant,
-                   drake::systems::Context<double>& context,
+                   drake::systems::Context<double>* context,
                    const Eigen::Vector2d& global_target_position,
                    const Eigen::Vector2d& params_of_no_turning);
 
@@ -68,7 +68,7 @@ class HighLevelCommand : public drake::systems::LeafSystem<double> {
       drake::systems::BasicVector<double>* output) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
-  drake::systems::Context<double>& context_;
+  drake::systems::Context<double>* context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
   Eigen::Vector2d global_target_position_;

--- a/examples/Cassie/osc/high_level_command.h
+++ b/examples/Cassie/osc/high_level_command.h
@@ -40,6 +40,7 @@ namespace osc {
 class HighLevelCommand : public drake::systems::LeafSystem<double> {
  public:
   HighLevelCommand(const drake::multibody::MultibodyPlant<double>& plant,
+                   drake::systems::Context<double>& context,
                    const Eigen::Vector2d& global_target_position,
                    const Eigen::Vector2d& params_of_no_turning);
 
@@ -67,12 +68,13 @@ class HighLevelCommand : public drake::systems::LeafSystem<double> {
       drake::systems::BasicVector<double>* output) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
   Eigen::Vector2d global_target_position_;
   Eigen::Vector2d params_of_no_turning_;
 
-  std::unique_ptr<drake::systems::Context<double>> context_;
+//  std::unique_ptr<drake::systems::Context<double>> context_;
 
   // Port index
   int state_port_;

--- a/examples/Cassie/osc/standing_com_traj.h
+++ b/examples/Cassie/osc/standing_com_traj.h
@@ -14,6 +14,7 @@ class StandingComTraj : public drake::systems::LeafSystem<double> {
  public:
   StandingComTraj(
       const drake::multibody::MultibodyPlant<double>& plant,
+      drake::systems::Context<double>& context,
       const std::vector<std::pair<const Eigen::Vector3d,
                                   const drake::multibody::Frame<double>&>>&
           feet_contact_points,
@@ -28,8 +29,8 @@ class StandingComTraj : public drake::systems::LeafSystem<double> {
                        drake::trajectories::Trajectory<double>* traj) const;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
   const drake::multibody::BodyFrame<double>& world_;
-  std::unique_ptr<drake::systems::Context<double>> context_;
 
   int state_port_;
 

--- a/examples/Cassie/run_osc_standing_controller.cc
+++ b/examples/Cassie/run_osc_standing_controller.cc
@@ -69,6 +69,8 @@ int DoMain(int argc, char* argv[]) {
                      false);
   plant_wo_springs.Finalize();
 
+  auto context_w_spr = plant_w_springs.CreateDefaultContext();
+
   // Get contact frames and position (doesn't matter whether we use
   // plant_w_springs or plant_wo_springs because the contact frames exit in both
   // plants)
@@ -105,7 +107,7 @@ int DoMain(int argc, char* argv[]) {
   std::vector<std::pair<const Vector3d, const drake::multibody::Frame<double>&>>
       feet_contact_points = {left_toe, left_heel, right_toe, right_heel};
   auto com_traj_generator = builder.AddSystem<cassie::osc::StandingComTraj>(
-      plant_w_springs, feet_contact_points, FLAGS_height);
+      plant_w_springs, *context_w_spr, feet_contact_points, FLAGS_height);
   builder.Connect(state_receiver->get_output_port(0),
                   com_traj_generator->get_input_port_state());
 

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -68,17 +68,19 @@ int DoMain(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   // Build Cassie MBP
-  drake::multibody::MultibodyPlant<double> plant_w_springs(0.0);
-  addCassieMultibody(&plant_w_springs, nullptr, true /*floating base*/,
+  drake::multibody::MultibodyPlant<double> plant_w_spr(0.0);
+  addCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
                      "examples/Cassie/urdf/cassie_v2.urdf",
                      true /*spring model*/, false /*loop closure*/);
-  plant_w_springs.Finalize();
+  plant_w_spr.Finalize();
   // Build fix-spring Cassie MBP
-  drake::multibody::MultibodyPlant<double> plant_wo_springs(0.0);
-  addCassieMultibody(&plant_wo_springs, nullptr, true,
+  drake::multibody::MultibodyPlant<double> plant_wo_spr(0.0);
+  addCassieMultibody(&plant_wo_spr, nullptr, true,
                      "examples/Cassie/urdf/cassie_fixed_springs.urdf", false,
                      false);
-  plant_wo_springs.Finalize();
+  plant_wo_spr.Finalize();
+
+  auto context_w_spr = plant_w_spr.CreateDefaultContext();
 
   // Build the controller diagram
   DiagramBuilder<double> builder;
@@ -86,43 +88,43 @@ int DoMain(int argc, char* argv[]) {
   drake::lcm::DrakeLcm lcm_local("udpm://239.255.76.67:7667?ttl=0");
 
   // Get contact frames and position (doesn't matter whether we use
-  // plant_w_springs or plant_wo_springs because the contact frames exit in both
+  // plant_w_spr or plant_wo_spr because the contact frames exit in both
   // plants)
-  auto left_toe = LeftToeFront(plant_wo_springs);
-  auto left_heel = LeftToeRear(plant_wo_springs);
-  auto right_toe = RightToeFront(plant_wo_springs);
-  auto right_heel = RightToeRear(plant_wo_springs);
+  auto left_toe = LeftToeFront(plant_w_spr);
+  auto left_heel = LeftToeRear(plant_w_spr);
+  auto right_toe = RightToeFront(plant_w_spr);
+  auto right_heel = RightToeRear(plant_w_spr);
 
   // Get body frames and points
   Vector3d mid_contact_point = (left_toe.first + left_heel.first) / 2;
   auto left_toe_mid = std::pair<const Vector3d, const Frame<double>&>(
-      mid_contact_point, plant_w_springs.GetFrameByName("toe_left"));
+      mid_contact_point, plant_w_spr.GetFrameByName("toe_left"));
   auto right_toe_mid = std::pair<const Vector3d, const Frame<double>&>(
-      mid_contact_point, plant_w_springs.GetFrameByName("toe_right"));
+      mid_contact_point, plant_w_spr.GetFrameByName("toe_right"));
   auto left_toe_origin = std::pair<const Vector3d, const Frame<double>&>(
-      Vector3d::Zero(), plant_w_springs.GetFrameByName("toe_left"));
+      Vector3d::Zero(), plant_w_spr.GetFrameByName("toe_left"));
   auto right_toe_origin = std::pair<const Vector3d, const Frame<double>&>(
-      Vector3d::Zero(), plant_w_springs.GetFrameByName("toe_right"));
+      Vector3d::Zero(), plant_w_spr.GetFrameByName("toe_right"));
 
   // Create state receiver.
   auto state_receiver =
-      builder.AddSystem<systems::RobotOutputReceiver>(plant_w_springs);
+      builder.AddSystem<systems::RobotOutputReceiver>(plant_w_spr);
 
   // Create command sender.
   auto command_pub =
       builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_robot_input>(
           FLAGS_channel_u, &lcm_local, TriggerTypeSet({TriggerType::kForced})));
   auto command_sender =
-      builder.AddSystem<systems::RobotCommandSender>(plant_w_springs);
+      builder.AddSystem<systems::RobotCommandSender>(plant_w_spr);
 
   builder.Connect(command_sender->get_output_port(0),
                   command_pub->get_input_port());
 
   // Add emulator for floating base drift
   Eigen::VectorXd drift_mean =
-      Eigen::VectorXd::Zero(plant_w_springs.num_positions());
+      Eigen::VectorXd::Zero(plant_w_spr.num_positions());
   Eigen::MatrixXd drift_cov = Eigen::MatrixXd::Zero(
-      plant_w_springs.num_positions(), plant_w_springs.num_positions());
+      plant_w_spr.num_positions(), plant_w_spr.num_positions());
   drift_cov(4, 4) = FLAGS_drift_rate;  // x
   drift_cov(5, 5) = FLAGS_drift_rate;  // y
   drift_cov(6, 6) = FLAGS_drift_rate;  // z
@@ -130,7 +132,7 @@ int DoMain(int argc, char* argv[]) {
   // changing SimulatorDrift.
 
   auto simulator_drift =
-      builder.AddSystem<SimulatorDrift>(plant_w_springs, drift_mean, drift_cov);
+      builder.AddSystem<SimulatorDrift>(plant_w_spr, drift_mean, drift_cov);
   builder.Connect(state_receiver->get_output_port(0),
                   simulator_drift->get_input_port_state());
 
@@ -142,13 +144,14 @@ int DoMain(int argc, char* argv[]) {
   //                     0.5    when x = 1
   //                     0.9993 when x = 2
   auto high_level_command = builder.AddSystem<cassie::osc::HighLevelCommand>(
-      plant_w_springs, global_target_position, params_of_no_turning);
+      plant_w_spr, *context_w_spr, global_target_position,
+      params_of_no_turning);
   builder.Connect(state_receiver->get_output_port(0),
                   high_level_command->get_state_input_port());
 
   // Create heading traj generator
-  auto head_traj_gen =
-      builder.AddSystem<cassie::osc::HeadingTrajGenerator>(plant_w_springs);
+  auto head_traj_gen = builder.AddSystem<cassie::osc::HeadingTrajGenerator>(
+      plant_w_spr, *context_w_spr);
   builder.Connect(simulator_drift->get_output_port(0),
                   head_traj_gen->get_state_input_port());
   builder.Connect(high_level_command->get_yaw_output_port(),
@@ -173,7 +176,7 @@ int DoMain(int argc, char* argv[]) {
                        right_support_duration, double_support_duration};
   }
   auto fsm = builder.AddSystem<systems::TimeBasedFiniteStateMachine>(
-      plant_w_springs, fsm_states, state_durations);
+      plant_w_spr, fsm_states, state_durations);
   builder.Connect(simulator_drift->get_output_port(0),
                   fsm->get_input_port_state());
 
@@ -198,7 +201,7 @@ int DoMain(int argc, char* argv[]) {
     contact_points_in_each_state.push_back({left_toe_mid, right_toe_mid});
   }
   auto lipm_traj_generator = builder.AddSystem<systems::LIPMTrajGenerator>(
-      plant_w_springs, desired_com_height, unordered_fsm_states,
+      plant_w_spr, *context_w_spr, desired_com_height, unordered_fsm_states,
       unordered_state_durations, contact_points_in_each_state);
   builder.Connect(fsm->get_output_port(0),
                   lipm_traj_generator->get_input_port_fsm());
@@ -207,8 +210,8 @@ int DoMain(int argc, char* argv[]) {
 
   // Create velocity control by foot placement
   auto deviation_from_cp =
-      builder.AddSystem<cassie::osc::DeviationFromCapturePoint>(
-          plant_w_springs);
+      builder.AddSystem<cassie::osc::DeviationFromCapturePoint>(plant_w_spr,
+                                                                *context_w_spr);
   builder.Connect(high_level_command->get_xy_output_port(),
                   deviation_from_cp->get_input_port_des_hor_vel());
   builder.Connect(simulator_drift->get_output_port(0),
@@ -234,10 +237,11 @@ int DoMain(int argc, char* argv[]) {
   vector<std::pair<const Vector3d, const Frame<double>&>> left_right_foot = {
       left_toe_origin, right_toe_origin};
   auto cp_traj_generator = builder.AddSystem<systems::CPTrajGenerator>(
-      plant_w_springs, left_right_support_fsm_states,
-      left_right_support_state_durations, left_right_foot, "pelvis", mid_foot_height,
-      desired_final_foot_height, desired_final_vertical_foot_velocity,
-      max_CoM_to_CP_dist, true, true, true, cp_offset, center_line_offset);
+      plant_w_spr, *context_w_spr, left_right_support_fsm_states,
+      left_right_support_state_durations, left_right_foot, "pelvis",
+      mid_foot_height, desired_final_foot_height,
+      desired_final_vertical_foot_velocity, max_CoM_to_CP_dist, true, true,
+      true, cp_offset, center_line_offset);
   builder.Connect(fsm->get_output_port(0),
                   cp_traj_generator->get_input_port_fsm());
   builder.Connect(simulator_drift->get_output_port(0),
@@ -249,18 +253,17 @@ int DoMain(int argc, char* argv[]) {
 
   // Create Operational space control
   auto osc = builder.AddSystem<systems::controllers::OperationalSpaceControl>(
-      plant_w_springs, plant_wo_springs, true,
-      FLAGS_print_osc /*print_tracking_info*/);
+      plant_w_spr, plant_wo_spr, true, FLAGS_print_osc /*print_tracking_info*/);
 
   // Cost
-  int n_v = plant_wo_springs.num_velocities();
+  int n_v = plant_wo_spr.num_velocities();
   MatrixXd Q_accel = 2 * MatrixXd::Identity(n_v, n_v);
   osc->SetAccelerationCostForAllJoints(Q_accel);
 
   // Distance constraint
-  multibody::KinematicEvaluatorSet<double> evaluators(plant_wo_springs);
-  auto left_loop = LeftLoopClosureEvaluator(plant_wo_springs);
-  auto right_loop = RightLoopClosureEvaluator(plant_wo_springs);
+  multibody::KinematicEvaluatorSet<double> evaluators(plant_wo_spr);
+  auto left_loop = LeftLoopClosureEvaluator(plant_wo_spr);
+  auto right_loop = RightLoopClosureEvaluator(plant_wo_spr);
   evaluators.add_evaluator(&left_loop);
   evaluators.add_evaluator(&right_loop);
   osc->AddKinematicConstraint(&evaluators);
@@ -275,17 +278,17 @@ int DoMain(int argc, char* argv[]) {
   osc->SetContactFriction(mu);
   // Add contact points (The position doesn't matter. It's not used in OSC)
   auto left_toe_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_springs, left_toe.first, left_toe.second, Matrix3d::Identity(),
+      plant_wo_spr, left_toe.first, left_toe.second, Matrix3d::Identity(),
       Vector3d::Zero(), {1, 2});
   auto left_heel_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_springs, left_heel.first, left_heel.second, Matrix3d::Identity(),
+      plant_wo_spr, left_heel.first, left_heel.second, Matrix3d::Identity(),
       Vector3d::Zero(), {0, 1, 2});
   auto right_toe_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_springs, right_toe.first, right_toe.second, Matrix3d::Identity(),
+      plant_wo_spr, right_toe.first, right_toe.second, Matrix3d::Identity(),
       Vector3d::Zero(), {1, 2});
   auto right_heel_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_springs, right_heel.first, right_heel.second,
-      Matrix3d::Identity(), Vector3d::Zero(), {0, 1, 2});
+      plant_wo_spr, right_heel.first, right_heel.second, Matrix3d::Identity(),
+      Vector3d::Zero(), {0, 1, 2});
   osc->AddStateAndContactPoint(left_stance_state, &left_toe_evaluator);
   osc->AddStateAndContactPoint(left_stance_state, &left_heel_evaluator);
   osc->AddStateAndContactPoint(right_stance_state, &right_toe_evaluator);
@@ -301,9 +304,8 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd W_swing_foot = 400 * MatrixXd::Identity(3, 3);
   MatrixXd K_p_sw_ft = 100 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_sw_ft = 10 * MatrixXd::Identity(3, 3);
-  TransTaskSpaceTrackingData swing_foot_traj("cp_traj", K_p_sw_ft, K_d_sw_ft,
-                                             W_swing_foot, plant_w_springs,
-                                             plant_wo_springs);
+  TransTaskSpaceTrackingData swing_foot_traj(
+      "cp_traj", K_p_sw_ft, K_d_sw_ft, W_swing_foot, plant_w_spr, plant_wo_spr);
   swing_foot_traj.AddStateAndPointToTrack(left_stance_state, "toe_right");
   swing_foot_traj.AddStateAndPointToTrack(right_stance_state, "toe_left");
   osc->AddTrackingData(&swing_foot_traj);
@@ -315,7 +317,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_p_com = 50 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_com = 10 * MatrixXd::Identity(3, 3);
   ComTrackingData center_of_mass_traj("lipm_traj", K_p_com, K_d_com, W_com,
-                                      plant_w_springs, plant_wo_springs);
+                                      plant_w_spr, plant_wo_spr);
   osc->AddTrackingData(&center_of_mass_traj);
   // Pelvis rotation tracking (pitch and roll)
   double w_pelvis_balance = 200;
@@ -332,7 +334,7 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis_balance(1, 1) = k_d_pelvis_balance;
   RotTaskSpaceTrackingData pelvis_balance_traj(
       "pelvis_balance_traj", K_p_pelvis_balance, K_d_pelvis_balance,
-      W_pelvis_balance, plant_w_springs, plant_wo_springs);
+      W_pelvis_balance, plant_w_spr, plant_wo_spr);
   pelvis_balance_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_balance_traj);
   // Pelvis rotation tracking (yaw)
@@ -347,7 +349,7 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis_heading(2, 2) = k_d_heading;
   RotTaskSpaceTrackingData pelvis_heading_traj(
       "pelvis_heading_traj", K_p_pelvis_heading, K_d_pelvis_heading,
-      W_pelvis_heading, plant_w_springs, plant_wo_springs);
+      W_pelvis_heading, plant_w_spr, plant_wo_spr);
   pelvis_heading_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_heading_traj, 0.1);  // 0.05
   // Swing toe joint tracking (Currently use fix position)
@@ -357,8 +359,8 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_p_swing_toe = 200 * MatrixXd::Identity(1, 1);
   MatrixXd K_d_swing_toe = 20 * MatrixXd::Identity(1, 1);
   JointSpaceTrackingData swing_toe_traj("swing_toe_traj", K_p_swing_toe,
-                                        K_d_swing_toe, W_swing_toe,
-                                        plant_w_springs, plant_wo_springs);
+                                        K_d_swing_toe, W_swing_toe, plant_w_spr,
+                                        plant_wo_spr);
   swing_toe_traj.AddStateAndJointToTrack(left_stance_state, "toe_right",
                                          "toe_rightdot");
   swing_toe_traj.AddStateAndJointToTrack(right_stance_state, "toe_left",
@@ -368,9 +370,9 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd W_hip_yaw = 20 * MatrixXd::Identity(1, 1);
   MatrixXd K_p_hip_yaw = 200 * MatrixXd::Identity(1, 1);
   MatrixXd K_d_hip_yaw = 160 * MatrixXd::Identity(1, 1);
-  JointSpaceTrackingData swing_hip_yaw_traj(
-      "swing_hip_yaw_traj", K_p_hip_yaw, K_d_hip_yaw, W_hip_yaw,
-      plant_w_springs, plant_wo_springs);
+  JointSpaceTrackingData swing_hip_yaw_traj("swing_hip_yaw_traj", K_p_hip_yaw,
+                                            K_d_hip_yaw, W_hip_yaw, plant_w_spr,
+                                            plant_wo_spr);
   swing_hip_yaw_traj.AddStateAndJointToTrack(left_stance_state, "hip_yaw_right",
                                              "hip_yaw_rightdot");
   swing_hip_yaw_traj.AddStateAndJointToTrack(right_stance_state, "hip_yaw_left",

--- a/systems/controllers/cp_traj_gen.cc
+++ b/systems/controllers/cp_traj_gen.cc
@@ -31,6 +31,7 @@ namespace systems {
 
 CPTrajGenerator::CPTrajGenerator(
     const drake::multibody::MultibodyPlant<double>& plant,
+    drake::systems::Context<double>& context,
     std::vector<int> left_right_support_fsm_states,
     std::vector<double> left_right_support_durations,
     std::vector<std::pair<const Vector3d, const Frame<double>&>>
@@ -41,6 +42,7 @@ CPTrajGenerator::CPTrajGenerator(
     bool add_extra_control, bool is_feet_collision_avoid,
     bool is_using_predicted_com, double cp_offset, double center_line_offset)
     : plant_(plant),
+    context_(context),
       left_right_support_fsm_states_(left_right_support_fsm_states),
       mid_foot_height_(mid_foot_height),
       desired_final_foot_height_(desired_final_foot_height),
@@ -107,8 +109,6 @@ CPTrajGenerator::CPTrajGenerator(
   swing_foot_map_.insert(
       {left_right_support_fsm_states.at(0), left_right_foot.at(0)});
 
-  // Create context
-  context_ = plant_.CreateDefaultContext();
 }
 
 EventStatus CPTrajGenerator::DiscreteVariableUpdate(
@@ -148,11 +148,11 @@ EventStatus CPTrajGenerator::DiscreteVariableUpdate(
     prev_td_time(0) = current_time;
 
     VectorXd q = robot_output->GetPositions();
-    plant_.SetPositions(context_.get(), q);
+    plant_.SetPositions(&context_, q);
 
     // Swing foot position (Forward Kinematics) at touchdown
     auto swing_foot = swing_foot_map_.at(int(fsm_state(0)));
-    plant_.CalcPointsPositions(*context_, swing_foot.second, swing_foot.first,
+    plant_.CalcPointsPositions(context_, swing_foot.second, swing_foot.first,
                                world_, &swing_foot_pos_td);
   }
 
@@ -169,12 +169,12 @@ void CPTrajGenerator::calcCpAndStanceFootHeight(
   VectorXd fsm_state = fsm_output->get_value();
 
   VectorXd q = robot_output->GetPositions();
-  plant_.SetPositions(context_.get(), q);
+  plant_.SetPositions(&context_, q);
 
   // Stance foot position
   auto stance_foot = stance_foot_map_.at(int(fsm_state(0)));
   Vector3d stance_foot_pos;
-  plant_.CalcPointsPositions(*context_, stance_foot.second, stance_foot.first,
+  plant_.CalcPointsPositions(context_, stance_foot.second, stance_foot.first,
                              world_, &stance_foot_pos);
 
   // Get CoM or predicted CoM
@@ -194,9 +194,9 @@ void CPTrajGenerator::calcCpAndStanceFootHeight(
 
     MatrixXd J_com(3, plant_.num_velocities());
     plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-        *context_, JacobianWrtVariable::kV, world_, world_, &J_com);
+        context_, JacobianWrtVariable::kV, world_, world_, &J_com);
     VectorXd v = robot_output->GetVelocities();
-    CoM = plant_.CalcCenterOfMassPosition(*context_);
+    CoM = plant_.CalcCenterOfMassPosition(context_);
     dCoM = J_com * v;
   }
 
@@ -216,7 +216,7 @@ void CPTrajGenerator::calcCpAndStanceFootHeight(
   if (is_feet_collision_avoid_) {
     // Get approximated heading angle of pelvis
     Vector3d pelvis_heading_vec =
-        plant_.EvalBodyPoseInWorld(*context_, pelvis_).rotation().col(0);
+        plant_.EvalBodyPoseInWorld(context_, pelvis_).rotation().col(0);
     double approx_pelvis_yaw =
         atan2(pelvis_heading_vec(1), pelvis_heading_vec(0));
 

--- a/systems/controllers/cp_traj_gen.h
+++ b/systems/controllers/cp_traj_gen.h
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "multibody/multibody_utils.h"
+#include "systems/controllers/control_utils.h"
+#include "systems/framework/output_vector.h"
+
 #include "drake/common/trajectories/exponential_plus_piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/leaf_system.h"
-
-#include "multibody/multibody_utils.h"
-#include "systems/controllers/control_utils.h"
-#include "systems/framework/output_vector.h"
 
 namespace dairlib {
 namespace systems {
@@ -44,7 +44,7 @@ namespace systems {
 class CPTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
   CPTrajGenerator(const drake::multibody::MultibodyPlant<double>& plant,
-                  drake::systems::Context<double>& context,
+                  drake::systems::Context<double>* context,
                   std::vector<int> left_right_support_fsm_states,
                   std::vector<double> left_right_support_durations,
                   std::vector<std::pair<const Eigen::Vector3d,
@@ -100,7 +100,7 @@ class CPTrajGenerator : public drake::systems::LeafSystem<double> {
   int prev_fsm_state_idx_;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
-  drake::systems::Context<double>& context_;
+  drake::systems::Context<double>* context_;
   std::vector<int> left_right_support_fsm_states_;
   double mid_foot_height_;
   double desired_final_foot_height_;

--- a/systems/controllers/cp_traj_gen.h
+++ b/systems/controllers/cp_traj_gen.h
@@ -44,6 +44,7 @@ namespace systems {
 class CPTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
   CPTrajGenerator(const drake::multibody::MultibodyPlant<double>& plant,
+                  drake::systems::Context<double>& context,
                   std::vector<int> left_right_support_fsm_states,
                   std::vector<double> left_right_support_durations,
                   std::vector<std::pair<const Eigen::Vector3d,
@@ -99,6 +100,7 @@ class CPTrajGenerator : public drake::systems::LeafSystem<double> {
   int prev_fsm_state_idx_;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
   std::vector<int> left_right_support_fsm_states_;
   double mid_foot_height_;
   double desired_final_foot_height_;
@@ -106,11 +108,10 @@ class CPTrajGenerator : public drake::systems::LeafSystem<double> {
   double max_CoM_to_CP_dist_;
   bool add_extra_control_;
   bool is_feet_collision_avoid_;
-  bool is_using_predicted_com_;
 
+  bool is_using_predicted_com_;
   const drake::multibody::BodyFrame<double>& world_;
   const drake::multibody::Body<double>& pelvis_;
-  std::unique_ptr<drake::systems::Context<double>> context_;
 
   // Parameters
   const double cp_offset_;           // in meters

--- a/systems/controllers/lipm_traj_gen.cc
+++ b/systems/controllers/lipm_traj_gen.cc
@@ -1,6 +1,7 @@
 #include "systems/controllers/lipm_traj_gen.h"
 
 #include <math.h>
+
 #include <string>
 
 using std::cout;
@@ -28,13 +29,14 @@ namespace dairlib {
 namespace systems {
 
 LIPMTrajGenerator::LIPMTrajGenerator(
-    const MultibodyPlant<double>& plant, double desired_com_height,
-    const vector<int>& unordered_fsm_states,
+    const MultibodyPlant<double>& plant, Context<double>& context,
+    double desired_com_height, const vector<int>& unordered_fsm_states,
     const vector<double>& unordered_state_durations,
-    const vector<vector<std::pair<
-        const Eigen::Vector3d, const drake::multibody::Frame<double>&>>>&
+    const vector<vector<std::pair<const Eigen::Vector3d,
+                                  const drake::multibody::Frame<double>&>>>&
         contact_points_in_each_state)
     : plant_(plant),
+      context_(context),
       desired_com_height_(desired_com_height),
       unordered_fsm_states_(unordered_fsm_states),
       unordered_state_durations_(unordered_state_durations),
@@ -70,9 +72,6 @@ LIPMTrajGenerator::LIPMTrajGenerator(
   prev_td_time_idx_ = this->DeclareDiscreteState(1);
   // The last state of FSM
   prev_fsm_state_idx_ = this->DeclareDiscreteState(-0.1 * VectorXd::Ones(1));
-
-  // Create context
-  context_ = plant_.CreateDefaultContext();
 }
 
 EventStatus LIPMTrajGenerator::DiscreteVariableUpdate(
@@ -142,13 +141,13 @@ void LIPMTrajGenerator::CalcTraj(
   }
 
   VectorXd q = robot_output->GetPositions();
-  plant_.SetPositions(context_.get(), q);
+  plant_.SetPositions(&context_, q);
 
   // Get center of mass position and velocity
-  Vector3d CoM = plant_.CalcCenterOfMassPosition(*context_);
+  Vector3d CoM = plant_.CalcCenterOfMassPosition(context_);
   MatrixXd J(3, plant_.num_velocities());
   plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-      *context_, JacobianWrtVariable::kV, world_, world_, &J);
+      context_, JacobianWrtVariable::kV, world_, world_, &J);
   Vector3d dCoM = J * v;
 
   // Stance foot position (Forward Kinematics)
@@ -158,7 +157,7 @@ void LIPMTrajGenerator::CalcTraj(
        j++) {
     Vector3d position;
     plant_.CalcPointsPositions(
-        *context_, contact_points_in_each_state_[mode_index][j].second,
+        context_, contact_points_in_each_state_[mode_index][j].second,
         contact_points_in_each_state_[mode_index][j].first, world_, &position);
     stance_foot_pos += position;
   }
@@ -176,8 +175,7 @@ void LIPMTrajGenerator::CalcTraj(
   // create a 3D one-segment polynomial for ExponentialPlusPiecewisePolynomial
   // Note that the start time in T_waypoint_com is also used by
   // ExponentialPlusPiecewisePolynomial.
-  vector<double> T_waypoint_com = {current_time,
-                                        end_time_of_this_fsm_state};
+  vector<double> T_waypoint_com = {current_time, end_time_of_this_fsm_state};
 
   vector<MatrixXd> Y(T_waypoint_com.size(), MatrixXd::Zero(3, 1));
   Y[0](0, 0) = stance_foot_pos(0);

--- a/systems/controllers/lipm_traj_gen.cc
+++ b/systems/controllers/lipm_traj_gen.cc
@@ -29,7 +29,7 @@ namespace dairlib {
 namespace systems {
 
 LIPMTrajGenerator::LIPMTrajGenerator(
-    const MultibodyPlant<double>& plant, Context<double>& context,
+    const MultibodyPlant<double>& plant, Context<double>* context,
     double desired_com_height, const vector<int>& unordered_fsm_states,
     const vector<double>& unordered_state_durations,
     const vector<vector<std::pair<const Eigen::Vector3d,
@@ -141,13 +141,13 @@ void LIPMTrajGenerator::CalcTraj(
   }
 
   VectorXd q = robot_output->GetPositions();
-  plant_.SetPositions(&context_, q);
+  plant_.SetPositions(context_, q);
 
   // Get center of mass position and velocity
-  Vector3d CoM = plant_.CalcCenterOfMassPosition(context_);
+  Vector3d CoM = plant_.CalcCenterOfMassPosition(*context_);
   MatrixXd J(3, plant_.num_velocities());
   plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-      context_, JacobianWrtVariable::kV, world_, world_, &J);
+      *context_, JacobianWrtVariable::kV, world_, world_, &J);
   Vector3d dCoM = J * v;
 
   // Stance foot position (Forward Kinematics)
@@ -157,7 +157,7 @@ void LIPMTrajGenerator::CalcTraj(
        j++) {
     Vector3d position;
     plant_.CalcPointsPositions(
-        context_, contact_points_in_each_state_[mode_index][j].second,
+        *context_, contact_points_in_each_state_[mode_index][j].second,
         contact_points_in_each_state_[mode_index][j].first, world_, &position);
     stance_foot_pos += position;
   }

--- a/systems/controllers/lipm_traj_gen.h
+++ b/systems/controllers/lipm_traj_gen.h
@@ -34,7 +34,7 @@ class LIPMTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
   LIPMTrajGenerator(
       const drake::multibody::MultibodyPlant<double>& plant,
-      drake::systems::Context<double>& context,
+      drake::systems::Context<double>* context,
       double desired_com_height, const std::vector<int>& unordered_fsm_states,
       const std::vector<double>& unordered_state_durations,
       const std::vector<std::vector<std::pair<
@@ -66,7 +66,7 @@ class LIPMTrajGenerator : public drake::systems::LeafSystem<double> {
   int prev_fsm_state_idx_;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
-  drake::systems::Context<double>& context_;
+  drake::systems::Context<double>* context_;
 
   double desired_com_height_;
   std::vector<int> unordered_fsm_states_;

--- a/systems/controllers/lipm_traj_gen.h
+++ b/systems/controllers/lipm_traj_gen.h
@@ -34,6 +34,7 @@ class LIPMTrajGenerator : public drake::systems::LeafSystem<double> {
  public:
   LIPMTrajGenerator(
       const drake::multibody::MultibodyPlant<double>& plant,
+      drake::systems::Context<double>& context,
       double desired_com_height, const std::vector<int>& unordered_fsm_states,
       const std::vector<double>& unordered_state_durations,
       const std::vector<std::vector<std::pair<
@@ -65,19 +66,18 @@ class LIPMTrajGenerator : public drake::systems::LeafSystem<double> {
   int prev_fsm_state_idx_;
 
   const drake::multibody::MultibodyPlant<double>& plant_;
+  drake::systems::Context<double>& context_;
 
   double desired_com_height_;
-
   std::vector<int> unordered_fsm_states_;
+
   std::vector<double> unordered_state_durations_;
 
   // A list of pairs of contact body frame and contact point in each FSM state
   const std::vector<std::vector<std::pair<
       const Eigen::Vector3d, const drake::multibody::Frame<double>&>>>&
       contact_points_in_each_state_;
-
   const drake::multibody::BodyFrame<double>& world_;
-  std::unique_ptr<drake::systems::Context<double>> context_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
To take advantage of context caching, we create a single Context object for the plant with springs and share it across the leaf systems that call kinematics functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/184)
<!-- Reviewable:end -->
