### PR TITLE
Manual estop

### DIFF
--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -37,6 +37,9 @@ using std::string;
 DEFINE_string(address, "127.0.0.1", "IPv4 address to publish to (UDP).");
 DEFINE_int64(port, 25000, "Port to publish to (UDP).");
 DEFINE_double(pub_rate, .02, "Network LCM pubishing period (s).");
+DEFINE_string(
+    cassie_out_channel, "CASSIE_OUTPUT_ECHO",
+    "The name of the channel to receive the cassie out structure from.");
 DEFINE_double(max_joint_velocity, 5,
               "Maximum joint velocity before error is triggered");
 DEFINE_double(input_limit, -1,
@@ -85,6 +88,9 @@ int do_main(int argc, char* argv[]) {
   auto controller_switch_sub = builder.AddSystem(
       LcmSubscriberSystem::Make<dairlib::lcmt_controller_switch>(switch_channel,
                                                                  &lcm_local));
+  auto cassie_out_receiver =
+      builder.AddSystem(LcmSubscriberSystem::Make<dairlib::lcmt_cassie_out>(
+          FLAGS_cassie_out_channel, &lcm_local));
   auto state_receiver = builder.AddSystem<systems::RobotOutputReceiver>(plant);
   auto input_supervisor_status_pub = builder.AddSystem(
       LcmPublisherSystem::Make<dairlib::lcmt_input_supervisor_status>(
@@ -108,6 +114,8 @@ int do_main(int argc, char* argv[]) {
                   input_supervisor->get_input_port_controller_switch());
   builder.Connect(input_supervisor->get_output_port_status(),
                   input_supervisor_status_pub->get_input_port());
+  builder.Connect(cassie_out_receiver->get_output_port(),
+                  input_supervisor->get_input_port_cassie());
 
   // Create and connect translator
   auto input_translator =

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -76,6 +76,7 @@ InputSupervisor::InputSupervisor(
   K_(7, 13) = -1;
   K_(8, 19) = -1;
   K_(9, 21) = -1;
+  K_ = 10 * K_;
 
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -1,5 +1,7 @@
 #include "examples/Cassie/input_supervisor.h"
 
+#include <dairlib/lcmt_cassie_out.hpp>
+
 #include "dairlib/lcmt_controller_switch.hpp"
 #include "systems/framework/output_vector.h"
 
@@ -22,7 +24,7 @@ InputSupervisor::InputSupervisor(
       min_consecutive_failures_(min_consecutive_failures),
       max_joint_velocity_(max_joint_velocity),
       input_limit_(input_limit) {
-  if(input_limit_ == std::numeric_limits<double>::max()){
+  if (input_limit_ == std::numeric_limits<double>::max()) {
     std::cout << "Warning. No input limits have been set." << std::endl;
   }
 
@@ -38,6 +40,10 @@ InputSupervisor::InputSupervisor(
       this->DeclareAbstractInputPort(
               "lcmt_controller_switch",
               drake::Value<dairlib::lcmt_controller_switch>{})
+          .get_index();
+  cassie_input_port_ =
+      this->DeclareAbstractInputPort("lcmt_cassie_out",
+                                     drake::Value<dairlib::lcmt_cassie_out>{})
           .get_index();
 
   // Create output port for commands
@@ -59,6 +65,18 @@ InputSupervisor::InputSupervisor(
   prev_efforts_time_index_ = DeclareDiscreteState(1);
   prev_efforts_index_ = DeclareDiscreteState(num_actuators_);
 
+  K_ = Eigen::MatrixXd::Zero(num_actuators_, num_velocities_);
+  K_(0, 6) = -1;
+  K_(1, 7) = -1;
+  K_(2, 8) = -1;
+  K_(3, 9) = -1;
+  K_(4, 10) = -1;
+  K_(5, 11) = -1;
+  K_(6, 12) = -1;
+  K_(7, 13) = -1;
+  K_(8, 19) = -1;
+  K_(9, 21) = -1;
+
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
                                      &InputSupervisor::UpdateErrorFlag);
@@ -69,6 +87,11 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
   const TimestampedVector<double>* command =
       (TimestampedVector<double>*)this->EvalVectorInput(context,
                                                         command_input_port_);
+  const OutputVector<double>* state =
+      (OutputVector<double>*)this->EvalVectorInput(context, state_input_port_);
+
+  const auto& cassie_out = this->EvalInputValue<dairlib::lcmt_cassie_out>(
+      context, cassie_input_port_);
 
   bool is_error =
       context.get_discrete_state(status_vars_index_)[n_fails_index_] >=
@@ -82,6 +105,12 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
        kMaxControllerDelay)) {
     std::cout << "Delay between controller commands is too long, shutting down"
               << std::endl;
+  }
+
+  if (cassie_out->pelvis.radio.channel[15] == -1) {
+    Eigen::VectorXd u = -K_ * state->get_value();
+    output->SetDataVector(Eigen::VectorXd::Zero(num_actuators_));
+    return;
   }
 
   // If there has not been an error, copy over the command.
@@ -160,9 +189,9 @@ void InputSupervisor::SetStatus(
     output->shutdown = true;
   }
 
-  if((command->get_timestamp() -
-      context.get_discrete_state(prev_efforts_time_index_)[0] >
-      kMaxControllerDelay)){
+  if ((command->get_timestamp() -
+           context.get_discrete_state(prev_efforts_time_index_)[0] >
+       kMaxControllerDelay)) {
     output->act_delay = true;
     output->shutdown = true;
   }

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -76,7 +76,6 @@ InputSupervisor::InputSupervisor(
   K_(7, 13) = -1;
   K_(8, 19) = -1;
   K_(9, 21) = -1;
-  K_ = 10 * K_;
 
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
@@ -110,7 +109,7 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
 
   if (cassie_out->pelvis.radio.channel[15] == -1) {
     Eigen::VectorXd u = -K_ * state->get_value();
-    output->SetDataVector(Eigen::VectorXd::Zero(num_actuators_));
+    output->SetDataVector(u);
     return;
   }
 

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -5,6 +5,7 @@
 #include "dairlib/lcmt_controller_switch.hpp"
 #include "systems/framework/output_vector.h"
 
+using drake::multibody::JointActuatorIndex;
 using drake::systems::Context;
 using drake::systems::DiscreteValues;
 
@@ -64,18 +65,11 @@ InputSupervisor::InputSupervisor(
   switch_time_index_ = DeclareDiscreteState(1);
   prev_efforts_time_index_ = DeclareDiscreteState(1);
   prev_efforts_index_ = DeclareDiscreteState(num_actuators_);
+  soft_estop_flag_index_ = DeclareDiscreteState(1);
 
-  K_ = Eigen::MatrixXd::Zero(num_actuators_, num_velocities_);
-  K_(0, 6) = -1;
-  K_(1, 7) = -1;
-  K_(2, 8) = -1;
-  K_(3, 9) = -1;
-  K_(4, 10) = -1;
-  K_(5, 11) = -1;
-  K_(6, 12) = -1;
-  K_(7, 13) = -1;
-  K_(8, 19) = -1;
-  K_(9, 21) = -1;
+  K_ = plant_.MakeActuationMatrix().transpose();
+  K_ *= kEStopGain;
+  std::cout << K_ << std::endl;
 
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
@@ -100,6 +94,8 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
       is_error || (command->get_timestamp() -
                        context.get_discrete_state(prev_efforts_time_index_)[0] >
                    kMaxControllerDelay);
+  is_error =
+      is_error || context.get_discrete_state(soft_estop_flag_index_)[0] != 0;
   if ((command->get_timestamp() -
            context.get_discrete_state(prev_efforts_time_index_)[0] >
        kMaxControllerDelay)) {
@@ -107,6 +103,8 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
               << std::endl;
   }
 
+  // If the soft estop signal is triggered, applying only damping regardless of
+  // any other controller signal
   if (cassie_out->pelvis.radio.channel[15] == -1) {
     Eigen::VectorXd u = -K_ * state->get_value();
     output->SetDataVector(u);
@@ -208,6 +206,8 @@ void InputSupervisor::UpdateErrorFlag(
   const TimestampedVector<double>* command =
       (TimestampedVector<double>*)this->EvalVectorInput(context,
                                                         command_input_port_);
+  const auto& cassie_out = this->EvalInputValue<dairlib::lcmt_cassie_out>(
+      context, cassie_input_port_);
 
   if (command->get_timestamp() -
           discrete_state->get_mutable_vector(prev_efforts_time_index_)[0] >
@@ -216,6 +216,10 @@ void InputSupervisor::UpdateErrorFlag(
   } else {
     discrete_state->get_mutable_vector(prev_efforts_time_index_)[0] =
         command->get_timestamp();
+  }
+
+  if (cassie_out->pelvis.radio.channel[15] == -1) {
+    discrete_state->get_mutable_vector(soft_estop_flag_index_)[0] = 1;
   }
 
   const Eigen::VectorXd& velocities = state->GetVelocities();

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -105,7 +105,7 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
   // If the soft estop signal is triggered, applying only damping regardless of
   // any other controller signal
   if (cassie_out->pelvis.radio.channel[15] == -1) {
-    Eigen::VectorXd u = -K_ * state->get_value();
+    Eigen::VectorXd u = -K_ * state->GetVelocities();
     output->SetDataVector(u);
     return;
   }

--- a/examples/Cassie/input_supervisor.cc
+++ b/examples/Cassie/input_supervisor.cc
@@ -69,7 +69,6 @@ InputSupervisor::InputSupervisor(
 
   K_ = plant_.MakeActuationMatrix().transpose();
   K_ *= kEStopGain;
-  std::cout << K_ << std::endl;
 
   // Create update for error flag
   DeclarePeriodicDiscreteUpdateEvent(update_period, 0,
@@ -95,7 +94,7 @@ void InputSupervisor::SetMotorTorques(const Context<double>& context,
                        context.get_discrete_state(prev_efforts_time_index_)[0] >
                    kMaxControllerDelay);
   is_error =
-      is_error || context.get_discrete_state(soft_estop_flag_index_)[0] != 0;
+      is_error || context.get_discrete_state(soft_estop_flag_index_)[0] == 1;
   if ((command->get_timestamp() -
            context.get_discrete_state(prev_efforts_time_index_)[0] >
        kMaxControllerDelay)) {

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -7,6 +7,7 @@
 #include "drake/systems/framework/leaf_system.h"
 
 static constexpr double kMaxControllerDelay = 0.1;
+static constexpr double kEStopGain = 5.0;
 
 namespace dairlib {
 
@@ -92,6 +93,7 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   double input_limit_;
   mutable double blend_duration_ = 0.0;
   int status_vars_index_;
+  int soft_estop_flag_index_;
   int n_fails_index_;
   int status_index_;
   int switch_time_index_;

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -55,6 +55,10 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
     return this->get_input_port(controller_switch_input_port_);
   }
 
+  const drake::systems::InputPort<double>& get_input_port_cassie() const {
+    return this->get_input_port(cassie_input_port_);
+  }
+
   const drake::systems::OutputPort<double>& get_output_port_command() const {
     return this->get_output_port(command_output_port_);
   }
@@ -96,8 +100,11 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   int state_input_port_;
   int command_input_port_;
   int controller_switch_input_port_;
+  int cassie_input_port_;
   int command_output_port_;
   int status_output_port_;
+
+  Eigen::MatrixXd K_;
 };
 
 }  // namespace dairlib


### PR DESCRIPTION
Implementing the soft-estop (which applies a damping only controller) in the input supervisor.

The soft-estop is triggered by the radio and the dispatcher will remain in the error state after it is triggered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/234)
<!-- Reviewable:end -->
