### PR TITLE
addressing velocity discontinuities correctly in the cost function

### DIFF
--- a/systems/trajectory_optimization/dircon/dircon.h
+++ b/systems/trajectory_optimization/dircon/dircon.h
@@ -1,17 +1,18 @@
 #pragma once
 
 #include <vector>
+
 #include <memory.h>
+
+#include "multibody/multipose_visualizer.h"
+#include "systems/trajectory_optimization/dircon/dircon_mode.h"
+#include "systems/trajectory_optimization/dircon/dynamics_cache.h"
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/symbolic.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/solvers/constraint.h"
 #include "drake/systems/trajectory_optimization/multiple_shooting.h"
-
-#include "systems/trajectory_optimization/dircon/dircon_mode.h"
-#include "systems/trajectory_optimization/dircon/dynamics_cache.h"
-#include "multibody/multipose_visualizer.h"
 
 namespace dairlib {
 namespace systems {
@@ -57,21 +58,21 @@ class Dircon
   /// %drake::trajectories::PiecewisePolynomialTrajectory%.
   drake::trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory(
       const drake::solvers::MathematicalProgramResult& result) const override;
- 
+
   /// Get the state samples by mode, as a matrix. Each column corresponds to
   /// a knotpoint.
   Eigen::MatrixXd GetStateSamplesByMode(
-    const drake::solvers::MathematicalProgramResult& result, int mode) const;
+      const drake::solvers::MathematicalProgramResult& result, int mode) const;
 
   /// Get the input samples by mode, as a matrix. Each column corresponds to
   /// a knotpoint.
   Eigen::MatrixXd GetInputSamplesByMode(
-    const drake::solvers::MathematicalProgramResult& result, int mode) const;
+      const drake::solvers::MathematicalProgramResult& result, int mode) const;
 
   /// Get the state samples by mode, as a matrix. Each column corresponds to
   /// a knotpoint.
   Eigen::MatrixXd GetForceSamplesByMode(
-    const drake::solvers::MathematicalProgramResult& result, int mode) const;
+      const drake::solvers::MathematicalProgramResult& result, int mode) const;
 
   /// Adds a visualization callback that will visualize knot points
   /// without transparency. Cannot be called twice
@@ -84,8 +85,9 @@ class Dircon
   /// @param weld_frame_to_world The name of a frame to weld to the world frame
   ///   when parsing the model. Defaults to blank, which will not perform a weld
   void CreateVisualizationCallback(std::string model_file,
-      std::vector<unsigned int> poses_per_mode, double alpha,
-      std::string weld_frame_to_world = "");
+                                   std::vector<unsigned int> poses_per_mode,
+                                   double alpha,
+                                   std::string weld_frame_to_world = "");
 
   /// See CreateVisualizationCallback(std::string model_file,
   ///    std::vector<unsigned int> poses_per_mode,
@@ -96,8 +98,8 @@ class Dircon
   /// of frames in that mode. Since start/end poses per mdoe are required, must
   /// have num_poses >= num_modes + 1
   void CreateVisualizationCallback(std::string model_file,
-      unsigned int num_poses, double alpha,
-      std::string weld_frame_to_world = "");
+                                   unsigned int num_poses, double alpha,
+                                   std::string weld_frame_to_world = "");
 
   /// See CreateVisualizationCallback(std::string model_file,
   ///    unsigned int poses_per_mode,
@@ -105,7 +107,7 @@ class Dircon
   ///
   /// Creates a visualization callback that shows all knot points.
   void CreateVisualizationCallback(std::string model_file, double alpha,
-      std::string weld_frame_to_world = "");
+                                   std::string weld_frame_to_world = "");
 
   /// Set the initial guess for the force variables for a specific mode
   /// @param mode the mode index
@@ -129,8 +131,8 @@ class Dircon
 
   /// Get all knotpoint force variables associated with a specific mode and
   /// knotpoint
-  const drake::solvers::VectorXDecisionVariable force_vars(int mode_index,
-      int knotpoint_index) const;
+  const drake::solvers::VectorXDecisionVariable force_vars(
+      int mode_index, int knotpoint_index) const;
 
   /// Get all collocation force variables associated with a specific mode and
   /// collocation point
