### PR TITLE
Fixing size bug from saving decision variables

### DIFF
--- a/bindings/pydairlib/lcm_trajectory_py.cc
+++ b/bindings/pydairlib/lcm_trajectory_py.cc
@@ -3,7 +3,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "dairlib/lcmt_saved_traj.hpp"
 #include "lcm/dircon_saved_trajectory.h"
 #include "lcm/lcm_trajectory.h"
 
@@ -14,6 +13,12 @@ namespace pydairlib {
 
 PYBIND11_MODULE(lcm_trajectory, m) {
   m.doc() = "Binding functions for saving/loading trajectories";
+
+  py::class_<lcmt_metadata>(m, "lcmt_metadata")
+      .def_readwrite("datetime", &lcmt_metadata::datetime)
+      .def_readwrite("name", &lcmt_metadata::name)
+      .def_readwrite("description", &lcmt_metadata::description)
+      .def_readwrite("git_commit_hash", &lcmt_metadata::git_commit_hash);
 
   py::class_<LcmTrajectory::Trajectory>(m, "Trajectory")
       .def_readwrite("traj_name", &LcmTrajectory::Trajectory::traj_name)
@@ -26,10 +31,13 @@ PYBIND11_MODULE(lcm_trajectory, m) {
       .def("LoadFromFile", &LcmTrajectory::LoadFromFile,
            py::arg("trajectory_name"))
       .def("GetTrajectoryNames", &LcmTrajectory::GetTrajectoryNames)
+      .def("GetMetadata", &LcmTrajectory::GetMetadata)
       .def("GetTrajectory", &LcmTrajectory::GetTrajectory,
            py::arg("trajectory_name"));
   py::class_<DirconTrajectory>(m, "DirconTrajectory")
       .def(py::init<const std::string&>())
+      .def("GetMetadata", &LcmTrajectory::GetMetadata)
+      .def("GetTrajectoryNames", &LcmTrajectory::GetTrajectoryNames)
       .def("GetTrajectory", &LcmTrajectory::GetTrajectory,
            py::arg("trajectory_name"))
       .def("GetStateSamples", &DirconTrajectory::GetStateSamples)

--- a/lcm/dircon_saved_trajectory.cc
+++ b/lcm/dircon_saved_trajectory.cc
@@ -101,7 +101,7 @@ DirconTrajectory::DirconTrajectory(
   decision_var_traj.traj_name = "decision_vars";
   decision_var_traj.datapoints = result.GetSolution();
   decision_var_traj.time_vector =
-      VectorXd::Zero(decision_var_traj.datapoints.size());
+      VectorXd::Zero(1);
   decision_var_traj.datatypes =
       vector<string>(decision_var_traj.datapoints.size());
   AddTrajectory(decision_var_traj.traj_name, decision_var_traj);
@@ -197,7 +197,7 @@ DirconTrajectory::DirconTrajectory(
   decision_var_traj.traj_name = "decision_vars";
   decision_var_traj.datapoints = result.GetSolution();
   decision_var_traj.time_vector =
-      VectorXd::Zero(decision_var_traj.datapoints.size());
+      VectorXd::Zero(1);
   decision_var_traj.datatypes =
       vector<string>(decision_var_traj.datapoints.size());
   AddTrajectory(decision_var_traj.traj_name, decision_var_traj);


### PR DESCRIPTION
Previously DirconTrajectory files were abnormally large due a bug in saving the decision variables.

This fix changes the size of the file from ~25MB to ~44KB for a squatting example. Other trajectories are a similar size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/204)
<!-- Reviewable:end -->
