### PR TITLE
Fix a little bug in OSC logging for rotation tracking data

### DIFF
--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -339,9 +339,9 @@ void RotTaskSpaceTrackingData::UpdateYdotAndError(
   Quaterniond y_quat_des(y_des_(0), y_des_(1), y_des_(2), y_des_(3));
   Quaterniond dy_quat_des(ydot_des_(0), ydot_des_(1), ydot_des_(2),
                           ydot_des_(3));
-  Vector3d w_des_ = 2 * (dy_quat_des * y_quat_des.conjugate()).vec();
-  ydot_des_ = w_des_;  // Overwrite 4d quat_dot with 3d omega. Need this for osc logging
-  error_ydot_ = w_des_ - ydot_;
+  Vector3d w_des = 2 * (dy_quat_des * y_quat_des.conjugate()).vec();
+  ydot_des_ = w_des;  // Overwrite 4d quat_dot with 3d omega. Need this for osc logging
+  error_ydot_ = w_des - ydot_;
 }
 
 void RotTaskSpaceTrackingData::UpdateYddotDes() {

--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -340,6 +340,7 @@ void RotTaskSpaceTrackingData::UpdateYdotAndError(
   Quaterniond dy_quat_des(ydot_des_(0), ydot_des_(1), ydot_des_(2),
                           ydot_des_(3));
   Vector3d w_des_ = 2 * (dy_quat_des * y_quat_des.conjugate()).vec();
+  ydot_des_ = w_des_;  // Overwrite 4d quat_dot with 3d omega. Need this for osc logging
   error_ydot_ = w_des_ - ydot_;
 }
 


### PR DESCRIPTION
We were logging the time derivatives of quaternion (4D) instead of angular velocities (3D)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/254)
<!-- Reviewable:end -->
