### PR TITLE
Add an input port in EKF to store lcm time

### DIFF
--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -61,6 +61,19 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
       const multibody::KinematicEvaluatorSet<double>* right_contact_evaluator,
       bool test_with_ground_truth_state = false,
       bool print_info_to_terminal = false, int hardware_test_mode = -1);
+
+  // Getters for input ports
+  const drake::systems::InputPort<double>& get_cassie_out_input_port() const {
+    return this->get_input_port(cassie_out_input_port_);
+  }
+  const drake::systems::InputPort<double>& get_message_time_input_port() const {
+    return this->get_input_port(incoming_message_time_input_port_);
+  }
+  const drake::systems::InputPort<double>& get_state_input_port() const {
+    return this->get_input_port(state_input_port_);
+  }
+
+  // A function that solves for heel spring deflection (unmeasured joint)
   void solveFourbarLinkage(const Eigen::VectorXd& q_init,
                            double* left_heel_spring,
                            double* right_heel_spring) const;
@@ -136,6 +149,7 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
 
   // Input/output port indices
   int cassie_out_input_port_;
+  int incoming_message_time_input_port_;
   int state_input_port_;
 
   // Below are indices of system states:

--- a/examples/Cassie/networking/udp_lcm_translator.cc
+++ b/examples/Cassie/networking/udp_lcm_translator.cc
@@ -134,10 +134,6 @@ void cassieOutFromLcm(const lcmt_cassie_out& message,
   copy_vector(message.messages,
               cassie_out->messages, 4);
   cassie_out->isCalibrated = message.isCalibrated;
-
-  // Testing
-  // TODO(yminchen): delete this after you resolve the issue of delayed update
-  // cassie_out->pelvis.targetPc.taskExecutionTime = message.utime*1e-6;
 }
 
 void cassieOutToLcm(const cassie_out_t& cassie_out, double time_seconds,


### PR DESCRIPTION
This PR fixes issue #63 

Instead of implementing the two solutions from Drake developers, I implemented a simpler approach here. I added an input port to EKF to store the message time. The port is updated after a new message arrives and before the simulation is advanced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/187)
<!-- Reviewable:end -->
