### PR TITLE
Fix a bug of using stale context time in FiniteStateMachineEventTime

### DIFF
--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -207,13 +207,13 @@ int DoMain(int argc, char* argv[]) {
                                             right_stance_state};
   auto liftoff_event_time =
       builder.AddSystem<systems::FiniteStateMachineEventTime>(
-          single_support_states);
+          plant_w_spr, single_support_states);
   liftoff_event_time->set_name("liftoff_time");
   builder.Connect(fsm->get_output_port(0),
                   liftoff_event_time->get_input_port_fsm());
   auto touchdown_event_time =
       builder.AddSystem<systems::FiniteStateMachineEventTime>(
-          std::vector<int>(1, double_support_state));
+          plant_w_spr, std::vector<int>(1, double_support_state));
   touchdown_event_time->set_name("touchdown_time");
   builder.Connect(fsm->get_output_port(0),
                   touchdown_event_time->get_input_port_fsm());

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -211,12 +211,16 @@ int DoMain(int argc, char* argv[]) {
   liftoff_event_time->set_name("liftoff_time");
   builder.Connect(fsm->get_output_port(0),
                   liftoff_event_time->get_input_port_fsm());
+  builder.Connect(simulator_drift->get_output_port(0),
+                  liftoff_event_time->get_input_port_state());
   auto touchdown_event_time =
       builder.AddSystem<systems::FiniteStateMachineEventTime>(
           plant_w_spr, std::vector<int>(1, double_support_state));
   touchdown_event_time->set_name("touchdown_time");
   builder.Connect(fsm->get_output_port(0),
                   touchdown_event_time->get_input_port_fsm());
+  builder.Connect(simulator_drift->get_output_port(0),
+                  touchdown_event_time->get_input_port_state());
 
   // Create CoM trajectory generator
   // Note that we are tracking COM acceleration instead of position and velocity

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -109,6 +109,7 @@ cc_library(
     srcs = ["fsm_event_time.cc"],
     hdrs = ["fsm_event_time.h"],
     deps = [
+        "//systems/framework:vector",
         "@drake//:drake_shared_library",
     ],
 )

--- a/systems/controllers/fsm_event_time.cc
+++ b/systems/controllers/fsm_event_time.cc
@@ -76,7 +76,7 @@ EventStatus FiniteStateMachineEventTime::DiscreteVariableUpdate(
         (OutputVector<double>*)this->EvalVectorInput(context,
                                                      robot_output_port_);
     discrete_state->get_mutable_vector(prev_time_idx_).get_mutable_value()
-        << static_cast<double>(robot_output->get_timestamp());
+        << robot_output->get_timestamp();
 
     // Check if the current state is of our interest
     auto it = find(fsm_states_of_interest_.begin(),
@@ -86,7 +86,7 @@ EventStatus FiniteStateMachineEventTime::DiscreteVariableUpdate(
       // Record time
       discrete_state->get_mutable_vector(prev_time_of_state_of_interest_idx_)
               .get_mutable_value()
-          << static_cast<double>(robot_output->get_timestamp());
+          << robot_output->get_timestamp();
     }
   }
 

--- a/systems/controllers/fsm_event_time.cc
+++ b/systems/controllers/fsm_event_time.cc
@@ -1,5 +1,7 @@
 #include "systems/controllers/fsm_event_time.h"
 
+#include <limits>
+
 using std::cout;
 using std::endl;
 using std::string;
@@ -19,12 +21,18 @@ namespace dairlib {
 namespace systems {
 
 FiniteStateMachineEventTime::FiniteStateMachineEventTime(
+    const drake::multibody::MultibodyPlant<double>& plant,
     std::vector<int> fsm_states_of_interest)
     : fsm_states_of_interest_(fsm_states_of_interest) {
   this->set_name("fsm_event_time");
 
   // Input/Output Setup
   fsm_port_ = this->DeclareVectorInputPort(BasicVector<double>(1)).get_index();
+  robot_output_port_ =
+      this->DeclareVectorInputPort(OutputVector<double>(plant.num_positions(),
+                                                        plant.num_velocities(),
+                                                        plant.num_actuators()))
+          .get_index();
   start_time_port_ =
       this->DeclareVectorOutputPort(
               BasicVector<double>(1),
@@ -37,48 +45,66 @@ FiniteStateMachineEventTime::FiniteStateMachineEventTime(
                 &FiniteStateMachineEventTime::AssignStartTimeOfStateOfInterest)
             .get_index();
   }
+
+  // Per-step update to record the previous state and the previous event time
+  DeclarePerStepDiscreteUpdateEvent(
+      &FiniteStateMachineEventTime::DiscreteVariableUpdate);
+  // The start time of the current fsm state
+  prev_time_idx_ = this->DeclareDiscreteState(1);
+  // The start time of the most recent fsm state that we are interested
+  prev_time_of_state_of_interest_idx_ = this->DeclareDiscreteState(1);
+  // The last state of FSM
+  prev_fsm_state_idx_ = this->DeclareDiscreteState(
+      -std::numeric_limits<double>::infinity() * VectorXd::Ones(1));
+}
+
+EventStatus FiniteStateMachineEventTime::DiscreteVariableUpdate(
+    const Context<double>& context,
+    DiscreteValues<double>* discrete_state) const {
+  // Read in current finite state machine state
+  VectorXd fsm_state = this->EvalVectorInput(context, fsm_port_)->get_value();
+  // Read in previous finite state machine state
+  auto prev_fsm_state = discrete_state->get_mutable_vector(prev_fsm_state_idx_)
+                            .get_mutable_value();
+
+  // when entering a new state which is in fsm_states_of_interest
+  if (fsm_state(0) != prev_fsm_state(0)) {
+    prev_fsm_state(0) = fsm_state(0);
+
+    // Record time
+    const OutputVector<double>* robot_output =
+        (OutputVector<double>*)this->EvalVectorInput(context,
+                                                     robot_output_port_);
+    discrete_state->get_mutable_vector(prev_time_idx_).get_mutable_value()
+        << static_cast<double>(robot_output->get_timestamp());
+
+    // Check if the current state is of our interest
+    auto it = find(fsm_states_of_interest_.begin(),
+                   fsm_states_of_interest_.end(), int(fsm_state(0)));
+    bool is_state_of_interest = it != fsm_states_of_interest_.end();
+    if (is_state_of_interest) {
+      // Record time
+      discrete_state->get_mutable_vector(prev_time_of_state_of_interest_idx_)
+              .get_mutable_value()
+          << static_cast<double>(robot_output->get_timestamp());
+    }
+  }
+
+  return EventStatus::Succeeded();
 }
 
 void FiniteStateMachineEventTime::AssignStartTimeOfCurrentState(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* current_state_start_time) const {
-  // Read in current finite state machine state
-  double fsm_state = this->EvalVectorInput(context, fsm_port_)->get_value()(0);
-
-  // when entering a new state which is in fsm_states_of_interest
-  if (fsm_state != prev_fsm_state0_) {
-    prev_fsm_state0_ = fsm_state;
-
-    // Record time
-    prev_time_ = context.get_time();
-  }
-
-  // Assign
-  current_state_start_time->get_mutable_value() << prev_time_;
+  current_state_start_time->get_mutable_value() =
+      context.get_discrete_state(prev_time_idx_).get_value();
 }
-
 void FiniteStateMachineEventTime::AssignStartTimeOfStateOfInterest(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* state_start_time) const {
-  // Read in current finite state machine state
-  double fsm_state = this->EvalVectorInput(context, fsm_port_)->get_value()(0);
-
-  // when entering a new state which is in fsm_states_of_interest
-  if (fsm_state != prev_fsm_state1_) {
-    prev_fsm_state1_ = fsm_state;
-
-    // Check if the current state is of our interest
-    auto it = find(fsm_states_of_interest_.begin(),
-                   fsm_states_of_interest_.end(), int(fsm_state));
-    bool is_state_of_interest = it != fsm_states_of_interest_.end();
-    if (is_state_of_interest) {
-      // Record time
-      prev_time_of_state_of_interest_ = context.get_time();
-    }
-  }
-
-  // Assign
-  state_start_time->get_mutable_value() << prev_time_of_state_of_interest_;
+  state_start_time->get_mutable_value() =
+      context.get_discrete_state(prev_time_of_state_of_interest_idx_)
+          .get_value();
 }
 
 }  // namespace systems

--- a/systems/controllers/fsm_event_time.cc
+++ b/systems/controllers/fsm_event_time.cc
@@ -1,7 +1,5 @@
 #include "systems/controllers/fsm_event_time.h"
 
-#include <limits>
-
 using std::cout;
 using std::endl;
 using std::string;
@@ -39,65 +37,48 @@ FiniteStateMachineEventTime::FiniteStateMachineEventTime(
                 &FiniteStateMachineEventTime::AssignStartTimeOfStateOfInterest)
             .get_index();
   }
-
-  // Per-step update to record the previous state and the previous event time
-  DeclarePerStepDiscreteUpdateEvent(
-      &FiniteStateMachineEventTime::DiscreteVariableUpdate);
-  // The start time of the current fsm state
-  prev_time_idx_ = this->DeclareDiscreteState(1);
-  // The start time of the most recent fsm state that we are interested
-  prev_time_of_state_of_interest_idx_ = this->DeclareDiscreteState(1);
-  // The last state of FSM
-  prev_fsm_state_idx_ = this->DeclareDiscreteState(
-      -std::numeric_limits<double>::infinity() * VectorXd::Ones(1));
-}
-
-EventStatus FiniteStateMachineEventTime::DiscreteVariableUpdate(
-    const Context<double>& context,
-    DiscreteValues<double>* discrete_state) const {
-  // Read in current finite state machine state
-  auto fsm_output =
-      (BasicVector<double>*)this->EvalVectorInput(context, fsm_port_);
-  VectorXd fsm_state = fsm_output->get_value();
-  // Read in previous finite state machine state
-  auto prev_fsm_state = discrete_state->get_mutable_vector(prev_fsm_state_idx_)
-                            .get_mutable_value();
-
-  // Check if the current state is of our interest
-  auto it = find(fsm_states_of_interest_.begin(), fsm_states_of_interest_.end(),
-                 int(fsm_state(0)));
-  bool is_state_of_interest = it != fsm_states_of_interest_.end();
-
-  // when entering a new state which is in fsm_states_of_interest
-  if (fsm_state(0) != prev_fsm_state(0)) {
-    prev_fsm_state(0) = fsm_state(0);
-
-    // Record time
-    discrete_state->get_mutable_vector(prev_time_idx_)
-        .get_mutable_value() << context.get_time();
-
-    if (is_state_of_interest) {
-      // Record time
-      discrete_state->get_mutable_vector(prev_time_of_state_of_interest_idx_)
-          .get_mutable_value() << context.get_time();
-    }
-  }
-
-  return EventStatus::Succeeded();
 }
 
 void FiniteStateMachineEventTime::AssignStartTimeOfCurrentState(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* current_state_start_time) const {
-  current_state_start_time->get_mutable_value() =
-      context.get_discrete_state(prev_time_idx_).get_value();
+  // Read in current finite state machine state
+  double fsm_state = this->EvalVectorInput(context, fsm_port_)->get_value()(0);
+
+  // when entering a new state which is in fsm_states_of_interest
+  if (fsm_state != prev_fsm_state0_) {
+    prev_fsm_state0_ = fsm_state;
+
+    // Record time
+    prev_time_ = context.get_time();
+  }
+
+  // Assign
+  current_state_start_time->get_mutable_value() << prev_time_;
 }
+
 void FiniteStateMachineEventTime::AssignStartTimeOfStateOfInterest(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* state_start_time) const {
-  state_start_time->get_mutable_value() =
-      context.get_discrete_state(prev_time_of_state_of_interest_idx_)
-          .get_value();
+  // Read in current finite state machine state
+  double fsm_state = this->EvalVectorInput(context, fsm_port_)->get_value()(0);
+
+  // when entering a new state which is in fsm_states_of_interest
+  if (fsm_state != prev_fsm_state1_) {
+    prev_fsm_state1_ = fsm_state;
+
+    // Check if the current state is of our interest
+    auto it = find(fsm_states_of_interest_.begin(),
+                   fsm_states_of_interest_.end(), int(fsm_state));
+    bool is_state_of_interest = it != fsm_states_of_interest_.end();
+    if (is_state_of_interest) {
+      // Record time
+      prev_time_of_state_of_interest_ = context.get_time();
+    }
+  }
+
+  // Assign
+  state_start_time->get_mutable_value() << prev_time_of_state_of_interest_;
 }
 
 }  // namespace systems

