### PR TITLE
adding procman script that runs all the basic controllers

### DIFF
--- a/examples/Cassie/integration_test.pmd
+++ b/examples/Cassie/integration_test.pmd
@@ -1,0 +1,198 @@
+group "1.controllers-and-dispatchers" {
+    cmd "osc_standing_controller (state_est)" {
+        exec = "bazel-bin/examples/Cassie/run_osc_standing_controller --channel_x=CASSIE_STATE_DISPATCHER  --height=.85";
+        host = "localhost";
+    }
+    cmd "osc_walking_controller" {
+        exec = "bazel-bin/examples/Cassie/run_osc_walking_controller";
+        host = "localhost";
+    }
+    cmd "osc_walking_controller (state_est)" {
+        exec = "bazel-bin/examples/Cassie/run_osc_walking_controller --channel_x=CASSIE_STATE_DISPATCHER";
+        host = "localhost";
+    }
+    cmd "dispatcher_robot_out" {
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_out --port 25001 --simulation=true";
+        host = "localhost";
+    }
+    cmd "osc_standing_controller" {
+        exec = "bazel-bin/examples/Cassie/run_osc_standing_controller  --height=.85";
+        host = "localhost";
+    }
+    cmd "pd_controller" {
+        exec = "bazel-bin/examples/Cassie/run_pd_controller";
+        host = "localhost";
+    }
+    cmd "dispatcher_robot_in" {
+        exec = "bazel-bin/examples/Cassie/dispatcher_robot_in --port 25000 --control_channel_name_1=CASSIE_INPUT";
+        host = "localhost";
+    }
+    cmd "osc_jumping_controller" {
+        exec = "bazel-bin/examples/Cassie/run_osc_jumping_controller --channel_u=CASSIE_INPUT --delay_time=2.0 --channel_x=CASSIE_STATE_SIMULATION --traj_name=jumping_0.15h_0.3d";
+        host = "localhost";
+    }
+    cmd "osc_jumping_controller (state_est)" {
+        exec = "bazel-bin/examples/Cassie/run_osc_jumping_controller --channel_u=CASSIE_INPUT --delay_time=2.0 --channel_x=CASSIE_STATE_DISPATCHER --traj_name=jumping_0.15h_0.3d";
+        host = "localhost";
+    }
+}
+
+group "2.simulators" {
+    cmd "cassie_sim" {
+        exec = "bazel-bin/examples/Cassie/multibody_sim --init_height=0.95";
+        host = "localhost";
+    }
+    cmd "cassie_mujoco_sim" {
+        exec = "../experimental/cassie-mujoco-sim/test/cassiesim -s -r";
+        host = "localhost";
+    }
+    cmd "cassie_sim_w_actuator_delay" {
+        exec = "bazel-bin/examples/Cassie/multibody_sim --init_height=0.95 --actuator_delay=0.005";
+        host = "localhost";
+    }
+}
+
+group "0.operator" {
+    cmd "state_visualizer" {
+        exec = "bazel-bin/examples/Cassie/visualizer --channel=CASSIE_STATE_SIMULATION";
+        host = "localhost";
+    }
+    cmd "drake_director" {
+        exec = "bazel-bin/director/drake-director  --script=examples/Cassie/director_scripts/show_time.py --use_builtin_scripts=point_pair_contact";
+        host = "localhost";
+    }
+    cmd "state_visualizer (dispatcher)" {
+        exec = "bazel-bin/examples/Cassie/visualizer";
+        host = "localhost";
+    }
+    cmd "switch_to_standing" {
+        exec = "bazel-bin/examples/Cassie/run_controller_switch --switch_channel=PD_CONTROLLER --new_channel=OSC_STANDING";
+        host = "localhost";
+    }
+}
+
+group "3.lcm-tools" {
+    cmd "1.signal-scope" {
+        exec = "bazel-bin/signalscope/signal-scope";
+        host = "localhost";
+    }
+    cmd "0.lcm-spy" {
+        exec = "bazel-bin/lcmtypes/dair-lcm-spy";
+        host = "localhost";
+    }
+}
+
+
+script "full_integration_test" {
+    run_script "standing_integration_test";
+    run_script "walking_integration_test";
+    run_script "jumping_integration_test";
+}
+
+script "jumping_integration_test" {
+    stop everything;
+    start cmd "drake_director";
+    wait ms 5000;
+    start cmd "state_visualizer";
+    start cmd "osc_jumping_controller";
+    start cmd "cassie_sim";
+    wait ms 5000;
+    stop cmd "cassie_sim";
+    start cmd "cassie_sim_w_actuator_delay";
+    wait ms 5000;
+    stop cmd "cassie_sim_w_actuator_delay";
+    stop cmd "osc_jumping_controller";
+    stop cmd "state_visualizer";
+    start cmd "state_visualizer (dispatcher)";
+    start cmd "osc_jumping_controller (state_est)";
+    start cmd "dispatcher_robot_out";
+    start cmd "cassie_sim";
+    wait ms 10000;
+    stop cmd "cassie_sim";
+    stop cmd "osc_jumping_controller (state_est)";
+    stop cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_in";
+    start cmd "osc_jumping_controller (state_est)";
+    wait ms 1000;
+    start cmd "cassie_mujoco_sim";
+    wait ms 10000;
+    stop cmd "state_visualizer (dispatcher)";
+    stop group "1.controllers-and-dispatchers";
+    stop group "2.simulators";
+}
+
+script "mujoco_standing" {
+    start cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_in";
+    start cmd "osc_standing_controller (state_est)";
+    start cmd "cassie_mujoco_sim";
+    wait ms 10000;
+}
+
+script "standing_integration_test" {
+    stop everything;
+    start cmd "drake_director";
+    wait ms 5000;
+    start cmd "state_visualizer";
+    start cmd "osc_standing_controller";
+    start cmd "cassie_sim";
+    wait ms 5000;
+    stop cmd "cassie_sim";
+    start cmd "cassie_sim_w_actuator_delay";
+    wait ms 5000;
+    stop cmd "cassie_sim_w_actuator_delay";
+    stop cmd "osc_standing_controller";
+    stop cmd "state_visualizer";
+    start cmd "state_visualizer (dispatcher)";
+    start cmd "osc_standing_controller (state_est)";
+    start cmd "dispatcher_robot_out";
+    start cmd "cassie_sim";
+    wait ms 5000;
+    stop cmd "cassie_sim";
+    stop cmd "osc_standing_controller (state_est)";
+    stop cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_in";
+    start cmd "osc_standing_controller (state_est)";
+    start cmd "cassie_mujoco_sim";
+    wait ms 10000;
+    stop cmd "state_visualizer (dispatcher)";
+    stop group "1.controllers-and-dispatchers";
+    stop group "2.simulators";
+}
+
+script "walking_integration_test" {
+    stop everything;
+    start cmd "drake_director";
+    wait ms 5000;
+    start cmd "state_visualizer";
+    start cmd "osc_walking_controller";
+    start cmd "cassie_sim";
+    wait ms 10000;
+    stop cmd "cassie_sim";
+    restart cmd "osc_walking_controller";
+    wait ms 500;
+    start cmd "cassie_sim_w_actuator_delay";
+    wait ms 10000;
+    stop cmd "cassie_sim_w_actuator_delay";
+    stop cmd "osc_walking_controller";
+    stop cmd "state_visualizer";
+    start cmd "state_visualizer (dispatcher)";
+    start cmd "osc_walking_controller (state_est)";
+    start cmd "dispatcher_robot_out";
+    start cmd "cassie_sim";
+    wait ms 10000;
+    stop cmd "cassie_sim";
+    stop cmd "osc_walking_controller (state_est)";
+    stop cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_out";
+    start cmd "dispatcher_robot_in";
+    start cmd "osc_walking_controller (state_est)";
+    wait ms 1000;
+    start cmd "cassie_mujoco_sim";
+    wait ms 10000;
+    stop cmd "state_visualizer (dispatcher)";
+    stop group "1.controllers-and-dispatchers";
+    stop group "2.simulators";
+}


### PR DESCRIPTION
Given the amount of changes we've been making to our Cassie controllers, it would be good to have a baseline test that makes sure that all the previous basic functionality is still working as intended.

This PR just adds a procman script that runs through all the common commands. This does not automatically check if any controller is failing and relies on the tester to manually observe the behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/264)
<!-- Reviewable:end -->