@@ -170,7 +172,7 @@ class Dircon
       int mode_index, int knotpoint_index) const;
 
   /// Get the input decision variables, given a mode and time index.
-  /// (knotpoint_index is w.r.t that particular mode). 
+  /// (knotpoint_index is w.r.t that particular mode).
   const drake::solvers::VectorXDecisionVariable input_vars(
       int mode_index, int knotpoint_index) const;
 
@@ -178,14 +180,20 @@ class Dircon
       const drake::VectorX<drake::symbolic::Expression>& f,
       int interval_index) const;
 
+  /// Substitute the velocity variables in the expression with
+  /// v_post_impact_vars_ for the corresponding mode
+  /// It is up to the user to make sure this is used only on the first knotpoint
+  drake::symbolic::Expression SubstitutePostImpactVelocityVariables(
+      const drake::symbolic::Expression& e, int mode) const;
+
   using drake::systems::trajectory_optimization::MultipleShooting::N;
   using drake::systems::trajectory_optimization::MultipleShooting::
-      SubstitutePlaceholderVariables;
+  SubstitutePlaceholderVariables;
 
-  int num_modes() const ;
+  int num_modes() const;
 
   /// Get the number of knotpoints in a specified mode
-  int mode_length(int mode_index) const; 
+  int mode_length(int mode_index) const;
 
   const multibody::KinematicEvaluatorSet<T>& get_evaluator_set(int mode) const {
     return mode_sequence_.mode(mode).evaluators();
@@ -217,9 +225,8 @@ class Dircon
  private:
   // Private constructor to which public constructors funnel
   Dircon(std::unique_ptr<DirconModeSequence<T>> my_sequence,
-      const DirconModeSequence<T>* ext_sequence,
-      const drake::multibody::MultibodyPlant<T>& plant,
-      int num_knotpoints);
+         const DirconModeSequence<T>* ext_sequence,
+         const drake::multibody::MultibodyPlant<T>& plant, int num_knotpoints);
 
   std::unique_ptr<DirconModeSequence<T>> my_sequence_;
   const drake::multibody::MultibodyPlant<T>& plant_;
@@ -237,6 +244,10 @@ class Dircon
   std::vector<drake::solvers::VectorXDecisionVariable> quaternion_slack_vars_;
   std::unique_ptr<multibody::MultiposeVisualizer> callback_visualizer_;
   std::vector<std::unique_ptr<DynamicsCache<T>>> cache_;
+
+  std::vector<std::pair<drake::VectorX<drake::symbolic::Variable>,
+                        drake::VectorX<drake::symbolic::Expression>>>
+      v_post_impact_vars_substitute_;
 };
 
 }  // namespace trajectory_optimization

--- a/systems/trajectory_optimization/hybrid_dircon.cc
+++ b/systems/trajectory_optimization/hybrid_dircon.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "multibody/multibody_utils.h"
+
 #include "drake/math/autodiff.h"
 #include "drake/solvers/decision_variable.h"
 
@@ -20,6 +21,7 @@ using drake::solvers::Binding;
 using drake::solvers::Constraint;
 using drake::solvers::MathematicalProgram;
 using drake::solvers::MathematicalProgramResult;
+using drake::solvers::MatrixXDecisionVariable;
 using drake::solvers::VectorXDecisionVariable;
 using drake::symbolic::Expression;
 using drake::systems::trajectory_optimization::MultipleShooting;
@@ -37,10 +39,10 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
                               vector<DirconKinematicDataSet<T>*> constraints,
                               vector<DirconOptions> options)
     : MultipleShooting(
-          plant.num_actuators(), plant.num_positions() + plant.num_velocities(),
-          std::accumulate(num_time_samples.begin(), num_time_samples.end(), 0) -
-              num_time_samples.size() + 1,
-          1e-8, 1e8),
+    plant.num_actuators(), plant.num_positions() + plant.num_velocities(),
+    std::accumulate(num_time_samples.begin(), num_time_samples.end(), 0) -
+        num_time_samples.size() + 1,
+    1e-8, 1e8),
       plant_(plant),
       constraints_(constraints),
       num_modes_(num_time_samples.size()),
