### PR TITLE
Removed static keyworkd from matrix allocations.

### DIFF
--- a/multibody/kinematic/kinematic_evaluator_set.cc
+++ b/multibody/kinematic/kinematic_evaluator_set.cc
@@ -226,7 +226,7 @@ VectorX<T> KinematicEvaluatorSet<T>::CalcMassMatrixTimesVDot(
 template <typename T>
 VectorX<T> KinematicEvaluatorSet<T>::CalcTimeDerivativesWithForce(
     Context<T>* context, const VectorX<T>& lambda) const {
-  static MatrixX<T> J(count_full(), plant_.num_velocities());
+  MatrixX<T> J(count_full(), plant_.num_velocities());
   EvalFullJacobian(*context, &J);
   VectorX<T> J_transpose_lambda = J.transpose() * lambda;
 

--- a/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
@@ -25,7 +25,7 @@ void QuaternionConstraint<T>::EvaluateConstraint(
     const Eigen::Ref<const VectorX<T>>& x, VectorX<T>* y) const {
   (*y).resize(1);
   // Using x.norm() is better, numerically, than x.squaredNorm() except when
-  // x is near zero. The below is a permutation of x.norm() = 1 that will be
+  // x is near zero. The bstaticelow is a permutation of x.norm() = 1 that will be
   // differentiable everywhere, unlike x.norm().
   *y << sqrt(x.squaredNorm() + 1e-3) - sqrt(1 + 1e-3);
 }
@@ -95,7 +95,7 @@ void DirconCollocationConstraint<T>::EvaluateConstraint(
   const auto& xdotcol = -1.5 * (x0 - x1) / h - .25 * (xdot0 + xdot1);
   const auto& ucol = 0.5 * (u0 + u1);
 
-  static drake::MatrixX<T> J(evaluators_.count_full(), plant_.num_velocities());
+  drake::MatrixX<T> J(evaluators_.count_full(), plant_.num_velocities());
 
   // Evaluate dynamics at colocation point
   multibody::setContext<T>(plant_, xcol, ucol, context_col_.get());

--- a/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
@@ -25,7 +25,7 @@ void QuaternionConstraint<T>::EvaluateConstraint(
     const Eigen::Ref<const VectorX<T>>& x, VectorX<T>* y) const {
   (*y).resize(1);
   // Using x.norm() is better, numerically, than x.squaredNorm() except when
-  // x is near zero. The bstaticelow is a permutation of x.norm() = 1 that will be
+  // x is near zero. The below is a permutation of x.norm() = 1 that will be
   // differentiable everywhere, unlike x.norm().
   *y << sqrt(x.squaredNorm() + 1e-3) - sqrt(1 + 1e-3);
 }


### PR DESCRIPTION
Fix for #216 credit @ShaneRozenLevy.

This eliminates some memory usage optimization that could easily be re-instated by making the relevant matrices class members rather than static objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/217)
<!-- Reviewable:end -->