--- a/systems/controllers/fsm_event_time.h
+++ b/systems/controllers/fsm_event_time.h
@@ -2,6 +2,8 @@
 
 #include <limits>
 
+#include "systems/framework/output_vector.h"
+#include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace dairlib {
@@ -13,10 +15,15 @@ namespace systems {
 /// sends out the start time of the state that the user is interested in.
 class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
  public:
-  FiniteStateMachineEventTime(std::vector<int> fsm_states_of_interest = {});
+  FiniteStateMachineEventTime(
+      const drake::multibody::MultibodyPlant<double>& plant,
+      std::vector<int> fsm_states_of_interest = {});
 
   const drake::systems::InputPort<double>& get_input_port_fsm() const {
     return this->get_input_port(fsm_port_);
+  }
+  const drake::systems::InputPort<double>& get_input_port_state() const {
+    return this->get_input_port(robot_output_port_);
   }
   const drake::systems::OutputPort<double>& get_output_port_event_time() const {
     return this->get_output_port(start_time_port_);
@@ -27,6 +34,9 @@ class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
   }
 
  private:
+  drake::systems::EventStatus DiscreteVariableUpdate(
+      const drake::systems::Context<double>& context,
+      drake::systems::DiscreteValues<double>* discrete_state) const;
   void AssignStartTimeOfCurrentState(
       const drake::systems::Context<double>& context,
       drake::systems::BasicVector<double>* current_state_start_time) const;
@@ -36,18 +46,16 @@ class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
 
   // Port index
   int fsm_port_;
+  int robot_output_port_;
   int start_time_port_;
   int start_time_of_interest_port_;
 
-  std::vector<int> fsm_states_of_interest_;
+  // Discrete state index
+  int prev_fsm_state_idx_;
+  int prev_time_idx_;
+  int prev_time_of_state_of_interest_idx_;
 
-  // Internal states of this leafsystem
-  // prev_fsm_state0_ is used for AssignStartTimeOfCurrentState()
-  // prev_fsm_state1_ is used for AssignStartTimeOfStateOfInterest()
-  mutable double prev_fsm_state0_ = -std::numeric_limits<double>::infinity();
-  mutable double prev_fsm_state1_ = -std::numeric_limits<double>::infinity();
-  mutable double prev_time_;
-  mutable double prev_time_of_state_of_interest_;
+  std::vector<int> fsm_states_of_interest_;
 };
 
 }  // namespace systems