@@ -67,7 +69,7 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
     for (int j = 0; j < mode_lengths_[i] - 2; j++) {
       // all timesteps must be equal
       AddLinearConstraint(timestep(mode_start_[i] + j) ==
-                          timestep(mode_start_[i] + j + 1));
+          timestep(mode_start_[i] + j + 1));
     }
 
     // initialize constraint lengths
@@ -107,6 +109,17 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
           constraints_[i]->countConstraintsWithoutSkipping(),
           "impulse[" + std::to_string(i) + "]"));
     }
+    //  Post-impact variables. Note: impulse variables declared below.
+    if (i > 0) {
+      v_post_impact_vars_substitute_.push_back(
+          {state().tail(plant_.num_velocities()),
+           Eigen::Map<MatrixXDecisionVariable>(
+               ((drake::solvers::VectorXDecisionVariable)
+                   v_post_impact_vars_by_mode(i))
+                   .data(),
+               plant_.num_velocities(), 1)
+               .cast<Expression>()});
+    }
 
     // For N-1 timesteps, add a constraint which depends on the knot
     // value along with the state and input vectors at that knot and the
@@ -128,7 +141,7 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
     auto dynamic_constraint = std::make_shared<DirconDynamicConstraint<T>>(
         plant_, *constraints_[i], is_quaternion);
     DRAKE_ASSERT(static_cast<int>(dynamic_constraint->num_constraints()) ==
-                 num_states());
+        num_states());
     dynamic_constraint->SetConstraintScaling(
         options[i].getDynConstraintScaling());
     for (int j = 0; j < mode_lengths_[i] - 1; j++) {
@@ -221,8 +234,8 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
     // Add force to cost function
     if (options[i].getForceCost() != 0) {
       auto A = options[i].getForceCost() *
-               MatrixXd::Identity(num_kinematic_constraints_wo_skipping(i),
-                                  num_kinematic_constraints_wo_skipping(i));
+          MatrixXd::Identity(num_kinematic_constraints_wo_skipping(i),
+                             num_kinematic_constraints_wo_skipping(i));
       auto b = MatrixXd::Zero(num_kinematic_constraints_wo_skipping(i), 1);
       for (int j = 0; j < mode_lengths_[i]; j++) {
         // Add || Ax - b ||^2
@@ -256,7 +269,7 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
       } else {
         auto x_vars_prev = state_vars_by_mode(i - 1, mode_lengths_[i - 1] - 1);
         AddConstraint(v_post_impact_vars_by_mode(i - 1) ==
-                      x_vars_prev.tail(plant.num_velocities()));
+            x_vars_prev.tail(plant.num_velocities()));
       }
     }
 
@@ -305,7 +318,19 @@ VectorXDecisionVariable HybridDircon<T>::state_vars_by_mode(
   }
 }
 
-// TODO: need to configure this to handle the hybrid discontinuities properly
+template <typename T>
+Expression HybridDircon<T>::SubstitutePostImpactVelocityVariables(
+    const drake::symbolic::Expression& e, int mode) const {
+  DRAKE_DEMAND(mode > 0);
+  drake::symbolic::Substitution s;
+  for (int i = 0; i < v_post_impact_vars_substitute_[mode - 1].first.size();
+       ++i) {
+    s.emplace(v_post_impact_vars_substitute_[mode - 1].first[i],
+              v_post_impact_vars_substitute_[mode - 1].second[i]);
+  }
+  return e.Substitute(s);
+}
+
 template <typename T>
 void HybridDircon<T>::DoAddRunningCost(const drake::symbolic::Expression& g) {
   // Trapezoidal integration:
@@ -316,14 +341,26 @@ void HybridDircon<T>::DoAddRunningCost(const drake::symbolic::Expression& g) {
   // Here, we add the cost using symbolic expression. The expression is a
   // polynomial of degree 3 which Drake can handle, although the
   // documentation says it only supports up to second order.
-  AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, 0) * h_vars()(0) /
-          2);
-  for (int i = 1; i <= N() - 2; i++) {
-    AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, i) *
-            (h_vars()(i - 1) + h_vars()(i)) / 2);
+  for (int mode = 0; mode < num_modes(); ++mode) {
+    int mode_start = mode_start_[mode];
+    int mode_end = mode_start_[mode] + mode_length(mode);
+    // Substitute the velocity vars with the correct post-impact velocity vars
+    // before substituting the rest of the expression
+    if (mode > 0) {
+      AddCost(MultipleShooting::SubstitutePlaceholderVariables(
+          SubstitutePostImpactVelocityVariables(g, mode), mode_start) *
+          (h_vars()(mode_start) / 2));
+    } else {
+      AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, mode_start) *
+          (h_vars()(mode_start) / 2));
+    }
+    for (int i = mode_start + 1; i < mode_end - 1; ++i) {
+      AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, i) *
+          (h_vars()(i - 1) + h_vars()(i)) / 2);
+    }
+    AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, mode_end - 1) *
+        h_vars()(mode_end - 2) / 2);
   }
