### PR TITLE
Use spring cassie model in OSC walking

### DIFF
--- a/examples/Cassie/BUILD.bazel
+++ b/examples/Cassie/BUILD.bazel
@@ -327,6 +327,7 @@ cc_binary(
         ":simulator_drift",
         "//examples/Cassie/osc",
         "//multibody:utils",
+        "//multibody/kinematic",
         "//systems:robot_lcm_systems",
         "//systems/framework:lcm_driven_loop",
         "//systems/primitives",

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -7,6 +7,7 @@
 #include "examples/Cassie/osc/heading_traj_generator.h"
 #include "examples/Cassie/osc/high_level_command.h"
 #include "examples/Cassie/simulator_drift.h"
+#include "multibody/kinematic/fixed_joint_evaluator.h"
 #include "multibody/kinematic/kinematic_evaluator_set.h"
 #include "multibody/multibody_utils.h"
 #include "systems/controllers/cp_traj_gen.h"
@@ -42,6 +43,8 @@ using systems::controllers::JointSpaceTrackingData;
 using systems::controllers::RotTaskSpaceTrackingData;
 using systems::controllers::TransTaskSpaceTrackingData;
 
+using multibody::FixedJointEvaluator;
+
 DEFINE_double(drift_rate, 0.0, "Drift rate for floating-base state");
 
 DEFINE_string(channel_x, "CASSIE_STATE_SIMULATION",
@@ -73,15 +76,8 @@ int DoMain(int argc, char* argv[]) {
                      "examples/Cassie/urdf/cassie_v2.urdf",
                      true /*spring model*/, false /*loop closure*/);
   plant_w_spr.Finalize();
-  // Build fix-spring Cassie MBP
-  drake::multibody::MultibodyPlant<double> plant_wo_spr(0.0);
-  addCassieMultibody(&plant_wo_spr, nullptr, true,
-                     "examples/Cassie/urdf/cassie_fixed_springs.urdf", false,
-                     false);
-  plant_wo_spr.Finalize();
 
   auto context_w_spr = plant_w_spr.CreateDefaultContext();
-  auto context_wo_spr = plant_wo_spr.CreateDefaultContext();
 
   // Build the controller diagram
   DiagramBuilder<double> builder;
@@ -89,7 +85,7 @@ int DoMain(int argc, char* argv[]) {
   drake::lcm::DrakeLcm lcm_local("udpm://239.255.76.67:7667?ttl=0");
 
   // Get contact frames and position (doesn't matter whether we use
-  // plant_w_spr or plant_wo_spr because the contact frames exit in both
+  // plant_w_spr or plant_wospr because the contact frames exit in both
   // plants)
   auto left_toe = LeftToeFront(plant_w_spr);
   auto left_heel = LeftToeRear(plant_w_spr);
@@ -255,20 +251,38 @@ int DoMain(int argc, char* argv[]) {
 
   // Create Operational space control
   auto osc = builder.AddSystem<systems::controllers::OperationalSpaceControl>(
-      plant_w_spr, plant_wo_spr, context_w_spr.get(), context_wo_spr.get(),
+      plant_w_spr, plant_w_spr, context_w_spr.get(), context_w_spr.get(),
       true, FLAGS_print_osc /*print_tracking_info*/);
 
   // Cost
-  int n_v = plant_wo_spr.num_velocities();
+  int n_v = plant_w_spr.num_velocities();
   MatrixXd Q_accel = 2 * MatrixXd::Identity(n_v, n_v);
   osc->SetAccelerationCostForAllJoints(Q_accel);
 
   // Distance constraint
-  multibody::KinematicEvaluatorSet<double> evaluators(plant_wo_spr);
-  auto left_loop = LeftLoopClosureEvaluator(plant_wo_spr);
-  auto right_loop = RightLoopClosureEvaluator(plant_wo_spr);
+  multibody::KinematicEvaluatorSet<double> evaluators(plant_w_spr);
+  auto left_loop = LeftLoopClosureEvaluator(plant_w_spr);
+  auto right_loop = RightLoopClosureEvaluator(plant_w_spr);
   evaluators.add_evaluator(&left_loop);
   evaluators.add_evaluator(&right_loop);
+  auto pos_idx_map = multibody::makeNameToPositionsMap(plant_w_spr);
+  auto vel_idx_map = multibody::makeNameToVelocitiesMap(plant_w_spr);
+  auto left_fixed_knee_spring =
+      FixedJointEvaluator(plant_w_spr, pos_idx_map.at("knee_joint_left"),
+                          vel_idx_map.at("knee_joint_leftdot"), 0);
+  auto right_fixed_knee_spring =
+      FixedJointEvaluator(plant_w_spr, pos_idx_map.at("knee_joint_right"),
+                          vel_idx_map.at("knee_joint_rightdot"), 0);
+  auto left_fixed_ankle_spring = FixedJointEvaluator(
+      plant_w_spr, pos_idx_map.at("ankle_spring_joint_left"),
+      vel_idx_map.at("ankle_spring_joint_leftdot"), 0);
+  auto right_fixed_ankle_spring = FixedJointEvaluator(
+      plant_w_spr, pos_idx_map.at("ankle_spring_joint_right"),
+      vel_idx_map.at("ankle_spring_joint_rightdot"), 0);
+  evaluators.add_evaluator(&left_fixed_knee_spring);
+  evaluators.add_evaluator(&right_fixed_knee_spring);
+  evaluators.add_evaluator(&left_fixed_ankle_spring);
+  evaluators.add_evaluator(&right_fixed_ankle_spring);
   osc->AddKinematicConstraint(&evaluators);
 
   // Soft constraint
@@ -281,16 +295,16 @@ int DoMain(int argc, char* argv[]) {
   osc->SetContactFriction(mu);
   // Add contact points (The position doesn't matter. It's not used in OSC)
   auto left_toe_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_spr, left_toe.first, left_toe.second, Matrix3d::Identity(),
+      plant_w_spr, left_toe.first, left_toe.second, Matrix3d::Identity(),
       Vector3d::Zero(), {1, 2});
   auto left_heel_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_spr, left_heel.first, left_heel.second, Matrix3d::Identity(),
+      plant_w_spr, left_heel.first, left_heel.second, Matrix3d::Identity(),
       Vector3d::Zero(), {0, 1, 2});
   auto right_toe_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_spr, right_toe.first, right_toe.second, Matrix3d::Identity(),
+      plant_w_spr, right_toe.first, right_toe.second, Matrix3d::Identity(),
       Vector3d::Zero(), {1, 2});
   auto right_heel_evaluator = multibody::WorldPointEvaluator(
-      plant_wo_spr, right_heel.first, right_heel.second, Matrix3d::Identity(),
+      plant_w_spr, right_heel.first, right_heel.second, Matrix3d::Identity(),
       Vector3d::Zero(), {0, 1, 2});
   osc->AddStateAndContactPoint(left_stance_state, &left_toe_evaluator);
   osc->AddStateAndContactPoint(left_stance_state, &left_heel_evaluator);
@@ -308,7 +322,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_p_sw_ft = 100 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_sw_ft = 10 * MatrixXd::Identity(3, 3);
   TransTaskSpaceTrackingData swing_foot_traj(
-      "cp_traj", K_p_sw_ft, K_d_sw_ft, W_swing_foot, plant_w_spr, plant_wo_spr);
+      "cp_traj", K_p_sw_ft, K_d_sw_ft, W_swing_foot, plant_w_spr, plant_w_spr);
   swing_foot_traj.AddStateAndPointToTrack(left_stance_state, "toe_right");
   swing_foot_traj.AddStateAndPointToTrack(right_stance_state, "toe_left");
   osc->AddTrackingData(&swing_foot_traj);
@@ -320,7 +334,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_p_com = 50 * MatrixXd::Identity(3, 3);
   MatrixXd K_d_com = 10 * MatrixXd::Identity(3, 3);
   ComTrackingData center_of_mass_traj("lipm_traj", K_p_com, K_d_com, W_com,
-                                      plant_w_spr, plant_wo_spr);
+                                      plant_w_spr, plant_w_spr);
   osc->AddTrackingData(&center_of_mass_traj);
   // Pelvis rotation tracking (pitch and roll)
   double w_pelvis_balance = 200;
