### PR TITLE
Add collocation slack forces DirconTrajectory object

### DIFF
--- a/lcm/dircon_saved_trajectory.cc
+++ b/lcm/dircon_saved_trajectory.cc
@@ -78,6 +78,24 @@ DirconTrajectory::DirconTrajectory(
       lambda_c_.push_back(&collocation_force_traj);
     }
 
+    // Collocation slack vars
+    if (state_breaks[mode].size() > 1) {
+      LcmTrajectory::Trajectory collocation_slack_traj;
+      collocation_slack_traj.traj_name =
+          "collocation_slack_vars" + std::to_string(mode);
+      collocation_slack_traj.datatypes = collocation_force_names;
+      collocation_slack_traj.time_vector =
+          GetCollocationPoints(state_breaks[mode]);
+      collocation_slack_traj.datapoints =
+          MatrixXd::Zero(num_forces, collocation_slack_traj.time_vector.size());
+      for (int i = 0; i < collocation_slack_traj.time_vector.size(); ++i) {
+        collocation_slack_traj.datapoints.col(i) =
+            result.GetSolution(dircon.collocation_slack_vars(mode, i));
+      }
+      AddTrajectory(collocation_slack_traj.traj_name, collocation_slack_traj);
+      gamma_c_.push_back(&collocation_slack_traj);
+    }
+
     AddTrajectory(state_traj.traj_name, state_traj);
     AddTrajectory(state_derivative_traj.traj_name, state_derivative_traj);
     AddTrajectory(force_traj.traj_name, force_traj);
@@ -235,6 +253,52 @@ PiecewisePolynomial<double> DirconTrajectory::ReconstructInputTrajectory()
   return input_traj;
 }
 
+std::vector<PiecewisePolynomial<double>> DirconTrajectory::ReconstructLambdaTrajectory()
+    const {
+  std::vector<PiecewisePolynomial<double>> lambda_traj;
+  for(int mode_index = 0; mode_index < num_modes_; mode_index ++){
+    if(lambda_[mode_index]->datapoints.size() > 0) {
+      lambda_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(lambda_[mode_index]->time_vector,
+                                                                        lambda_[mode_index]->datapoints));
+    }else{
+      lambda_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(lambda_[mode_index]->time_vector,
+                            MatrixXd::Zero(1,lambda_[mode_index]->time_vector.size())));
+    }
+  }
+  return lambda_traj;
+}
+
+std::vector<PiecewisePolynomial<double>> DirconTrajectory::ReconstructLambdaCTrajectory()
+    const {
+  std::vector<PiecewisePolynomial<double>> lambda_c_traj;
+  for(int mode_index = 0; mode_index < num_modes_; mode_index ++){
+    if(lambda_c_[mode_index]->datapoints.size() > 0) {
+      lambda_c_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(lambda_c_[mode_index]->time_vector,
+                                                                        lambda_c_[mode_index]->datapoints));
+    }else{
+      lambda_c_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(lambda_c_[mode_index]->time_vector,
+                              MatrixXd::Zero(1,lambda_c_[mode_index]->time_vector.size())));
+    }
+  }
+  return lambda_c_traj;
+}
+
+std::vector<PiecewisePolynomial<double>> DirconTrajectory::ReconstructGammaCTrajectory()
+    const {
+  std::vector<PiecewisePolynomial<double>> gamma_c_traj;
+  for(int mode_index = 0; mode_index < num_modes_; mode_index ++){
+    if(gamma_c_[mode_index]->datapoints.size() > 0) {
+      gamma_c_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(gamma_c_[mode_index]->time_vector,
+                                                                         gamma_c_[mode_index]->datapoints));
+    }else{
+      gamma_c_traj.push_back(PiecewisePolynomial<double>::FirstOrderHold(gamma_c_[mode_index]->time_vector,
+                             MatrixXd::Zero(1,gamma_c_[mode_index]->time_vector.size())));
+    }
+  }
+  return gamma_c_traj;
+}
+
+
 void DirconTrajectory::LoadFromFile(const std::string& filepath) {
   LcmTrajectory::LoadFromFile(filepath);
 
@@ -252,6 +316,8 @@ void DirconTrajectory::LoadFromFile(const std::string& filepath) {
     if (x_[mode]->time_vector.size() > 1) {
       lambda_c_.push_back(
           &GetTrajectory("collocation_force_vars" + std::to_string(mode)));
+      gamma_c_.push_back(
+          &GetTrajectory("collocation_slack_vars" + std::to_string(mode)));
     }
   }
   u_ = &GetTrajectory("input_traj");

--- a/lcm/dircon_saved_trajectory.h
+++ b/lcm/dircon_saved_trajectory.h
@@ -24,9 +24,10 @@ namespace dairlib {
 /// filepath of the previously saved DirconTrajectory object
 
 /// DirconTrajectory by default contains four Trajectory objects: the state
-/// trajectory, the input trajectory, the force trajectory, and the decision
-/// variables. Additional trajectories can be added using the AddTrajectory()
-/// function
+/// trajectory, the input trajectory, the force trajectory, the contact force
+/// trajectory, the collocation force trajectory, the collocation slack trajectory
+/// and the decision variables. Additional trajectories can be added using
+/// the AddTrajectory() function
 
 class DirconTrajectory : public LcmTrajectory {
  public:
@@ -47,6 +48,12 @@ class DirconTrajectory : public LcmTrajectory {
   drake::trajectories::PiecewisePolynomial<double> ReconstructInputTrajectory()
       const;
   drake::trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory()
+      const;
+  std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructLambdaTrajectory()
+      const;
+  std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructLambdaCTrajectory()
+      const;
+  std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructGammaCTrajectory()
       const;
 
   /// Loads the saved state and input trajectory as well as the decision
@@ -97,6 +104,7 @@ class DirconTrajectory : public LcmTrajectory {
   const Trajectory* u_;
   std::vector<const Trajectory*> lambda_;
   std::vector<const Trajectory*> lambda_c_;
+  std::vector<const Trajectory*> gamma_c_;
   std::vector<const Trajectory*> x_;
   std::vector<const Trajectory*> xdot_;
 };

--- a/lcm/dircon_saved_trajectory.h
+++ b/lcm/dircon_saved_trajectory.h
@@ -49,10 +49,19 @@ class DirconTrajectory : public LcmTrajectory {
       const;
   drake::trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory()
       const;
+
+  /// Returns a vector of polynomials describing the contact forces for each mode. For use when
+  /// adding knot points to the initial guess
   std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructLambdaTrajectory()
       const;
+
+  /// Returns a vector of polynomials describing the collocation forces for each mode. For use
+  /// when adding knot points to the initial guess
   std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructLambdaCTrajectory()
       const;
+
+  /// Returns a vector of polynomials describing the collocation slack vars. For use when adding
+  /// knot points to the initial guess
   std::vector<drake::trajectories::PiecewisePolynomial<double>> ReconstructGammaCTrajectory()
       const;
 


### PR DESCRIPTION
The goal of this modification is to make it easier to change the number of knot points when loading a trajectory and using it as the initial guess for another trajopt problem. By working in trajectories/splines you can re-interpolate to increase and decrease the number of knot points.

I add the collocation slack variables to the DirconTrajectory trajectory object while also adding functions which return a vector of trajectories for the contact forces, collocation forces, and collocation slack variables.

This code was initially developed for kod*lab's work on spirit, but it sounds like y'all might find it useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/228)
<!-- Reviewable:end -->
