### PR TITLE
adding a check to make sure we are not sending NaN in our motor commands

### DIFF
--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -83,22 +83,31 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   void SetStatus(const drake::systems::Context<double>& context,
                  dairlib::lcmt_input_supervisor_status* output) const;
 
+  void CheckVelocities(const drake::systems::Context<double> &context, drake::systems::DiscreteValues<double>* discrete_state) const;
+  void CheckRadio(const drake::systems::Context<double> &context, drake::systems::DiscreteValues<double>* discrete_state) const;
+
  private:
   const drake::multibody::MultibodyPlant<double>& plant_;
   const int num_actuators_;
   const int num_positions_;
   const int num_velocities_;
+  // supervisor settings
   const int min_consecutive_failures_;
   double max_joint_velocity_;
   double input_limit_;
   mutable double blend_duration_ = 0.0;
+
+  int soft_estop_trigger_index_;
+
   int status_vars_index_;
-  int soft_estop_flag_index_;
   int n_fails_index_;
   int status_index_;
+  // for blending controller efforts
   int switch_time_index_;
   int prev_efforts_index_;
   int prev_efforts_time_index_;
+
+  // leafsystem ports
   int state_input_port_;
   int command_input_port_;
   int controller_switch_input_port_;

--- a/examples/Cassie/input_supervisor.h
+++ b/examples/Cassie/input_supervisor.h
@@ -98,6 +98,7 @@ class InputSupervisor : public drake::systems::LeafSystem<double> {
   mutable double blend_duration_ = 0.0;
 
   int soft_estop_trigger_index_;
+  int is_nan_index_;
 
   int status_vars_index_;
   int n_fails_index_;


### PR DESCRIPTION
On April 14, we noticed that it is possible to forward NaN motor commands through the input supervisor, resulting in undesirable behavior on Cassie. This change triggers the soft-estop if any value in the motor commands is NaN.

We shouldn't be sending NaNs from our controllers anyway, but this acts as another safety check.

I also made minor refactoring to input supervisor to improve readability, open to feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/239)
<!-- Reviewable:end -->
