### PR TITLE
Using the more efficient method of evaluating derivatives

### DIFF
--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -55,8 +55,8 @@ bool OscTrackingData::Update(
     // Careful: must update y_des_ before calling UpdateYAndError()
     // Update desired output
     y_des_ = traj.value(t);
-    ydot_des_ = traj.MakeDerivative(1)->value(t);
-    yddot_des_ = traj.MakeDerivative(2)->value(t);
+    ydot_des_ = traj.EvalDerivative(t, 1);
+    yddot_des_ = traj.EvalDerivative(t, 2);
 
     // Update feedback output (Calling virtual methods)
     UpdateYAndError(x_w_spr, context_w_spr);


### PR DESCRIPTION
This is a very small change.

Previously we were creating constructing the derivatives of the entire trajectory just to evaluate the derivative at a single time. Now we use Drake's `EvalDerivative(t, order)` function to do this more efficiently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/197)
<!-- Reviewable:end -->