--- a/systems/controllers/fsm_event_time.h
+++ b/systems/controllers/fsm_event_time.h
@@ -13,6 +13,10 @@ namespace systems {
 /// state machine. If the user provides `fsm_states_of_interest` to the
 /// constructor, FiniteStateMachineEventTime creates a second output port that
 /// sends out the start time of the state that the user is interested in.
+///
+/// We connect this leafsystem to OutputVector in order to get the current time.
+/// We note that context.time is always at least one timestep older robot's
+/// output time when we use LcmDrivenLoop.
 class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
  public:
   FiniteStateMachineEventTime(

--- a/systems/controllers/fsm_event_time.h
+++ b/systems/controllers/fsm_event_time.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "drake/systems/framework/leaf_system.h"
 
 namespace dairlib {
@@ -25,9 +27,6 @@ class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
   }
 
  private:
-  drake::systems::EventStatus DiscreteVariableUpdate(
-      const drake::systems::Context<double>& context,
-      drake::systems::DiscreteValues<double>* discrete_state) const;
   void AssignStartTimeOfCurrentState(
       const drake::systems::Context<double>& context,
       drake::systems::BasicVector<double>* current_state_start_time) const;
@@ -40,12 +39,15 @@ class FiniteStateMachineEventTime : public drake::systems::LeafSystem<double> {
   int start_time_port_;
   int start_time_of_interest_port_;
 
-  // Discrete state index
-  int prev_fsm_state_idx_;
-  int prev_time_idx_;
-  int prev_time_of_state_of_interest_idx_;
-
   std::vector<int> fsm_states_of_interest_;
+
+  // Internal states of this leafsystem
+  // prev_fsm_state0_ is used for AssignStartTimeOfCurrentState()
+  // prev_fsm_state1_ is used for AssignStartTimeOfStateOfInterest()
+  mutable double prev_fsm_state0_ = -std::numeric_limits<double>::infinity();
+  mutable double prev_fsm_state1_ = -std::numeric_limits<double>::infinity();
+  mutable double prev_time_;
+  mutable double prev_time_of_state_of_interest_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
It's the same issue described in #63, but I didn't fix it with the same approach as #188, because we would have to set the message time manually which makes LcmDrivenLoop more complicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/233)
<!-- Reviewable:end -->
