### PR TITLE
adding edge case for exponentialpluspiecewisepolynomial

### DIFF
--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -55,8 +55,14 @@ bool OscTrackingData::Update(
     // Careful: must update y_des_ before calling UpdateYAndError()
     // Update desired output
     y_des_ = traj.value(t);
-    ydot_des_ = traj.EvalDerivative(t, 1);
-    yddot_des_ = traj.EvalDerivative(t, 2);
+    if(traj.has_derivative()){
+      ydot_des_ = traj.EvalDerivative(t, 1);
+      yddot_des_ = traj.EvalDerivative(t, 2);
+    }
+    else{
+      ydot_des_ = traj.MakeDerivative(1)->value(t);
+      yddot_des_ = traj.MakeDerivative(2)->value(t);
+    }
 
     // Update feedback output (Calling virtual methods)
     UpdateYAndError(x_w_spr, context_w_spr);

--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -1,8 +1,11 @@
 #include "systems/controllers/osc/osc_tracking_data.h"
 
 #include <math.h>
+
 #include <algorithm>
+
 #include <drake/multibody/plant/multibody_plant.h>
+
 #include "multibody/multibody_utils.h"
 
 using std::cout;
@@ -55,11 +58,13 @@ bool OscTrackingData::Update(
     // Careful: must update y_des_ before calling UpdateYAndError()
     // Update desired output
     y_des_ = traj.value(t);
-    if(traj.has_derivative()){
+    if (traj.has_derivative()) {
       ydot_des_ = traj.EvalDerivative(t, 1);
       yddot_des_ = traj.EvalDerivative(t, 2);
     }
-    else{
+    // TODO (yangwill): Remove this edge case after EvalDerivative has been
+    // implemented for ExponentialPlusPiecewisePolynomial
+    else {
       ydot_des_ = traj.MakeDerivative(1)->value(t);
       yddot_des_ = traj.MakeDerivative(2)->value(t);
     }


### PR DESCRIPTION
`ExponentialPlusPiecewisePolynomial` extends from `PiecewiseTrajectory` and not `PiecewisePolynomial` and therefore does not support `EvalDerivative`. This adds an edge case just for `ExponentialPlusPiecewisePolynomial` which is used by `lipm_traj_gen.cc`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/201)
<!-- Reviewable:end -->