@@ -337,7 +351,7 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis_balance(1, 1) = k_d_pelvis_balance;
   RotTaskSpaceTrackingData pelvis_balance_traj(
       "pelvis_balance_traj", K_p_pelvis_balance, K_d_pelvis_balance,
-      W_pelvis_balance, plant_w_spr, plant_wo_spr);
+      W_pelvis_balance, plant_w_spr, plant_w_spr);
   pelvis_balance_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_balance_traj);
   // Pelvis rotation tracking (yaw)
@@ -352,7 +366,7 @@ int DoMain(int argc, char* argv[]) {
   K_d_pelvis_heading(2, 2) = k_d_heading;
   RotTaskSpaceTrackingData pelvis_heading_traj(
       "pelvis_heading_traj", K_p_pelvis_heading, K_d_pelvis_heading,
-      W_pelvis_heading, plant_w_spr, plant_wo_spr);
+      W_pelvis_heading, plant_w_spr, plant_w_spr);
   pelvis_heading_traj.AddFrameToTrack("pelvis");
   osc->AddTrackingData(&pelvis_heading_traj, 0.1);  // 0.05
   // Swing toe joint tracking (Currently use fix position)
@@ -363,7 +377,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_swing_toe = 20 * MatrixXd::Identity(1, 1);
   JointSpaceTrackingData swing_toe_traj("swing_toe_traj", K_p_swing_toe,
                                         K_d_swing_toe, W_swing_toe, plant_w_spr,
-                                        plant_wo_spr);
+                                        plant_w_spr);
   swing_toe_traj.AddStateAndJointToTrack(left_stance_state, "toe_right",
                                          "toe_rightdot");
   swing_toe_traj.AddStateAndJointToTrack(right_stance_state, "toe_left",
@@ -375,7 +389,7 @@ int DoMain(int argc, char* argv[]) {
   MatrixXd K_d_hip_yaw = 160 * MatrixXd::Identity(1, 1);
   JointSpaceTrackingData swing_hip_yaw_traj("swing_hip_yaw_traj", K_p_hip_yaw,
                                             K_d_hip_yaw, W_hip_yaw, plant_w_spr,
-                                            plant_wo_spr);
+                                            plant_w_spr);
   swing_hip_yaw_traj.AddStateAndJointToTrack(left_stance_state, "hip_yaw_right",
                                              "hip_yaw_rightdot");
   swing_hip_yaw_traj.AddStateAndJointToTrack(right_stance_state, "hip_yaw_left",

--- a/multibody/kinematic/BUILD.bazel
+++ b/multibody/kinematic/BUILD.bazel
@@ -7,16 +7,18 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "kinematic",
     srcs = [
+        "distance_evaluator.cc",
+        "fixed_joint_evaluator.cc",
         "kinematic_evaluator.cc",
         "kinematic_evaluator_set.cc",
         "world_point_evaluator.cc",
-        "distance_evaluator.cc",
     ],
     hdrs = [
+        "distance_evaluator.h",
+        "fixed_joint_evaluator.h",
         "kinematic_evaluator.h",
         "kinematic_evaluator_set.h",
         "world_point_evaluator.h",
-        "distance_evaluator.h",
     ],
     deps = [
         "//solvers:constraint_factory",
@@ -48,13 +50,14 @@ cc_binary(
     deps = [
         ":kinematic",
         "//common",
-        "//examples/Cassie:cassie_utils",
         "//examples/Cassie:cassie_urdf",
+        "//examples/Cassie:cassie_utils",
     ],
 )
 
 cc_test(
     name = "kinematic_evaluator_test",
+    size = "small",
     srcs = [
         "test/kinematic_evaluator_test.cc",
     ],
@@ -65,5 +68,4 @@ cc_test(
         "@drake//common/test_utilities",
         "@gtest//:main",
     ],
-    size = "small",
 )

--- a/multibody/kinematic/fixed_joint_evaluator.cc
+++ b/multibody/kinematic/fixed_joint_evaluator.cc
@@ -1,15 +1,9 @@
 #include "multibody/kinematic/fixed_joint_evaluator.h"
 
-#include "drake/math/orthonormal_basis.h"
-
-using drake::Matrix3X;
 using drake::MatrixX;
-using drake::Vector3;
 using drake::VectorX;
-using drake::multibody::Frame;
 using drake::multibody::MultibodyPlant;
 using drake::systems::Context;
-using Eigen::Vector3d;
 
 namespace dairlib {
 namespace multibody {

--- a/multibody/kinematic/fixed_joint_evaluator.cc
+++ b/multibody/kinematic/fixed_joint_evaluator.cc
@@ -21,7 +21,10 @@ FixedJointEvaluator<T>::FixedJointEvaluator(const MultibodyPlant<T>& plant,
     : KinematicEvaluator<T>(plant, 1),
       pos_idx_(pos_idx),
       vel_idx_(vel_idx),
-      pos_value_(pos_value) {}
+      pos_value_(pos_value) {
+  J_ = MatrixX<T>::Zero(1, plant.num_velocities());
+  J_(0, vel_idx_) = 1;
+}
 
 template <typename T>
 VectorX<T> FixedJointEvaluator<T>::EvalFull(const Context<T>& context) const {
@@ -34,9 +37,7 @@ VectorX<T> FixedJointEvaluator<T>::EvalFull(const Context<T>& context) const {
 template <typename T>
 void FixedJointEvaluator<T>::EvalFullJacobian(
     const Context<T>& context, drake::EigenPtr<MatrixX<T>> J) const {
-  MatrixX<T> J_temp = MatrixX<T>::Zero(1, plant().num_velocities());
-  J_temp(0, vel_idx_) = 1;
-  *J = J_temp;
+  *J = J_;
 }
 
 template <typename T>

--- a/multibody/kinematic/fixed_joint_evaluator.cc
+++ b/multibody/kinematic/fixed_joint_evaluator.cc
@@ -20,10 +20,9 @@ FixedJointEvaluator<T>::FixedJointEvaluator(const MultibodyPlant<T>& plant,
                                             double pos_value)
     : KinematicEvaluator<T>(plant, 1),
       pos_idx_(pos_idx),
-      vel_idx_(vel_idx),
       pos_value_(pos_value) {
   J_ = MatrixX<T>::Zero(1, plant.num_velocities());
-  J_(0, vel_idx_) = 1;
+  J_(0, vel_idx) = 1;
 }
 
 template <typename T>

--- a/multibody/kinematic/fixed_joint_evaluator.cc
+++ b/multibody/kinematic/fixed_joint_evaluator.cc
@@ -1,0 +1,52 @@
+#include "multibody/kinematic/fixed_joint_evaluator.h"
+
+#include "drake/math/orthonormal_basis.h"
+
+using drake::Matrix3X;
+using drake::MatrixX;
+using drake::Vector3;
+using drake::VectorX;
+using drake::multibody::Frame;
+using drake::multibody::MultibodyPlant;
+using drake::systems::Context;
+using Eigen::Vector3d;
+
+namespace dairlib {
+namespace multibody {
+
+template <typename T>
+FixedJointEvaluator<T>::FixedJointEvaluator(const MultibodyPlant<T>& plant,
+                                            int pos_idx, int vel_idx,
+                                            double pos_value)
+    : KinematicEvaluator<T>(plant, 1),
+      pos_idx_(pos_idx),
+      vel_idx_(vel_idx),
+      pos_value_(pos_value) {}
+
+template <typename T>
+VectorX<T> FixedJointEvaluator<T>::EvalFull(const Context<T>& context) const {
+  // Transform points A and B to world frame
+  VectorX<T> difference(1);
+  difference << plant().GetPositions(context)(pos_idx_) - pos_value_;
+  return difference;
+}
+
+template <typename T>
+void FixedJointEvaluator<T>::EvalFullJacobian(
+    const Context<T>& context, drake::EigenPtr<MatrixX<T>> J) const {
+  MatrixX<T> J_temp = MatrixX<T>::Zero(1, plant().num_velocities());
+  J_temp(0, vel_idx_) = 1;
+  *J = J_temp;
+}
+
+template <typename T>
+VectorX<T> FixedJointEvaluator<T>::EvalFullJacobianDotTimesV(
+    const Context<T>& context) const {
+  return VectorX<T>::Zero(1);
+}
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::dairlib::multibody::FixedJointEvaluator)
+
+}  // namespace multibody
+}  // namespace dairlib

--- a/multibody/kinematic/fixed_joint_evaluator.cc
+++ b/multibody/kinematic/fixed_joint_evaluator.cc
@@ -27,7 +27,6 @@ FixedJointEvaluator<T>::FixedJointEvaluator(const MultibodyPlant<T>& plant,
 
 template <typename T>
 VectorX<T> FixedJointEvaluator<T>::EvalFull(const Context<T>& context) const {
-  // Transform points A and B to world frame
   VectorX<T> difference(1);
   difference << plant().GetPositions(context)(pos_idx_) - pos_value_;
   return difference;

--- a/multibody/kinematic/fixed_joint_evaluator.h
+++ b/multibody/kinematic/fixed_joint_evaluator.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "multibody/kinematic/kinematic_evaluator.h"
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/context.h"
+
+namespace dairlib {
+namespace multibody {
+
+/// Simple evaluator for a one dimensional fixed joint
+template <typename T>
+class FixedJointEvaluator : public KinematicEvaluator<T> {
+ public:
+  /// Constructor for FixedJointEvaluator
+  /// @param plant
+  /// @param pos_idx index in the generalized position
+  /// @param vel_idx index in the generalized velocity
+
+  FixedJointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
+                      int pos_idx, int vel_idx, double pos_value);
+
+  drake::VectorX<T> EvalFull(
+      const drake::systems::Context<T>& context) const override;
+
+  void EvalFullJacobian(const drake::systems::Context<T>& context,
+                        drake::EigenPtr<drake::MatrixX<T>> J) const override;
+
+  drake::VectorX<T> EvalFullJacobianDotTimesV(
+      const drake::systems::Context<T>& context) const override;
+
+  using KinematicEvaluator<T>::EvalFullJacobian;
+  using KinematicEvaluator<T>::plant;
+
+ private:
+  const int pos_idx_;
+  const int vel_idx_;
+  const double pos_value_;
+};
+
+}  // namespace multibody
+}  // namespace dairlib

--- a/multibody/kinematic/fixed_joint_evaluator.h
+++ b/multibody/kinematic/fixed_joint_evaluator.h
@@ -33,7 +33,6 @@ class FixedJointEvaluator : public KinematicEvaluator<T> {
 
  private:
   const int pos_idx_;
-  const int vel_idx_;
   const double pos_value_;
   drake::MatrixX<T> J_;
 };

--- a/multibody/kinematic/fixed_joint_evaluator.h
+++ b/multibody/kinematic/fixed_joint_evaluator.h
@@ -35,6 +35,7 @@ class FixedJointEvaluator : public KinematicEvaluator<T> {
   const int pos_idx_;
   const int vel_idx_;
   const double pos_value_;
+  drake::MatrixX<T> J_;
 };
 
 }  // namespace multibody

--- a/multibody/kinematic/fixed_joint_evaluator.h
+++ b/multibody/kinematic/fixed_joint_evaluator.h
@@ -13,8 +13,8 @@ class FixedJointEvaluator : public KinematicEvaluator<T> {
  public:
   /// Constructor for FixedJointEvaluator
   /// @param plant
-  /// @param pos_idx index in the generalized position
-  /// @param vel_idx index in the generalized velocity
+  /// @param pos_idx index in the generalized positions
+  /// @param vel_idx index in the generalized velocities
 
   FixedJointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
                       int pos_idx, int vel_idx, double pos_value);


### PR DESCRIPTION
After adding a constraint on spring acceleration, we can use `cassie_v2.urdf` in OSC walking. 

There is a bug currently in `osc_tracking_data` which #201 is fixing, so we need to merge with #201 to run the walking controller without segfault.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/202)
<!-- Reviewable:end -->