-  AddCost(MultipleShooting::SubstitutePlaceholderVariables(g, N() - 1) *
-          h_vars()(N() - 2) / 2);
 }
 
 template <typename T>
@@ -380,7 +417,7 @@ PiecewisePolynomial<double> HybridDircon<T>::ReconstructStateTrajectory(
                                                 derivatives[0]);
   for (int mode = 1; mode < num_modes_; ++mode) {
     // Cannot form trajectory with only a single break
-    if(mode_lengths_[mode] < 2){
+    if (mode_lengths_[mode] < 2) {
       continue;
     }
     state_traj.ConcatenateInTime(PiecewisePolynomial<double>::CubicHermite(
@@ -564,47 +601,46 @@ void HybridDircon<T>::ScaleKinConstraintSlackVariables(
 }
 
 template <typename T>
-void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
-    std::vector<unsigned int> poses_per_mode, double alpha,
-    std::string weld_frame_to_world) {
+void HybridDircon<T>::CreateVisualizationCallback(
+    std::string model_file, std::vector<unsigned int> poses_per_mode,
+    double alpha, std::string weld_frame_to_world) {
   DRAKE_DEMAND(!callback_visualizer_);  // Cannot be set twice
-  DRAKE_DEMAND(poses_per_mode.size() == (uint) num_modes_);
+  DRAKE_DEMAND(poses_per_mode.size() == (uint)num_modes_);
 
   // Count number of total poses
-  int num_poses = num_modes_ + 1; // start and finish of every mode
+  int num_poses = num_modes_ + 1;  // start and finish of every mode
   for (int i = 0; i < num_modes_; i++) {
-    DRAKE_DEMAND(poses_per_mode.at(i) == 0 || 
-        (poses_per_mode.at(i) + 2 <= (uint) mode_lengths_.at(i)));
+    DRAKE_DEMAND(poses_per_mode.at(i) == 0 ||
+        (poses_per_mode.at(i) + 2 <= (uint)mode_lengths_.at(i)));
     num_poses += poses_per_mode.at(i);
   }
 
   // Assemble variable list
-  drake::solvers::VectorXDecisionVariable vars(
-      num_poses * plant_.num_positions());
+  drake::solvers::VectorXDecisionVariable vars(num_poses *
+      plant_.num_positions());
 
   int index = 0;
   for (int i = 0; i < num_modes_; i++) {
     // Set variable block, extracting positions only
-    vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
-      state_vars_by_mode(i, 0).head(plant_.num_positions());
+    vars.segment(index * plant_.num_positions(), plant_.num_positions()) =
+        state_vars_by_mode(i, 0).head(plant_.num_positions());
     index++;
 
     for (uint j = 0; j < poses_per_mode.at(i); j++) {
-
       // The jth element in mode i, counting in between the start/end poses
       int modei_index =
-          (j + 1) * (mode_lengths_.at(i) - 1)/(poses_per_mode.at(i) + 1);
+          (j + 1) * (mode_lengths_.at(i) - 1) / (poses_per_mode.at(i) + 1);
 
-      vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
+      vars.segment(index * plant_.num_positions(), plant_.num_positions()) =
           state_vars_by_mode(i, modei_index).head(plant_.num_positions());
       index++;
-    } 
+    }
   }
 
   // Final state
-  vars.segment(index * plant_.num_positions(), plant_.num_positions()) = 
-      state_vars_by_mode(num_modes_ - 1, mode_lengths_.at(num_modes_ - 1) - 1).
-          head(plant_.num_positions());
+  vars.segment(index * plant_.num_positions(), plant_.num_positions()) =
+      state_vars_by_mode(num_modes_ - 1, mode_lengths_.at(num_modes_ - 1) - 1)
+          .head(plant_.num_positions());
 
   // Create transparency vector
   VectorXd alpha_vec = VectorXd::Constant(num_poses, alpha);
@@ -613,13 +649,13 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
 
   // Create visualizer
   callback_visualizer_ = std::make_unique<multibody::MultiposeVisualizer>(
-    model_file, num_poses, alpha_vec, weld_frame_to_world);
+      model_file, num_poses, alpha_vec, weld_frame_to_world);
 
   // Callback lambda function
   auto my_callback = [this, num_poses](const Eigen::Ref<const VectorXd>& vars) {
     VectorXd vars_copy = vars;
     Eigen::Map<MatrixXd> states(vars_copy.data(), this->plant_.num_positions(),
-        num_poses);
+                                num_poses);
 
     this->callback_visualizer_->DrawPoses(states);
   };
@@ -628,11 +664,12 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
 }
 
 template <typename T>
-void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
-      unsigned int num_poses, double alpha, std::string weld_frame_to_world) {
+void HybridDircon<T>::CreateVisualizationCallback(
+    std::string model_file, unsigned int num_poses, double alpha,
+    std::string weld_frame_to_world) {
   // Check that there is an appropriate number of poses
-  DRAKE_DEMAND(num_poses >= (uint) num_modes_ + 1);
-  DRAKE_DEMAND(num_poses <= (uint) N());
+  DRAKE_DEMAND(num_poses >= (uint)num_modes_ + 1);
+  DRAKE_DEMAND(num_poses <= (uint)N());
 
   // sum of mode lengths, excluding ends
   int mode_sum = 0;
@@ -645,7 +682,7 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
   // Split up num_poses per modes, rounding down
   // If NP is the total number of  poses to visualize, excluding ends (interior)
   //   S is mode_sum, the total number of the interior knot points
-  //   and N the number of interior knot points for a particular mode, then 
+  //   and N the number of interior knot points for a particular mode, then
   //
   //   poses = (NP * N )/S
   unsigned int num_poses_without_ends = num_poses - num_modes_ - 1;
@@ -667,7 +704,7 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
     double value = 0;
     for (int i = 0; i < num_modes_; i++) {
       double fractional_value =
-          num_poses_without_ends * (mode_lengths_.at(i) - 2) - 
+          num_poses_without_ends * (mode_lengths_.at(i) - 2) -
               num_poses_per_mode.at(i) * mode_sum;
 
       if (fractional_value > value) {
@@ -680,15 +717,17 @@ void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
     assigned_sum++;
   }
 
-  for (auto& n : num_poses_per_mode)
+  std::cout << "poses per mode: " << std::endl;
+  for (auto& n : num_poses_per_mode) {
     std::cout << n << std::endl;
+  }
   CreateVisualizationCallback(model_file, num_poses_per_mode, alpha,
-      weld_frame_to_world);
+                              weld_frame_to_world);
 }
 
 template <typename T>
-void HybridDircon<T>::CreateVisualizationCallback(std::string model_file,
-      double alpha, std::string weld_frame_to_world) {
+void HybridDircon<T>::CreateVisualizationCallback(
+    std::string model_file, double alpha, std::string weld_frame_to_world) {
   CreateVisualizationCallback(model_file, N(), alpha, weld_frame_to_world);
 }
 

--- a/systems/trajectory_optimization/hybrid_dircon.h
+++ b/systems/trajectory_optimization/hybrid_dircon.h
@@ -1,7 +1,14 @@
 #pragma once
 
 #include <vector>
+
 #include <memory.h>
+
+#include "multibody/multipose_visualizer.h"
+#include "systems/trajectory_optimization/dircon_kinematic_data.h"
+#include "systems/trajectory_optimization/dircon_kinematic_data_set.h"
+#include "systems/trajectory_optimization/dircon_opt_constraints.h"
+#include "systems/trajectory_optimization/dircon_options.h"
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/symbolic.h"
@@ -10,12 +17,6 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/trajectory_optimization/multiple_shooting.h"
-
-#include "systems/trajectory_optimization/dircon_kinematic_data.h"
-#include "systems/trajectory_optimization/dircon_kinematic_data_set.h"
-#include "systems/trajectory_optimization/dircon_opt_constraints.h"
-#include "systems/trajectory_optimization/dircon_options.h"
-#include "multibody/multipose_visualizer.h"
 
 namespace dairlib {
 namespace systems {
@@ -85,8 +86,9 @@ class HybridDircon
   /// @param weld_frame_to_world The name of a frame to weld to the world frame
   ///   when parsing the model. Defaults to blank, which will not perform a weld
   void CreateVisualizationCallback(std::string model_file,
-      std::vector<unsigned int> poses_per_mode, double alpha = 1,
-      std::string weld_frame_to_world = "");
+                                   std::vector<unsigned int> poses_per_mode,
+                                   double alpha = 1,
+                                   std::string weld_frame_to_world = "");
 
   /// See CreateVisualizationCallback(std::string model_file,
   ///    std::vector<unsigned int> poses_per_mode,
@@ -97,8 +99,8 @@ class HybridDircon
   /// of frames in that mode. Since start/end poses per mdoe are required, must
   /// have num_poses >= num_modes + 1
   void CreateVisualizationCallback(std::string model_file,
-      unsigned int num_poses, double alpha = 1,
-      std::string weld_frame_to_world = "");
+                                   unsigned int num_poses, double alpha = 1,
+                                   std::string weld_frame_to_world = "");
 
   /// See CreateVisualizationCallback(std::string model_file,
   ///    unsigned int poses_per_mode,
@@ -106,7 +108,7 @@ class HybridDircon
   ///
   /// Creates a visualization callback that shows all knot points.
   void CreateVisualizationCallback(std::string model_file, double alpha = 1,
-      std::string weld_frame_to_world = "");
+                                   std::string weld_frame_to_world = "");
 
   /// Set the initial guess for the force variables for a specific mode
   /// @param mode the mode index
@@ -127,6 +129,9 @@ class HybridDircon
   }
 
   int num_modes() const { return num_modes_; }
