### PR TITLE
Properly handle discontinuities when adding velocity cost

### DIFF
--- a/systems/trajectory_optimization/dircon/dircon.h
+++ b/systems/trajectory_optimization/dircon/dircon.h
@@ -187,6 +187,10 @@ class Dircon
   /// Get the number of knotpoints in a specified mode
   int mode_length(int mode_index) const; 
 
+  /// Adds cost on sum of velocities squared while properly handling the
+  /// discontinuities from impacts
+  void AddVelocityCost(const double velocityCostGain);
+
   const multibody::KinematicEvaluatorSet<T>& get_evaluator_set(int mode) const {
     return mode_sequence_.mode(mode).evaluators();
   }


### PR DESCRIPTION
`doAddRunningCost` will not properly handle the discontinuities in velocity from impacts. I added a function which will only add a cost on sum of velocity squared, but will properly handle discontinuities. Code was tested on optimizing leaps for Spirit. 