### PR TITLE
Change EKF update to registered event.

### DIFF
--- a/examples/Cassie/cassie_state_estimator.cc
+++ b/examples/Cassie/cassie_state_estimator.cc
@@ -1315,9 +1315,9 @@ void CassieStateEstimator::DoCalcNextUpdateTime(
   // event. We set `next_message_time_ - eps_` to be the update time for our
   // callback function, because we want the event triggers before the publish
   // event at time `next_message_time_`.
-  // Note that we don't need to worry about declaring multiple events at a
-  // message time, because the events that are not at the next update time are
-  // cleared here:
+  // Note that we don't need to worry about declaring multiple events at the
+  // same message time, because the events that happen after the next update
+  // time of the Simulator are cleared here:
   // https://github.com/RobotLocomotion/drake/blob/5f0ac26e7bf7dc6f86c773c77b2c9926fb67a9d5/systems/framework/diagram.cc#L850
   if (context.get_time() < next_message_time_ - eps_) {
     // Subtract a small epsilon value so this event triggers before the publish

--- a/examples/Cassie/cassie_state_estimator.cc
+++ b/examples/Cassie/cassie_state_estimator.cc
@@ -938,6 +938,10 @@ void CassieStateEstimator::EstimateContactForController(
 EventStatus CassieStateEstimator::Update(
     const Context<double>& context,
     drake::systems::State<double>* state) const {
+  // Clear next_message_time_ so that this callback function only runs once per
+  // message
+  next_message_time_ = std::numeric_limits<double>::infinity();
+
   // Get cassie output
   const auto& cassie_out =
       this->EvalAbstractInput(context, cassie_out_input_port_)
@@ -1322,8 +1326,6 @@ void CassieStateEstimator::DoCalcNextUpdateTime(
   auto& uu_events = events->get_mutable_unrestricted_update_events();
   uu_events.add_event(std::make_unique<UnrestrictedUpdateEvent<double>>(
         drake::systems::TriggerType::kTimed, callback));
-
-  next_message_time_ = std::numeric_limits<double>::infinity();
 }
 
 }  // namespace systems

--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -243,7 +243,7 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
       std::make_unique<int>(0);
 
   // Timestamp from unprocessed message
-  double next_message_time_ = std::numeric_limits<double>::infinity();
+  double next_message_time_ = -std::numeric_limits<double>::infinity();
   double eps_ = 1e-12;
 };
 

--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -243,7 +243,7 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
       std::make_unique<int>(0);
 
   // Timestamp from unprocessed message
-  mutable double next_message_time_ = std::numeric_limits<double>::infinity();
+  double next_message_time_ = std::numeric_limits<double>::infinity();
   double eps_ = 1e-12;
 };
 

--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -98,12 +98,17 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
   void AssignNonFloatingBaseStateToOutputVector(const cassie_out_t& cassie_out,
       systems::OutputVector<double>* output) const;
 
+  // Currently, `DoCalcNextUpdateTime` seems to be the only gateway of adding
+  // kTimed events
   void DoCalcNextUpdateTime(
       const drake::systems::Context<double>& context,
       drake::systems::CompositeEventCollection<double>* events,
       double* time) const final;
 
-  // Set the time of the next received message. Is used to trigger update events
+  // Set the time of the next received message. Is used to trigger update
+  // events.
+  // Note that the real trigger/update time is `next_message_time_ - eps`,
+  // because we want the discrete update to happen before Publish
   void set_next_message_time(double t) { next_message_time_ = t; };
 
  private:

--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -98,6 +98,14 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
   void AssignNonFloatingBaseStateToOutputVector(const cassie_out_t& cassie_out,
       systems::OutputVector<double>* output) const;
 
+  void DoCalcNextUpdateTime(
+      const drake::systems::Context<double>& context,
+      drake::systems::CompositeEventCollection<double>* events,
+      double* time) const final;
+
+  // Set the time of the next received message. Is used to trigger update events
+  void set_next_message_time(double t) { next_message_time_ = t; };
+
  private:
   void AssignImuValueToOutputVector(const cassie_out_t& cassie_out,
       systems::OutputVector<double>* output) const;
@@ -228,6 +236,9 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
   int hardware_test_mode_;
   std::unique_ptr<int> counter_for_testing_ =
       std::make_unique<int>(0);
+
+  // Timestamp from unprocessed message
+  mutable double next_message_time_ = std::numeric_limits<double>::infinity();
 };
 
 }  // namespace systems

--- a/examples/Cassie/cassie_state_estimator.h
+++ b/examples/Cassie/cassie_state_estimator.h
@@ -244,6 +244,7 @@ class CassieStateEstimator : public drake::systems::LeafSystem<double> {
 
   // Timestamp from unprocessed message
   mutable double next_message_time_ = std::numeric_limits<double>::infinity();
+  double eps_ = 1e-12;
 };
 
 }  // namespace systems

--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -318,6 +318,8 @@ int do_main(int argc, char* argv[]) {
         simulator.get_mutable_context().SetTime(time);
       }
 
+      state_estimator->set_next_message_time(time);
+
       simulator.AdvanceTo(time);
       // Force-publish via the diagram
       diagram.Publish(diagram_context);
@@ -363,6 +365,8 @@ int do_main(int argc, char* argv[]) {
                   << std::endl;
         simulator.get_mutable_context().SetTime(time);
       }
+
+      state_estimator->set_next_message_time(time);
 
       simulator.AdvanceTo(time);
       // Force-publish via the diagram

--- a/examples/Cassie/networking/udp_lcm_translator.cc
+++ b/examples/Cassie/networking/udp_lcm_translator.cc
@@ -134,10 +134,6 @@ void cassieOutFromLcm(const lcmt_cassie_out& message,
   copy_vector(message.messages,
               cassie_out->messages, 4);
   cassie_out->isCalibrated = message.isCalibrated;
-
-  // Testing
-  // TODO(yminchen): delete this after you resolve the issue of delayed update
-  // cassie_out->pelvis.targetPc.taskExecutionTime = message.utime*1e-6;
 }
 
 void cassieOutToLcm(const cassie_out_t& cassie_out, double time_seconds,


### PR DESCRIPTION
Relates to #63 

Changes the EKF's update to be a kTimed event. The user must call `estimator.set_next_message_time(t)` to schedule an event at time `t` (technically, `t-eps`).

I'm not totally sure that this is the right approach, so please read with a critical eye. I'm also not totally sure it's better than #187 

Flaws:
- Since `DoCalcNextUpdateTime` is `const`, `next_message_time` is declared mutable so it can be reset within this method. This is probably not the right way to do this, as it breaks some of the Systems contracts regarding Context, but perhaps it's OK.
- The required use of `eps` in the event time. It could, alternatively, be moved to `simulator.AdvanceTo(t + eps)`, if that's any better.

The benefits from this approach are that:
- context.time is always correct (up to eps)
- Doesn't require superfluous states/ports to the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/188)
<!-- Reviewable:end -->