+
+  /// Get the number of knotpoints in a specified mode
+  int mode_length(int mode_index) const { return mode_lengths()[mode_index]; };
 
   std::vector<int> mode_lengths() const { return mode_lengths_; }
 
@@ -179,7 +184,7 @@ class HybridDircon
         num_kinematic_constraints_wo_skipping_[mode]);
   }
   Eigen::VectorBlock<const drake::solvers::VectorXDecisionVariable>
-      collocation_force(int mode, int index) const {
+  collocation_force(int mode, int index) const {
     DRAKE_DEMAND(index < mode_lengths_[mode] - 1);
     return collocation_force_vars_[mode].segment(
         index * num_kinematic_constraints_wo_skipping_[mode],
@@ -190,9 +195,15 @@ class HybridDircon
       const drake::VectorX<drake::symbolic::Expression>& f,
       int interval_index) const;
 
+  /// Substitute the velocity variables in the expression with
+  /// v_post_impact_vars_ for the corresponding mode
+  /// It is up to the user to make sure this is used only on the first knotpoint
+  drake::symbolic::Expression SubstitutePostImpactVelocityVariables(
+      const drake::symbolic::Expression& e, int mode) const;
+
   using drake::systems::trajectory_optimization::MultipleShooting::N;
   using drake::systems::trajectory_optimization::MultipleShooting::
-      SubstitutePlaceholderVariables;
+  SubstitutePlaceholderVariables;
 
   void ScaleTimeVariables(double scale);
   void ScaleQuaternionSlackVariables(double scale);
@@ -227,6 +238,10 @@ class HybridDircon
   std::vector<int> num_kinematic_constraints_wo_skipping_;
 
   std::unique_ptr<multibody::MultiposeVisualizer> callback_visualizer_;
+
+  std::vector<std::pair<drake::VectorX<drake::symbolic::Variable>,
+                        drake::VectorX<drake::symbolic::Expression>>>
+      v_post_impact_vars_substitute_;
 };
 
 }  // namespace trajectory_optimization


### PR DESCRIPTION
Implementation of a more general version of #231.

Creates a Substitution member variable in Dircon that replaces the velocity variables with the correct post-impact velocity variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/236)
<!-- Reviewable:end -->
