### PR TITLE
Add osc qp info

### DIFF
--- a/lcmtypes/lcmt_osc_output.lcm
+++ b/lcmtypes/lcmt_osc_output.lcm
@@ -7,6 +7,7 @@ struct lcmt_osc_output
   int32_t num_tracking_data;
 
   lcmt_osc_tracking_data tracking_data[num_tracking_data];
+  lcmt_osc_qp_output qp_output;
   string tracking_data_names[num_tracking_data];
 
   double input_cost;

--- a/lcmtypes/lcmt_osc_qp_output.lcm
+++ b/lcmtypes/lcmt_osc_qp_output.lcm
@@ -1,0 +1,15 @@
+package dairlib;
+
+struct lcmt_osc_qp_output
+{
+  int32_t u_dim;
+  int32_t lambda_c_dim;
+  int32_t lambda_h_dim;
+  int32_t v_dim;
+  int32_t epsilon_dim;
+  double u_sol[u_dim];
+  double lambda_c_sol[lambda_c_dim];
+  double lambda_h_sol[lambda_h_dim];
+  double dv_sol[v_dim];
+  double epsilon_sol[epsilon_dim];
+}

--- a/lcmtypes/lcmt_osc_qp_output.lcm
+++ b/lcmtypes/lcmt_osc_qp_output.lcm
@@ -7,6 +7,7 @@ struct lcmt_osc_qp_output
   int32_t lambda_h_dim;
   int32_t v_dim;
   int32_t epsilon_dim;
+  double solve_time;
   double u_sol[u_dim];
   double lambda_c_sol[lambda_c_dim];
   double lambda_h_sol[lambda_h_dim];

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -708,6 +708,19 @@ void OperationalSpaceControl::AssignOscLcmOutput(
   output->tracking_data.clear();
   output->tracking_cost.clear();
 
+  lcmt_osc_qp_output qp_output;
+  qp_output.u_dim = n_u_;
+  qp_output.lambda_c_dim = n_c_;
+  qp_output.lambda_h_dim = n_h_;
+  qp_output.v_dim = n_v_;
+  qp_output.epsilon_dim = n_c_active_;
+  qp_output.u_sol = CopyVectorXdToStdVector(*u_sol_);
+  qp_output.lambda_c_sol = CopyVectorXdToStdVector(*lambda_c_sol_);
+  qp_output.lambda_h_sol = CopyVectorXdToStdVector(*lambda_h_sol_);
+  qp_output.dv_sol = CopyVectorXdToStdVector(*dv_sol_);
+  qp_output.epsilon_sol = CopyVectorXdToStdVector(*epsilon_sol_);
+  output->qp_output = qp_output;
+
   for (unsigned int i = 0; i < tracking_data_vec_->size(); i++) {
     auto tracking_data = tracking_data_vec_->at(i);
 

--- a/systems/controllers/osc/operational_space_control.h
+++ b/systems/controllers/osc/operational_space_control.h
@@ -16,6 +16,7 @@
 #include "drake/systems/framework/leaf_system.h"
 
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/osqp_solver.h"
 #include "drake/solvers/solve.h"
 
 #include "multibody/kinematic/kinematic_evaluator_set.h"
@@ -23,6 +24,9 @@
 #include "systems/controllers/control_utils.h"
 #include "systems/controllers/osc/osc_tracking_data.h"
 #include "systems/framework/output_vector.h"
+
+// Maximum time limit for each QP solve
+static constexpr double kMaxSolveDuration = 0.001;
 
 namespace dairlib::systems::controllers {
 
@@ -256,6 +260,7 @@ class OperationalSpaceControl : public drake::systems::LeafSystem<double> {
   std::unique_ptr<Eigen::VectorXd> lambda_c_sol_;
   std::unique_ptr<Eigen::VectorXd> lambda_h_sol_;
   std::unique_ptr<Eigen::VectorXd> epsilon_sol_;
+  mutable double solve_time_;
 
   // OSC cost members
   /// Using u cost would push the robot away from the fixed point, so the user

--- a/systems/controllers/osc/operational_space_control.h
+++ b/systems/controllers/osc/operational_space_control.h
@@ -7,6 +7,8 @@
 #include <set>
 #include <drake/multibody/plant/multibody_plant.h>
 #include "dairlib/lcmt_osc_output.hpp"
+#include "dairlib/lcmt_osc_qp_output.hpp"
+
 #include "drake/common/trajectories/exponential_plus_piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/systems/framework/diagram.h"


### PR DESCRIPTION
To improve debugging capabilities, the OSC now logs the entire solution of the qp as well as the solve time. This PR also sets a maximum solve time for each QP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/209)
<!-- Reviewable:end -->
