### PR TITLE
Blend efforts after switch

### DIFF
--- a/examples/Cassie/BUILD.bazel
+++ b/examples/Cassie/BUILD.bazel
@@ -83,6 +83,7 @@ cc_library(
     srcs = ["input_supervisor.cc"],
     hdrs = ["input_supervisor.h"],
     deps = [
+        "//lcmtypes:lcmt_robot",
         "//systems/primitives",
         "@drake//:drake_shared_library",
     ],

--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -135,7 +135,6 @@ int do_main(int argc, char* argv[]) {
   auto owned_diagram = builder.Build();
   owned_diagram->set_name("dispatcher_robot_in");
 
-
   // Channel names of the controllers
   std::vector<std::string> input_channels;
   input_channels.push_back(FLAGS_control_channel_name_1);
@@ -150,7 +149,7 @@ int do_main(int argc, char* argv[]) {
        command_receiver,
        input_channels,
        FLAGS_control_channel_name_1,
-       switch_channel,
+       controller_switch_sub,
        true);
   loop.Simulate();
 

--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -149,7 +149,7 @@ int do_main(int argc, char* argv[]) {
        command_receiver,
        input_channels,
        FLAGS_control_channel_name_1,
-       controller_switch_sub,
+       switch_channel,
        true);
   loop.Simulate();
 

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -168,7 +168,7 @@ void InputSupervisor::UpdateErrorFlag(
       std::cout << "Error! Velocity has exceeded the threshold of "
                 << max_joint_velocity_ << std::endl;
       std::cout << "Consecutive error "
-                << discrete_state->get_data()[0]->get_value()[n_fails_index_]
+                << discrete_state->get_vector(status_vars_index_)[n_fails_index_]
                 << " of " << min_consecutive_failures_ << std::endl;
       std::cout << "Velocity vector: " << std::endl
                 << velocities << std::endl

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -101,6 +101,7 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
   double alpha = (command->get_timestamp() -
                   context.get_discrete_state(switch_time_index_)[0]) /
                  kFilterDuration;
+
   if (alpha <= 1.0) {
     Eigen::VectorXd blended_effort =
         alpha * command->get_value() +
@@ -168,7 +169,8 @@ void InputSupervisor::UpdateErrorFlag(
       std::cout << "Error! Velocity has exceeded the threshold of "
                 << max_joint_velocity_ << std::endl;
       std::cout << "Consecutive error "
-                << discrete_state->get_vector(status_vars_index_)[n_fails_index_]
+                << discrete_state->get_vector(
+                       status_vars_index_)[n_fails_index_]
                 << " of " << min_consecutive_failures_ << std::endl;
       std::cout << "Velocity vector: " << std::endl
                 << velocities << std::endl
@@ -182,16 +184,17 @@ void InputSupervisor::UpdateErrorFlag(
     }
   }
 
-  // Update the previous commanded switch message unless trying to blend efforts
+  // Update the previous commanded switch message unless currently blending
+  // efforts
   if (command->get_timestamp() - controller_switch->utime * 1e-6 >=
       kFilterDuration) {
     discrete_state->get_mutable_vector(prev_efforts_index_)
         .get_mutable_value() = command->get_value();
   }
 
-  // When receiving a new controller switch message record the time
+  // When receiving a new controller switch message, record the time
   if (discrete_state->get_mutable_vector(switch_time_index_)[0] <
-          controller_switch->utime * 1e-6) {
+      controller_switch->utime * 1e-6) {
     std::cout << "Got new switch message" << std::endl;
     discrete_state->get_mutable_vector(switch_time_index_)[0] =
         controller_switch->utime * 1e-6;

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -105,7 +105,7 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
     Eigen::VectorXd blended_effort =
         (1 - alpha) *
             context.get_discrete_state(prev_efforts_index_).get_value() +
-        alpha * output->get_data();
+        alpha * command->get_value();
     output->SetDataVector(blended_effort);
   }
 }
@@ -145,7 +145,6 @@ void InputSupervisor::UpdateErrorFlag(
   const auto* controller_switch =
       this->EvalInputValue<dairlib::lcmt_controller_switch>(
           context, controller_switch_input_port_);
-
   const TimestampedVector<double>* command =
       (TimestampedVector<double>*)this->EvalVectorInput(context,
                                                         command_input_port_);
@@ -179,9 +178,6 @@ void InputSupervisor::UpdateErrorFlag(
           false;
     }
   }
-
-  std::cout << state->get_timestamp() << std::endl;
-//  std::cout << command->get_timestamp() << std::endl;
 
   if (discrete_state->get_mutable_vector(switch_time_index_)[0] <
       controller_switch->utime * 1e-6) {

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -1,5 +1,6 @@
 #include "examples/Cassie/input_supervisor.h"
 
+#include "dairlib/lcmt_controller_switch.hpp"
 #include "systems/framework/output_vector.h"
 
 using drake::systems::Context;
@@ -29,6 +30,11 @@ InputSupervisor::InputSupervisor(
                           ->DeclareVectorInputPort(OutputVector<double>(
                               num_positions_, num_velocities_, num_actuators_))
                           .get_index();
+  controller_switch_input_port_ =
+      this->DeclareAbstractInputPort(
+              "lcmt_controller_switch",
+              drake::Value<dairlib::lcmt_controller_switch>{})
+          .get_index();
 
   // Create output port for commands
   command_output_port_ =
@@ -44,9 +50,11 @@ InputSupervisor::InputSupervisor(
 
   // Create error flag as discrete state
   // Store both values in single discrete vector
-  DeclareDiscreteState(2);
+  status_vars_index_ = DeclareDiscreteState(2);
   n_fails_index_ = 0;
   status_index_ = 1;
+  switch_time_index_ = DeclareDiscreteState(1);
+  prev_efforts_index_ = DeclareDiscreteState(num_actuators_);
 
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
@@ -59,8 +67,8 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
       (TimestampedVector<double>*)this->EvalVectorInput(context,
                                                         command_input_port_);
 
-  bool is_error =
-      context.get_discrete_state()[n_fails_index_] >= min_consecutive_failures_;
+  bool is_error = context.get_discrete_state(status_vars_index_)[n_fails_index_] >=
+                  min_consecutive_failures_;
 
   // If there has not been an error, copy over the command.
   // If there has been an error, set the command to all zeros
@@ -86,6 +94,18 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
     output->set_timestamp(command->get_timestamp());
     output->SetDataVector(Eigen::VectorXd::Zero(num_actuators_));
   }
+
+  double alpha = (command->get_timestamp() -
+                  context.get_discrete_state(switch_time_index_)[0]) /
+                 kFilterDuration;
+  if (alpha <= 1.0) {
+    if(fmod(command->get_timestamp(), 1.0) < 1e-3)
+      std::cout << "Blending efforts" << std::endl;
+    Eigen::VectorXd blended_effort =
+        (1 - alpha) * context.get_discrete_state(prev_efforts_index_).get_value() + alpha *
+        output->get_data();
+    output->SetDataVector(blended_effort);
+  }
 }
 
 void InputSupervisor::SetStatus(const Context<double>& context,
@@ -94,7 +114,7 @@ void InputSupervisor::SetStatus(const Context<double>& context,
       (TimestampedVector<double>*)this->EvalVectorInput(context,
                                                         command_input_port_);
 
-  output->get_mutable_value()(0) = context.get_discrete_state()[status_index_];
+  output->get_mutable_value()(0) = context.get_discrete_state(status_vars_index_)[status_index_];
   if (input_limit_ != std::numeric_limits<double>::max()) {
     for (int i = 0; i < command->get_data().size(); i++) {
       double command_value = command->get_data()(i);
@@ -108,7 +128,7 @@ void InputSupervisor::SetStatus(const Context<double>& context,
   // Shutdown is/will soon be active (the status flag is set in a separate loop
   // from the actual motor torques so the update of the status bit could be
   // slightly off
-  if (context.get_discrete_state()[n_fails_index_] >=
+  if (context.get_discrete_state(status_vars_index_)[n_fails_index_] >=
       min_consecutive_failures_) {
     output->get_mutable_value()(0) += 4;
   }
@@ -119,29 +139,44 @@ void InputSupervisor::UpdateErrorFlag(
     DiscreteValues<double>* discrete_state) const {
   const OutputVector<double>* state =
       (OutputVector<double>*)this->EvalVectorInput(context, state_input_port_);
+  auto controller_switch =
+      this->EvalInputValue<dairlib::lcmt_controller_switch>(
+          context, controller_switch_input_port_);
+  const TimestampedVector<double>* command =
+      (TimestampedVector<double>*)this->EvalVectorInput(context,
+                                                        command_input_port_);
 
   const Eigen::VectorXd& velocities = state->GetVelocities();
 
-  if ((*discrete_state)[n_fails_index_] < min_consecutive_failures_) {
+  if (discrete_state->get_vector(status_vars_index_)[n_fails_index_] <
+      min_consecutive_failures_) {
     // If any velocity is above the threshold, set the error flag
     bool is_velocity_error = (velocities.array() > max_joint_velocity_).any() ||
                              (velocities.array() < -max_joint_velocity_).any();
     if (is_velocity_error) {
       // Increment counter
-      (*discrete_state)[n_fails_index_]++;
-      (*discrete_state)[status_index_] = true;
+      discrete_state->get_mutable_vector(status_vars_index_)[n_fails_index_] += 1;
+      discrete_state->get_mutable_vector(status_vars_index_)[status_index_] = true;
       std::cout << "Error! Velocity has exceeded the threshold of "
                 << max_joint_velocity_ << std::endl;
-      std::cout << "Consecutive error " << (*discrete_state)[n_fails_index_]
+      std::cout << "Consecutive error "
+                << discrete_state->get_data()[0]->get_value()[n_fails_index_]
                 << " of " << min_consecutive_failures_ << std::endl;
       std::cout << "Velocity vector: " << std::endl
                 << velocities << std::endl
                 << std::endl;
     } else {
       // Reset counter
-      (*discrete_state)[n_fails_index_] = 0;
-      (*discrete_state)[status_index_] = false;
+      discrete_state->get_mutable_vector(status_vars_index_)[n_fails_index_] = 0;
+      discrete_state->get_mutable_vector(status_vars_index_)[status_index_] = false;
     }
+  }
+
+  if (controller_switch) {
+    discrete_state->get_mutable_vector(prev_efforts_index_).get_mutable_value() =
+        command->get_value();
+    discrete_state->get_mutable_vector(switch_time_index_)[0] =
+        state->get_timestamp();
   }
 }
 

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -57,8 +57,7 @@ InputSupervisor::InputSupervisor(
   prev_efforts_index_ = DeclareDiscreteState(num_actuators_);
 
   // Create update for error flag
-  DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
-                                     &InputSupervisor::UpdateErrorFlag);
+  DeclarePerStepDiscreteUpdateEvent(&InputSupervisor::UpdateErrorFlag);
 }
 
 void InputSupervisor::SetMotorTorques(const Context<double>& context,
@@ -141,7 +140,7 @@ void InputSupervisor::SetStatus(const Context<double>& context,
   }
 }
 
-void InputSupervisor::UpdateErrorFlag(
+drake::systems::EventStatus InputSupervisor::UpdateErrorFlag(
     const Context<double>& context,
     DiscreteValues<double>* discrete_state) const {
   const OutputVector<double>* state =
@@ -199,6 +198,8 @@ void InputSupervisor::UpdateErrorFlag(
     discrete_state->get_mutable_vector(switch_time_index_)[0] =
         controller_switch->utime * 1e-6;
   }
+
+  return drake::systems::EventStatus::Succeeded();
 }
 
 }  // namespace dairlib

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -7,9 +7,6 @@
 
 namespace dairlib {
 
-
-static constexpr double kFilterDuration = 2.0;
-
 /// The InputSupervisor is a simple Drake System that acts as an intermediary
 /// between commands from controllers and the actual robot. It's envisioned role
 /// is to (1) sanity check any inputs, (2) shut down in case of errors or
@@ -63,10 +60,9 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
     return this->get_output_port(status_output_port_);
   }
 
-
   void SetMotorTorques(const drake::systems::Context<double>& context,
                        systems::TimestampedVector<double>* output) const;
-  drake::systems::EventStatus UpdateErrorFlag(
+  void UpdateErrorFlag(
       const drake::systems::Context<double>& context,
       drake::systems::DiscreteValues<double>* discrete_state) const;
 
@@ -86,8 +82,8 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   const int num_velocities_;
   const int min_consecutive_failures_;
   double max_joint_velocity_;
-
   double input_limit_;
+  mutable double blend_duration_ = 0.0;
   int status_vars_index_;
   int n_fails_index_;
   int status_index_;

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -7,6 +7,9 @@
 
 namespace dairlib {
 
+
+static constexpr double kFilterDuration = 2;
+
 /// The InputSupervisor is a simple Drake System that acts as an intermediary
 /// between commands from controllers and the actual robot. It's envisioned role
 /// is to (1) sanity check any inputs, (2) shut down in case of errors or
@@ -48,6 +51,10 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
     return this->get_input_port(state_input_port_);
   }
 
+  const drake::systems::InputPort<double>& get_input_port_controller_switch() const {
+    return this->get_input_port(controller_switch_input_port_);
+  }
+
   const drake::systems::OutputPort<double>& get_output_port_command() const {
     return this->get_output_port(command_output_port_);
   }
@@ -81,10 +88,14 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   double max_joint_velocity_;
 
   double input_limit_;
+  int status_vars_index_;
   int n_fails_index_;
   int status_index_;
+  int switch_time_index_;
+  int prev_efforts_index_;
   int state_input_port_;
   int command_input_port_;
+  int controller_switch_input_port_;
   int command_output_port_;
   int status_output_port_;
 };

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -66,7 +66,7 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
 
   void SetMotorTorques(const drake::systems::Context<double>& context,
                        systems::TimestampedVector<double>* output) const;
-  void UpdateErrorFlag(
+  drake::systems::EventStatus UpdateErrorFlag(
       const drake::systems::Context<double>& context,
       drake::systems::DiscreteValues<double>* discrete_state) const;
 

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -8,7 +8,7 @@
 namespace dairlib {
 
 
-static constexpr double kFilterDuration = 2;
+static constexpr double kFilterDuration = 2.0;
 
 /// The InputSupervisor is a simple Drake System that acts as an intermediary
 /// between commands from controllers and the actual robot. It's envisioned role

--- a/examples/Cassie/run_controller_switch.cc
+++ b/examples/Cassie/run_controller_switch.cc
@@ -14,7 +14,7 @@ using drake::systems::TriggerType;
 using drake::systems::lcm::LcmPublisherSystem;
 using drake::systems::lcm::TriggerTypeSet;
 
-DEFINE_string(channel_x, "CASSIE_STATE",
+DEFINE_string(channel_x, "CASSIE_STATE_DISPATCHER",
               "The name of the channel which receives state");
 DEFINE_string(switch_channel, "INPUT_SWITCH",
               "The name of the channel which sends the channel name that "

--- a/examples/Cassie/run_controller_switch.cc
+++ b/examples/Cassie/run_controller_switch.cc
@@ -1,7 +1,10 @@
 #include <string>
+
 #include <gflags/gflags.h>
+
 #include "dairlib/lcmt_controller_switch.hpp"
 #include "dairlib/lcmt_robot_output.hpp"
+
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -22,17 +25,21 @@ DEFINE_string(switch_channel, "INPUT_SWITCH",
 DEFINE_string(new_channel, "PD_CONTROLLER",
               "The name of the new lcm channel that dispatcher_in listens to "
               "after switch");
+DEFINE_int32(n_publishes, 10,
+             "The simulation gets updated until it publishes the channel name "
+             "n_publishes times");
+
 DEFINE_int32(n_period_delay, -1,
              "the number of periods before we start publishing the new channel "
              "name. If the value is non-positive, the channel name is published"
              "right after the start of the program.");
-DEFINE_int32(n_publishes, 10,
-             "The simulation gets updated until it publishes the channel name "
-             "n_publishes times");
 DEFINE_double(fsm_period, -1.0, " the period of TimeBasedFiniteStateMachine");
 DEFINE_double(fsm_offset, 0.0,
               "a constant that's used to determined the publish time see the "
               "documentation below for details");
+DEFINE_double(blend_duration, 0.0,
+              "Duration to blend efforts between previous and current "
+              "controller command");
 
 /// This program is a one-time-use switch that tells dispatcher_robot_in which
 /// channel to listen to. It publishes the lcm message,
@@ -103,12 +110,13 @@ int do_main(int argc, char* argv[]) {
   double t_threshold = t0;
   if (FLAGS_n_period_delay > 0) {
     t_threshold = (floor(t0 / FLAGS_fsm_period) + FLAGS_n_period_delay) *
-                      FLAGS_fsm_period +
-                  FLAGS_fsm_offset;
+        FLAGS_fsm_period +
+        FLAGS_fsm_offset;
   }
   // Create output message
   dairlib::lcmt_controller_switch msg;
   msg.channel = FLAGS_new_channel;
+  msg.blend_duration = FLAGS_blend_duration;
 
   // Run the simulation until it publishes the channel name `n_publishes` times
   drake::log()->info(diagram_ptr->get_name() + " started");
@@ -122,6 +130,8 @@ int do_main(int argc, char* argv[]) {
     // Get message time from the input channel
     double t_current = input_sub.message().utime * 1e-6;
     if (t_current >= t_threshold) {
+      std::cout << "publish at t = " << t_current << std::endl;
+
       msg.utime = (int)input_sub.message().utime;
       name_pub->get_input_port().FixValue(
           &(diagram_ptr->GetMutableSubsystemContext(*name_pub,

--- a/examples/Cassie/test/input_supervisor_test.cc
+++ b/examples/Cassie/test/input_supervisor_test.cc
@@ -1,9 +1,12 @@
 #include "examples/Cassie/input_supervisor.h"
 
-#include "drake/multibody/plant/multibody_plant.h"
-#include "examples/Cassie/cassie_utils.h"
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
+
+#include "dairlib/lcmt_controller_switch.hpp"
+#include "examples/Cassie/cassie_utils.h"
+
+#include "drake/multibody/plant/multibody_plant.h"
 
 namespace dairlib {
 namespace systems {
@@ -14,8 +17,9 @@ using Eigen::VectorXd;
 // class InputSupervisorTest: public ::testing::Test {};
 
 class InputSupervisorTest : public ::testing::Test {
-protected:
-  InputSupervisorTest() : plant_(drake::multibody::MultibodyPlant<double>(0.0)) {
+ protected:
+  InputSupervisorTest()
+      : plant_(drake::multibody::MultibodyPlant<double>(0.0)) {
     addCassieMultibody(&plant_, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_v2.urdf",
                        true /*spring model*/, false /*loop closure*/);
@@ -24,19 +28,32 @@ protected:
         plant_, 10.0, 0.01, min_consecutive_failures, 20.0);
     context_ = supervisor_->CreateDefaultContext();
     status_output_ = std::make_unique<TimestampedVector<double>>(1);
+    motor_output_ = std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
     command_input_ =
         std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
     state_input_ = std::make_unique<OutputVector<double>>(
         plant_.num_positions(), plant_.num_velocities(),
         plant_.num_actuators());
+    //    controller_switch_input_ = std::make_unique<lcmt_controller_switch>();
+    //    controller_switch_input_->utime = 0;
+    //    controller_switch_input_->channel = "CONTROLLER_CHANNEL";
+    command_input_port_ = supervisor_->get_input_port_command().get_index();
+    state_input_port_ = supervisor_->get_input_port_state().get_index();
+    controller_switch_input_port_ =
+        supervisor_->get_input_port_controller_switch().get_index();
   }
 
+  int command_input_port_;
+  int state_input_port_;
+  int controller_switch_input_port_;
   drake::multibody::MultibodyPlant<double> plant_;
   const int min_consecutive_failures = 5;
   std::unique_ptr<InputSupervisor> supervisor_;
   std::unique_ptr<TimestampedVector<double>> status_output_;
+  std::unique_ptr<TimestampedVector<double>> motor_output_;
   std::unique_ptr<TimestampedVector<double>> command_input_;
   std::unique_ptr<OutputVector<double>> state_input_;
+  //  std::unique_ptr<lcmt_controller_switch> controller_switch_input_;
   std::unique_ptr<drake::systems::Context<double>> context_;
 };
 
@@ -44,7 +61,7 @@ TEST_F(InputSupervisorTest, StatusBitTest) {
   double output_bit;
   VectorXd zero_input = VectorXd::Zero(plant_.num_actuators());
   command_input_->get_mutable_value() = zero_input;
-  context_->FixInputPort(0, *command_input_);
+  context_->FixInputPort(command_input_port_, *command_input_);
 
   supervisor_->SetStatus(*context_, status_output_.get());
   output_bit = status_output_->get_value()[0];
@@ -52,14 +69,17 @@ TEST_F(InputSupervisorTest, StatusBitTest) {
 
   VectorXd large_input = 100 * VectorXd::Ones(plant_.num_actuators());
   command_input_->get_mutable_value() = large_input;
-  context_->FixInputPort(0, *command_input_);
+  context_->FixInputPort(command_input_port_, *command_input_);
   supervisor_->SetStatus(*context_, status_output_.get());
   output_bit = status_output_->get_value()[0];
   EXPECT_EQ(output_bit, 2);
 
   VectorXd high_velocities = 100 * VectorXd::Ones(plant_.num_velocities());
   state_input_->SetVelocities(high_velocities);
-  context_->FixInputPort(1, *state_input_);
+  context_->FixInputPort(state_input_port_, *state_input_);
+  context_->FixInputPort(
+      controller_switch_input_port_,
+      std::make_unique<drake::Value<lcmt_controller_switch>>());
   supervisor_->UpdateErrorFlag(*context_,
                                &context_->get_mutable_discrete_state());
   supervisor_->SetStatus(*context_, status_output_.get());
@@ -76,11 +96,29 @@ TEST_F(InputSupervisorTest, StatusBitTest) {
   EXPECT_EQ(output_bit, 7);
 }
 
-} // namespace
-} // namespace systems
-} // namespace dairlib
+TEST_F(InputSupervisorTest, BlendEffortsTest) {
+  VectorXd prev_input = VectorXd::Zero(plant_.num_actuators());
+  VectorXd desired_input = 10 * VectorXd::Ones(plant_.num_actuators());
+  double timestamp = 0.5;
+  context_->FixInputPort(
+      controller_switch_input_port_,
+      std::make_unique<drake::Value<lcmt_controller_switch>>());
+  command_input_->get_mutable_value() = desired_input;
+  command_input_->set_timestamp(timestamp);
+  context_->FixInputPort(command_input_port_, *command_input_);
 
-int main(int argc, char **argv) {
+  supervisor_->SetMotorTorques(*context_, motor_output_.get());
+
+  VectorXd output_from_supervisor = motor_output_->get_value();
+  double alpha = (timestamp - 0.0) / kFilterDuration;
+  EXPECT_EQ(output_from_supervisor, alpha * desired_input);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace dairlib
+
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/examples/Cassie/test/input_supervisor_test.cc
+++ b/examples/Cassie/test/input_supervisor_test.cc
@@ -4,118 +4,130 @@
 #include <gtest/gtest.h>
 
 #include "dairlib/lcmt_controller_switch.hpp"
-#include "examples/Cassie/cassie_utils.h"
-
+    #include "examples/Cassie/cassie_utils.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
-namespace dairlib {
-namespace systems {
-namespace {
+    namespace dairlib {
+  namespace systems {
+  namespace {
 
-using Eigen::VectorXd;
+  using Eigen::VectorXd;
 
-// class InputSupervisorTest: public ::testing::Test {};
+  // class InputSupervisorTest: public ::testing::Test {};
 
-class InputSupervisorTest : public ::testing::Test {
- protected:
-  InputSupervisorTest()
-      : plant_(drake::multibody::MultibodyPlant<double>(0.0)) {
-    addCassieMultibody(&plant_, nullptr, true /*floating base*/,
-                       "examples/Cassie/urdf/cassie_v2.urdf",
-                       true /*spring model*/, false /*loop closure*/);
-    plant_.Finalize();
-    supervisor_ = std::make_unique<InputSupervisor>(
-        plant_, 10.0, 0.01, min_consecutive_failures, 20.0);
-    context_ = supervisor_->CreateDefaultContext();
-    status_output_ = std::make_unique<TimestampedVector<double>>(1);
-    motor_output_ = std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
-    command_input_ =
-        std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
-    state_input_ = std::make_unique<OutputVector<double>>(
-        plant_.num_positions(), plant_.num_velocities(),
-        plant_.num_actuators());
-    //    controller_switch_input_ = std::make_unique<lcmt_controller_switch>();
-    //    controller_switch_input_->utime = 0;
-    //    controller_switch_input_->channel = "CONTROLLER_CHANNEL";
-    command_input_port_ = supervisor_->get_input_port_command().get_index();
-    state_input_port_ = supervisor_->get_input_port_state().get_index();
-    controller_switch_input_port_ =
-        supervisor_->get_input_port_controller_switch().get_index();
-  }
+  class InputSupervisorTest : public ::testing::Test {
+   protected:
+    InputSupervisorTest()
+        : plant_(drake::multibody::MultibodyPlant<double>(0.0)) {
+      addCassieMultibody(&plant_, nullptr, true /*floating base*/,
+                         "examples/Cassie/urdf/cassie_v2.urdf",
+                         true /*spring model*/, false /*loop closure*/);
+      plant_.Finalize();
+      supervisor_ = std::make_unique<InputSupervisor>(
+          plant_, 10.0, 0.01, min_consecutive_failures, 20.0);
+      context_ = supervisor_->CreateDefaultContext();
+      status_output_ = std::make_unique<TimestampedVector<double>>(1);
+      motor_output_ =
+          std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
+      command_input_ =
+          std::make_unique<TimestampedVector<double>>(plant_.num_actuators());
+      state_input_ = std::make_unique<OutputVector<double>>(
+          plant_.num_positions(), plant_.num_velocities(),
+          plant_.num_actuators());
+      //    controller_switch_input_ =
+      //    std::make_unique<lcmt_controller_switch>();
+      //    controller_switch_input_->utime = 0;
+      //    controller_switch_input_->channel = "CONTROLLER_CHANNEL";
+      command_input_port_ = supervisor_->get_input_port_command().get_index();
+      state_input_port_ = supervisor_->get_input_port_state().get_index();
+      controller_switch_input_port_ =
+          supervisor_->get_input_port_controller_switch().get_index();
+    }
 
-  int command_input_port_;
-  int state_input_port_;
-  int controller_switch_input_port_;
-  drake::multibody::MultibodyPlant<double> plant_;
-  const int min_consecutive_failures = 5;
-  std::unique_ptr<InputSupervisor> supervisor_;
-  std::unique_ptr<TimestampedVector<double>> status_output_;
-  std::unique_ptr<TimestampedVector<double>> motor_output_;
-  std::unique_ptr<TimestampedVector<double>> command_input_;
-  std::unique_ptr<OutputVector<double>> state_input_;
-  //  std::unique_ptr<lcmt_controller_switch> controller_switch_input_;
-  std::unique_ptr<drake::systems::Context<double>> context_;
-};
+    int command_input_port_;
+    int state_input_port_;
+    int controller_switch_input_port_;
+    drake::multibody::MultibodyPlant<double> plant_;
+    const int min_consecutive_failures = 5;
+    std::unique_ptr<InputSupervisor> supervisor_;
+    std::unique_ptr<TimestampedVector<double>> status_output_;
+    std::unique_ptr<TimestampedVector<double>> motor_output_;
+    std::unique_ptr<TimestampedVector<double>> command_input_;
+    std::unique_ptr<OutputVector<double>> state_input_;
+    //  std::unique_ptr<lcmt_controller_switch> controller_switch_input_;
+    std::unique_ptr<drake::systems::Context<double>> context_;
+  };
 
-TEST_F(InputSupervisorTest, StatusBitTest) {
-  double output_bit;
-  VectorXd zero_input = VectorXd::Zero(plant_.num_actuators());
-  command_input_->get_mutable_value() = zero_input;
-  context_->FixInputPort(command_input_port_, *command_input_);
+  TEST_F(InputSupervisorTest, StatusBitTest) {
+    double output_bit;
+    VectorXd zero_input = VectorXd::Zero(plant_.num_actuators());
+    command_input_->get_mutable_value() = zero_input;
 
-  supervisor_->SetStatus(*context_, status_output_.get());
-  output_bit = status_output_->get_value()[0];
-  EXPECT_EQ(output_bit, 0);
+    supervisor_->get_input_port_command().FixValue(context_.get(),
+                                                   *command_input_);
+    supervisor_->SetStatus(*context_, status_output_.get());
+    output_bit = status_output_->get_value()[0];
+    EXPECT_EQ(output_bit, 0);
 
-  VectorXd large_input = 100 * VectorXd::Ones(plant_.num_actuators());
-  command_input_->get_mutable_value() = large_input;
-  context_->FixInputPort(command_input_port_, *command_input_);
-  supervisor_->SetStatus(*context_, status_output_.get());
-  output_bit = status_output_->get_value()[0];
-  EXPECT_EQ(output_bit, 2);
+    VectorXd large_input = 100 * VectorXd::Ones(plant_.num_actuators());
+    command_input_->get_mutable_value() = large_input;
+    supervisor_->get_input_port_command().FixValue(context_.get(),
+                                                   *command_input_);
+    supervisor_->SetStatus(*context_, status_output_.get());
+    output_bit = status_output_->get_value()[0];
+    EXPECT_EQ(output_bit, 2);
 
-  VectorXd high_velocities = 100 * VectorXd::Ones(plant_.num_velocities());
-  state_input_->SetVelocities(high_velocities);
-  context_->FixInputPort(state_input_port_, *state_input_);
-  context_->FixInputPort(
-      controller_switch_input_port_,
-      std::make_unique<drake::Value<lcmt_controller_switch>>());
-  supervisor_->UpdateErrorFlag(*context_,
-                               &context_->get_mutable_discrete_state());
-  supervisor_->SetStatus(*context_, status_output_.get());
-  output_bit = status_output_->get_value()[0];
-  EXPECT_EQ(output_bit, 3);
-
-  // Trigger the min_consecutive_failures
-  for (int i = 0; i < min_consecutive_failures; ++i) {
+    VectorXd high_velocities = 100 * VectorXd::Ones(plant_.num_velocities());
+    state_input_->SetVelocities(high_velocities);
+    supervisor_->get_input_port_state().FixValue(context_.get(), *state_input_);
+    supervisor_->get_input_port_controller_switch().FixValue(
+        context_.get(),
+        *std::make_unique<drake::Value<lcmt_controller_switch>>());
     supervisor_->UpdateErrorFlag(*context_,
                                  &context_->get_mutable_discrete_state());
+    supervisor_->SetStatus(*context_, status_output_.get());
+    output_bit = status_output_->get_value()[0];
+    EXPECT_EQ(output_bit, 3);
+
+    // Trigger the min_consecutive_failures
+    for (int i = 0; i < min_consecutive_failures; ++i) {
+      supervisor_->UpdateErrorFlag(*context_,
+                                   &context_->get_mutable_discrete_state());
+    }
+    supervisor_->SetStatus(*context_, status_output_.get());
+    output_bit = status_output_->get_value()[0];
+    EXPECT_EQ(output_bit, 7);
   }
-  supervisor_->SetStatus(*context_, status_output_.get());
-  output_bit = status_output_->get_value()[0];
-  EXPECT_EQ(output_bit, 7);
-}
 
-TEST_F(InputSupervisorTest, BlendEffortsTest) {
-  VectorXd prev_input = VectorXd::Zero(plant_.num_actuators());
-  VectorXd desired_input = 10 * VectorXd::Ones(plant_.num_actuators());
-  double timestamp = 0.5;
-  context_->FixInputPort(
-      controller_switch_input_port_,
-      std::make_unique<drake::Value<lcmt_controller_switch>>());
-  command_input_->get_mutable_value() = desired_input;
-  command_input_->set_timestamp(timestamp);
-  context_->FixInputPort(command_input_port_, *command_input_);
+  TEST_F(InputSupervisorTest, BlendEffortsTest) {
+    VectorXd prev_input = VectorXd::Zero(plant_.num_actuators());
+    VectorXd desired_input = 10 * VectorXd::Ones(plant_.num_actuators());
+    double blend_start_time = 0.5;
+    double timestamp = 1.0;
+    double blend_duration = 1.0;
+    std::unique_ptr<drake::Value<lcmt_controller_switch>> switch_msg =
+        std::make_unique<drake::Value<lcmt_controller_switch>>();
+    switch_msg->get_mutable_value().blend_duration = blend_duration;
+    switch_msg->get_mutable_value().utime = blend_start_time * 1e6;
+    command_input_->get_mutable_value() = desired_input;
+    command_input_->set_timestamp(timestamp);
+    supervisor_->get_input_port_state().FixValue(context_.get(), *state_input_);
+    supervisor_->get_input_port_controller_switch().FixValue(context_.get(), (drake::AbstractValue&)*switch_msg);
+    supervisor_->get_input_port_command().FixValue(context_.get(), *command_input_);
+    supervisor_->UpdateErrorFlag(*context_,
+                                 &context_->get_mutable_discrete_state());
+    supervisor_->SetMotorTorques(*context_, motor_output_.get());
 
-  supervisor_->SetMotorTorques(*context_, motor_output_.get());
+    VectorXd output_from_supervisor = motor_output_->get_value();
+    double alpha = (timestamp - blend_start_time) / blend_duration;
 
-  VectorXd output_from_supervisor = motor_output_->get_value();
-  double alpha = (timestamp - 0.0) / kFilterDuration;
-  EXPECT_EQ(output_from_supervisor, alpha * desired_input);
-}
+    EXPECT_EQ(context_->get_discrete_state().get_vector(1)[0],
+              blend_start_time);
+    EXPECT_EQ(output_from_supervisor, alpha * desired_input);
+  }
 
-}  // namespace
-}  // namespace systems
+  }  // namespace
+  }  // namespace systems
 }  // namespace dairlib
 
 int main(int argc, char** argv) {

--- a/lcmtypes/lcmt_controller_switch.lcm
+++ b/lcmtypes/lcmt_controller_switch.lcm
@@ -4,4 +4,5 @@ struct lcmt_controller_switch
 {
   int64_t utime;
   string channel;
+  double blend_duration;
 }

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "dairlib/lcmt_controller_switch.hpp"
+
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
@@ -11,8 +13,6 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/serializer.h"
-
-#include "dairlib/lcmt_controller_switch.hpp"
 
 namespace dairlib {
 namespace systems {
@@ -72,7 +72,7 @@ class LcmDrivenLoop {
                 const std::string& input_channel, bool is_forced_publish)
       : LcmDrivenLoop(drake_lcm, std::move(diagram), lcm_parser,
                       std::vector<std::string>(1, input_channel), input_channel,
-                      "", is_forced_publish){};
+                      nullptr, is_forced_publish){};
 
   /// Constructor for multi-input LcmDrivenLoop
   ///     @param drake_lcm DrakeLcm
@@ -88,9 +88,11 @@ class LcmDrivenLoop {
                 const drake::systems::LeafSystem<double>* lcm_parser,
                 std::vector<std::string> input_channels,
                 const std::string& active_channel,
-                const std::string& switch_channel, bool is_forced_publish)
+                const drake::systems::lcm::LcmSubscriberSystem* switch_sub,
+                bool is_forced_publish)
       : drake_lcm_(drake_lcm),
         lcm_parser_(lcm_parser),
+        switch_sub_(switch_sub),
         is_forced_publish_(is_forced_publish) {
     // Move simulator
     if (!diagram->get_name().empty()) {
@@ -103,9 +105,10 @@ class LcmDrivenLoop {
     // Create subscriber for the switch (in the case of multi-input)
     DRAKE_DEMAND(!input_channels.empty());
     if (input_channels.size() > 1) {
-      DRAKE_DEMAND(!switch_channel.empty());
-      switch_sub_ = std::make_unique<drake::lcm::Subscriber<SwitchMessageType>>(
-          drake_lcm_, switch_channel);
+      //      DRAKE_DEMAND(!switch_channel.empty());
+      //      switch_sub_ =
+      //      std::make_unique<drake::lcm::Subscriber<SwitchMessageType>>(
+      //          drake_lcm_, switch_channel);
     }
 
     // Create subscribers for inputs
@@ -143,9 +146,7 @@ class LcmDrivenLoop {
                       "", is_forced_publish){};
 
   // Getters for diagram and its context
-  drake::systems::Diagram<double>* get_diagram() {
-    return diagram_ptr_;
-  }
+  drake::systems::Diagram<double>* get_diagram() { return diagram_ptr_; }
   drake::systems::Context<double>& get_diagram_mutable_context() {
     return simulator_->get_mutable_context();
   }
@@ -199,12 +200,46 @@ class LcmDrivenLoop {
           is_new_input_message = true;
         }
         if (switch_sub_ != nullptr) {
-          if (switch_sub_->count() > 0) {
+          if (switch_sub_->GetInternalMessageCount() > switch_msg_count_) {
             is_new_switch_message = true;
+            std::cout << switch_sub_->GetInternalMessageCount() << " messages in context\n";
           }
         }
         return is_new_input_message || is_new_switch_message;
       });
+
+
+      // Update the name of the active channel if there are multiple inputs and
+      // there is new switch message
+      if (is_new_switch_message) {
+        // Check if the channel name is a key of the map. If it is, we update
+        // the active channel name and clear switch_sub_'s message. If it is
+        // not we do not update the active channel name.
+        auto switch_signal = std::make_unique<drake::Value<lcmt_controller_switch>>();
+        switch_sub_->WaitForMessage(switch_msg_count_, switch_signal.get(), 1e-3);
+        if (name_to_input_sub_map_.count(switch_signal->get_value().channel) == 1) {
+          active_channel_ = switch_signal->get_value().channel;
+        } else {
+          std::cout << switch_signal->get_value().channel << " doesn't exist\n";
+        }
+        switch_msg_count_ = switch_sub_->GetInternalMessageCount();
+
+        simulator_->AdvanceTo(time);
+        if (is_forced_publish_) {
+          // Force-publish via the diagram
+          diagram_ptr_->Publish(diagram_context);
+        }
+
+        // Clear messages in the switch channel
+//        switch_sub_->clear();
+
+        // Clear messages in the new input channel if we just switched input
+        // channel in the current loop
+        if (previous_active_channel_name.compare(active_channel_) != 0) {
+          name_to_input_sub_map_.at(active_channel_).clear();
+        }
+      }
+      previous_active_channel_name = active_channel_;
 
       // Update the diagram context when there is new input message
       if (is_new_input_message) {
@@ -218,7 +253,8 @@ class LcmDrivenLoop {
         }
 
         // Get message time from the active channel to advance
-        time = name_to_input_sub_map_.at(active_channel_).message().utime * 1e-6;
+        time =
+            name_to_input_sub_map_.at(active_channel_).message().utime * 1e-6;
 
         // Check if we are very far ahead or behind
         // (likely due to a restart of the driving clock)
@@ -242,28 +278,7 @@ class LcmDrivenLoop {
         name_to_input_sub_map_.at(active_channel_).clear();
       }
 
-      // Update the name of the active channel if there are multiple inputs and
-      // there is new switch message
-      if (is_new_switch_message) {
-        // Check if the channel name is a key of the map. If it is, we update
-        // the active channel name and clear switch_sub_'s message. If it is
-        // not we do not update the active channel name.
-        if (name_to_input_sub_map_.count(switch_sub_->message().channel) == 1) {
-          active_channel_ = switch_sub_->message().channel;
-        } else {
-          std::cout << switch_sub_->message().channel << " doesn't exist\n";
-        }
 
-        // Clear messages in the switch channel
-        switch_sub_->clear();
-
-        // Clear messages in the new input channel if we just switched input
-        // channel in the current loop
-        if (previous_active_channel_name.compare(active_channel_) != 0) {
-          name_to_input_sub_map_.at(active_channel_).clear();
-        }
-      }
-      previous_active_channel_name = active_channel_;
     }
   };
 
@@ -273,10 +288,12 @@ class LcmDrivenLoop {
   const drake::systems::LeafSystem<double>* lcm_parser_;
   std::unique_ptr<drake::systems::Simulator<double>> simulator_;
 
+  int switch_msg_count_ = 0;
   std::string diagram_name_ = "diagram";
   std::string active_channel_;
-  std::unique_ptr<drake::lcm::Subscriber<SwitchMessageType>> switch_sub_ =
-      nullptr;
+  //  std::unique_ptr<drake::lcm::Subscriber<SwitchMessageType>> switch_sub_ =
+  //      nullptr;
+  const drake::systems::lcm::LcmSubscriberSystem* switch_sub_ = nullptr;
   std::map<std::string, drake::lcm::Subscriber<InputMessageType>>
       name_to_input_sub_map_;
 

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -142,6 +142,12 @@ class LcmDrivenLoop {
                       std::vector<std::string>(1, input_channel), input_channel,
                       "", is_forced_publish){};
 
+  // Getters for diagram and its context
+  drake::systems::Diagram<double>* get_diagram() { return diagram_ptr_; }
+  drake::systems::Context<double>& get_diagram_mutable_context() {
+    return simulator_->get_mutable_context();
+  }
+
   // Start simulating the diagram
   void Simulate(double end_time = std::numeric_limits<double>::infinity()) {
     // Get mutable contexts
@@ -249,8 +255,10 @@ class LcmDrivenLoop {
 
         // Advancing the simulator here ensure that the switch message is
         // received in the leaf systems without the encountering a race
-        // condition. Still need to investigate the exact sequence that causes
-        // the race condition
+        // condition when constructing a separate LcmSubscriberSystem that
+        // listens to the same channel. Advancing the simulator, ensures that
+        // the LCM message used here successfully arrives at the input port of
+        // the other LcmSubscriberSystem
         simulator_->AdvanceTo(time);
         if (is_forced_publish_) {
           // Force-publish via the diagram

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -72,7 +72,7 @@ class LcmDrivenLoop {
                 const std::string& input_channel, bool is_forced_publish)
       : LcmDrivenLoop(drake_lcm, std::move(diagram), lcm_parser,
                       std::vector<std::string>(1, input_channel), input_channel,
-                      nullptr, is_forced_publish){};
+                      "", is_forced_publish){};
 
   /// Constructor for multi-input LcmDrivenLoop
   ///     @param drake_lcm DrakeLcm
@@ -88,11 +88,9 @@ class LcmDrivenLoop {
                 const drake::systems::LeafSystem<double>* lcm_parser,
                 std::vector<std::string> input_channels,
                 const std::string& active_channel,
-                const drake::systems::lcm::LcmSubscriberSystem* switch_sub,
-                bool is_forced_publish)
+                const std::string& switch_channel, bool is_forced_publish)
       : drake_lcm_(drake_lcm),
         lcm_parser_(lcm_parser),
-        switch_sub_(switch_sub),
         is_forced_publish_(is_forced_publish) {
     // Move simulator
     if (!diagram->get_name().empty()) {
@@ -105,10 +103,9 @@ class LcmDrivenLoop {
     // Create subscriber for the switch (in the case of multi-input)
     DRAKE_DEMAND(!input_channels.empty());
     if (input_channels.size() > 1) {
-      //      DRAKE_DEMAND(!switch_channel.empty());
-      //      switch_sub_ =
-      //      std::make_unique<drake::lcm::Subscriber<SwitchMessageType>>(
-      //          drake_lcm_, switch_channel);
+      DRAKE_DEMAND(!switch_channel.empty());
+      switch_sub_ = std::make_unique<drake::lcm::Subscriber<SwitchMessageType>>(
+          drake_lcm_, switch_channel);
     }
 
     // Create subscribers for inputs
@@ -144,12 +141,6 @@ class LcmDrivenLoop {
       : LcmDrivenLoop(drake_lcm, std::move(diagram), nullptr,
                       std::vector<std::string>(1, input_channel), input_channel,
                       "", is_forced_publish){};
-
-  // Getters for diagram and its context
-  drake::systems::Diagram<double>* get_diagram() { return diagram_ptr_; }
-  drake::systems::Context<double>& get_diagram_mutable_context() {
-    return simulator_->get_mutable_context();
-  }
 
   // Start simulating the diagram
   void Simulate(double end_time = std::numeric_limits<double>::infinity()) {
@@ -200,46 +191,12 @@ class LcmDrivenLoop {
           is_new_input_message = true;
         }
         if (switch_sub_ != nullptr) {
-          if (switch_sub_->GetInternalMessageCount() > switch_msg_count_) {
+          if (switch_sub_->count() > 0) {
             is_new_switch_message = true;
-            std::cout << switch_sub_->GetInternalMessageCount() << " messages in context\n";
           }
         }
         return is_new_input_message || is_new_switch_message;
       });
-
-
-      // Update the name of the active channel if there are multiple inputs and
-      // there is new switch message
-      if (is_new_switch_message) {
-        // Check if the channel name is a key of the map. If it is, we update
-        // the active channel name and clear switch_sub_'s message. If it is
-        // not we do not update the active channel name.
-        auto switch_signal = std::make_unique<drake::Value<lcmt_controller_switch>>();
-        switch_sub_->WaitForMessage(switch_msg_count_, switch_signal.get(), 1e-3);
-        if (name_to_input_sub_map_.count(switch_signal->get_value().channel) == 1) {
-          active_channel_ = switch_signal->get_value().channel;
-        } else {
-          std::cout << switch_signal->get_value().channel << " doesn't exist\n";
-        }
-        switch_msg_count_ = switch_sub_->GetInternalMessageCount();
-
-        simulator_->AdvanceTo(time);
-        if (is_forced_publish_) {
-          // Force-publish via the diagram
-          diagram_ptr_->Publish(diagram_context);
-        }
-
-        // Clear messages in the switch channel
-//        switch_sub_->clear();
-
-        // Clear messages in the new input channel if we just switched input
-        // channel in the current loop
-        if (previous_active_channel_name.compare(active_channel_) != 0) {
-          name_to_input_sub_map_.at(active_channel_).clear();
-        }
-      }
-      previous_active_channel_name = active_channel_;
 
       // Update the diagram context when there is new input message
       if (is_new_input_message) {
@@ -278,7 +235,38 @@ class LcmDrivenLoop {
         name_to_input_sub_map_.at(active_channel_).clear();
       }
 
+      // Update the name of the active channel if there are multiple inputs and
+      // there is new switch message
+      if (is_new_switch_message) {
+        // Check if the channel name is a key of the map. If it is, we update
+        // the active channel name and clear switch_sub_'s message. If it is
+        // not we do not update the active channel name.
+        if (name_to_input_sub_map_.count(switch_sub_->message().channel) == 1) {
+          active_channel_ = switch_sub_->message().channel;
+        } else {
+          std::cout << switch_sub_->message().channel << " doesn't exist\n";
+        }
 
+        // Advancing the simulator here ensure that the switch message is
+        // received in the leaf systems without the encountering a race
+        // condition. Still need to investigate the exact sequence that causes
+        // the race condition
+        simulator_->AdvanceTo(time);
+        if (is_forced_publish_) {
+          // Force-publish via the diagram
+          diagram_ptr_->Publish(diagram_context);
+        }
+
+        // Clear messages in the switch channel
+        switch_sub_->clear();
+
+        // Clear messages in the new input channel if we just switched input
+        // channel in the current loop
+        if (previous_active_channel_name.compare(active_channel_) != 0) {
+          name_to_input_sub_map_.at(active_channel_).clear();
+        }
+      }
+      previous_active_channel_name = active_channel_;
     }
   };
 
@@ -288,12 +276,10 @@ class LcmDrivenLoop {
   const drake::systems::LeafSystem<double>* lcm_parser_;
   std::unique_ptr<drake::systems::Simulator<double>> simulator_;
 
-  int switch_msg_count_ = 0;
   std::string diagram_name_ = "diagram";
   std::string active_channel_;
-  //  std::unique_ptr<drake::lcm::Subscriber<SwitchMessageType>> switch_sub_ =
-  //      nullptr;
-  const drake::systems::lcm::LcmSubscriberSystem* switch_sub_ = nullptr;
+  std::unique_ptr<drake::lcm::Subscriber<SwitchMessageType>> switch_sub_ =
+      nullptr;
   std::map<std::string, drake::lcm::Subscriber<InputMessageType>>
       name_to_input_sub_map_;
 


### PR DESCRIPTION
Blends efforts after a controller switch message. This is to smoothly transition between controllers.

One issue that still needs to be fixed:
- Occasionally the "previous efforts" stored in `discrete_state->get_mutable_vector(prev_efforts_index_)` is written with the new controller efforts instead of the old controller efforts

Open to any suggestions about a fix for this. It looks like there's a race condition, but I don't see a clear way to avoid it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/199)
<!-- Reviewable:end -->
