### PR TITLE
Add Geom-Geom collider for basic queries

### DIFF
--- a/examples/trifinger/simulate_trifinger.py
+++ b/examples/trifinger/simulate_trifinger.py
@@ -9,7 +9,7 @@ class TrifingerDemoController(LeafSystem):
     LeafSystem.__init__(self)
 
     self.plant = plant
-        
+
     # Input is state, output is torque (control action)
     self.DeclareVectorInputPort("x", plant.num_positions() +
         plant.num_velocities())

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -102,3 +102,24 @@ cc_library(
     name = "ball_urdf",
     data = glob(["multibody/ball.urdf"]),
 )
+
+cc_library(
+    name = "geom_geom_collider",
+    srcs = ["geom_geom_collider.cc"],
+    hdrs = ["geom_geom_collider.h"],
+    deps = [
+        "@drake//:drake_shared_library",
+    ]
+)
+
+cc_binary(
+    name = "geom_geom_collider_test",
+    srcs = ["test/geom_geom_collider_test.cc"],
+    deps = [
+        ":geom_geom_collider",
+        ":utils",
+        "//common",
+        "@drake//:drake_shared_library",
+    ],
+    data = ["//examples/trifinger:trifinger_urdf"],
+)

--- a/multibody/geom_geom_collider.cc
+++ b/multibody/geom_geom_collider.cc
@@ -1,0 +1,109 @@
+#include "multibody/geom_geom_collider.h"
+
+#include "drake/math/rotation_matrix.h"
+
+using Eigen::Vector3d;
+using Eigen::Matrix;
+using drake::EigenPtr;
+using drake::MatrixX;
+using drake::geometry::GeometryId;
+using drake::geometry::SignedDistancePair;
+using drake::multibody::MultibodyPlant;
+using drake::systems::Context;
+
+namespace dairlib {
+namespace multibody {
+
+template <typename T>
+GeomGeomCollider<T>::GeomGeomCollider(
+    const drake::multibody::MultibodyPlant<T>& plant,
+    const drake::geometry::GeometryId geometry_id_A,
+    const drake::geometry::GeometryId geometry_id_B,
+    const int num_friction_directions)
+    : plant_(plant),
+      geometry_id_A_(geometry_id_A),
+      geometry_id_B_(geometry_id_B),
+      num_friction_directions_(num_friction_directions) ,
+      planar_normal_(Vector3d::Zero()) {
+  if (num_friction_directions == 1) {
+    throw std::runtime_error(
+      "GeomGeomCollider cannot specificy 1 friction direction unless "
+          "using planar constructor");
+  }
+}
+
+template <typename T>
+GeomGeomCollider<T>::GeomGeomCollider(
+    const drake::multibody::MultibodyPlant<T>& plant,
+    const drake::geometry::GeometryId geometry_id_A,
+    const drake::geometry::GeometryId geometry_id_B,
+    const Eigen::Vector3d planar_normal)
+    : plant_(plant),
+      geometry_id_A_(geometry_id_A),
+      geometry_id_B_(geometry_id_B),
+      num_friction_directions_(1),
+      planar_normal_(planar_normal) {}
+
+template <typename T>
+T GeomGeomCollider<T>::Eval(const Context<T>& context,
+                             EigenPtr<MatrixX<T>> J) {
+
+  const auto& query_port = plant_.get_geometry_query_input_port();
+  const auto& query_object =
+      query_port.template Eval<drake::geometry::QueryObject<T>>(context);
+
+  const SignedDistancePair<T> signed_distance_pair =
+      query_object.ComputeSignedDistancePairClosestPoints(geometry_id_A_,
+                                                          geometry_id_B_);
+
+  const auto& inspector = query_object.inspector();
+  const auto frame_A_id = inspector.GetFrameId(geometry_id_A_);
+  const auto frame_B_id = inspector.GetFrameId(geometry_id_B_);
+  const auto& frameA = plant_.GetBodyFromFrameId(frame_A_id)->body_frame();
+  const auto& frameB = plant_.GetBodyFromFrameId(frame_B_id)->body_frame();
+
+  const Eigen::Vector3d& p_ACa =
+      inspector.GetPoseInFrame(geometry_id_A_).template cast<T>() *
+          signed_distance_pair.p_ACa;
+
+  Matrix<double, 3, Eigen::Dynamic> Jq_v_BCa_W(3, plant_.num_positions());
+  auto wrt = drake::multibody::JacobianWrtVariable::kQDot;
+
+  plant_.CalcJacobianTranslationalVelocity(context, wrt,
+                                            frameA, p_ACa, frameB,
+                                            plant_.world_frame(), &Jq_v_BCa_W);
+
+  // Compute force basis
+  Matrix<double, 3, Eigen::Dynamic> force_basis(
+      3, 2 * num_friction_directions_ + 1);
+  force_basis.col(0) = signed_distance_pair.nhat_BA_W;
+
+  if (num_friction_directions_ == 1) {
+    // Then we have a planar problem
+    force_basis.col(1) =
+        signed_distance_pair.nhat_BA_W.cross(planar_normal_);
+    force_basis.col(1).normalize();
+    force_basis.col(2) = -force_basis.col(1);
+  } else {
+    // Build friction basis
+    const auto& R_WC =
+        drake::math::RotationMatrix<T>::MakeFromOneVector(
+            signed_distance_pair.nhat_BA_W, 0);
+    for (int i = 0; i < num_friction_directions_; i++) {
+      double theta = (M_PI * i) / num_friction_directions_;
+      force_basis.col(2*i + 1) = R_WC * Vector3d(0, cos(theta), sin(theta));
+      force_basis.col(2*i + 2) = -force_basis.col(2*i + 1);
+    }
+  }
+
+  *J = force_basis.transpose() * Jq_v_BCa_W;
+
+  return signed_distance_pair.distance;
+
+}
+
+}  // namespace multibody
+}  // namespace dairlib
+
+
+template class dairlib::multibody::GeomGeomCollider<double>;

--- a/multibody/geom_geom_collider.h
+++ b/multibody/geom_geom_collider.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace dairlib {
+namespace multibody {
+
+/// A class for computing collider properties between two geometries
+/// Specificaly, used to calculate the signed distance and contact Jacobians
+template <typename T>
+class GeomGeomCollider {
+ public:
+  /// Default constructor
+  /// Specifies the MultibodyPlant object, as well as the two geometries
+  /// Additionally specifies the number of friction directions, used to
+  /// construct a polytope representation of friction with
+  /// (2 * num_friction_dirctions) faces.
+  /// Setting this to 0 is acceptable for frictionless contact
+  /// With this constructor, it cannot be set to "1", as this would not be
+  /// well-defined in 3D. See alternate constructor below.
+  ///
+  /// @param plant
+  /// @param geometry_id_A
+  /// @param geometry_id_B
+  /// @param num_friction_directions
+  GeomGeomCollider(
+      const drake::multibody::MultibodyPlant<T>& plant,
+      const drake::geometry::GeometryId geometry_id_A,
+      const drake::geometry::GeometryId geometry_id_B,
+      const int num_friction_directions);
+
+  /// This is an alternate constructor for planar systems
+  /// Sets num_friction_directions_ = 1
+  /// The planar system is defined by a vector, in the world frame,
+  /// which is normal to the plane of interest.
+  ///
+  /// @param plant
+  /// @param geometry_id_A
+  /// @param geometry_id_B
+  /// @param planar_normal
+  GeomGeomCollider(
+      const drake::multibody::MultibodyPlant<T>& plant,
+      const drake::geometry::GeometryId geometry_id_A,
+      const drake::geometry::GeometryId geometry_id_B,
+      const Eigen::Vector3d planar_normal);
+
+  /// Calculates the distance and contact Jacobian, set via pointer
+  /// Jacobian is ordered [J_n; J_t], and has shape
+  /// (1 + 2 * num_friction_directions_) x (nq)
+  /// @param context
+  /// @param J
+  /// @return the distance as a scalar
+  T Eval(const drake::systems::Context<T>& context,
+         drake::EigenPtr<drake::MatrixX<T>> J);
+
+ private:
+  const drake::multibody::MultibodyPlant<T>& plant_;
+  const drake::geometry::GeometryId geometry_id_A_;
+  const drake::geometry::GeometryId geometry_id_B_;
+  const int num_friction_directions_;
+  const Eigen::Vector3d planar_normal_;
+};
+
+}  // namespace multibody
+}  // namespace dairlib
+
+extern template class dairlib::multibody::GeomGeomCollider<double>;

--- a/multibody/test/geom_geom_collider_test.cc
+++ b/multibody/test/geom_geom_collider_test.cc
@@ -1,0 +1,104 @@
+#include "multibody/multibody_utils.h"
+#include "multibody/geom_geom_collider.h"
+#include "common/find_resource.h"
+
+#include "drake/common/sorted_pair.h"
+#include "drake/multibody/plant/calc_distance_and_time_derivative.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace dairlib {
+namespace multibody {
+namespace {
+
+using drake::geometry::GeometryId;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::Parser;
+using Eigen::VectorXd;
+
+
+void GeomGeomColliderTest() {
+  drake::systems::DiagramBuilder<double> builder;
+
+  auto [plant, scene_graph] =
+      drake::multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
+
+  Parser parser(&plant, &scene_graph);
+
+  parser.package_map().Add("robot_properties_fingers",
+                           "examples/trifinger/robot_properties_fingers");
+  parser.AddModelFromFile(FindResourceOrThrow("examples/trifinger/"
+      "robot_properties_fingers/urdf/trifinger_minimal_collision.urdf"));
+  parser.AddModelFromFile(FindResourceOrThrow(
+      "examples/trifinger/robot_properties_fingers/cube/cube_v2.urdf"));
+
+  auto X_WI = drake::math::RigidTransform<double>::Identity();
+  plant.WeldFrames(plant.world_frame(),
+                    plant.GetFrameByName("base_link"), X_WI);
+  plant.Finalize();
+
+  auto diagram = builder.Build();
+
+
+  const std::vector<GeometryId>& finger_lower_link_0_geoms =
+      plant.GetCollisionGeometriesForBody(plant.GetBodyByName(
+          "finger_lower_link_0"));
+  const std::vector<GeometryId>& finger_lower_link_120_geoms =
+      plant.GetCollisionGeometriesForBody(plant.GetBodyByName(
+          "finger_lower_link_120"));
+  const std::vector<GeometryId>& cube_geoms =
+      plant.GetCollisionGeometriesForBody(plant.GetBodyByName(
+          "cube"));
+
+  // Each body here only has one geometry
+  auto geom_A = finger_lower_link_0_geoms[0];
+  auto geom_B = finger_lower_link_120_geoms[0];
+
+  GeomGeomCollider collider_A_B(plant, geom_A, geom_B, 2);
+  GeomGeomCollider collider_A_cube(plant, geom_A, cube_geoms[0], 4);
+
+  auto geometry_pair = drake::SortedPair<GeometryId>(geom_A, cube_geoms[0]);
+
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto& context = diagram->GetMutableSubsystemContext(plant,
+                                                      diagram_context.get());
+
+  VectorXd q = VectorXd::Zero(plant.num_positions());
+  auto q_map = makeNameToPositionsMap(plant);
+
+  q(q_map.at("finger_base_to_upper_joint_0")) = 0;
+  q(q_map.at("finger_upper_to_middle_joint_0")) = -1;
+  q(q_map.at("finger_middle_to_lower_joint_0")) = -1.5;
+  q(q_map.at("finger_base_to_upper_joint_0")) = 0;
+  q(q_map.at("finger_upper_to_middle_joint_120")) = -1;
+  q(q_map.at("finger_middle_to_lower_joint_120")) = -1.5;
+  q(q_map.at("finger_base_to_upper_joint_240")) = 0;
+  q(q_map.at("finger_upper_to_middle_joint_240")) = -1;
+  q(q_map.at("finger_middle_to_lower_joint_240")) = -1.5;
+  q(q_map.at("base_qw")) = 1;
+  q(q_map.at("base_qx")) = 0;
+  q(q_map.at("base_qz")) = 0;
+  q(q_map.at("base_x")) = 0;
+  q(q_map.at("base_y")) = 0;
+  q(q_map.at("base_z")) = .05;
+
+  plant.SetPositions(&context, q);
+
+  Eigen::MatrixXd J_A_cube(9, plant.num_positions());
+  collider_A_cube.Eval(context, &J_A_cube);
+  std::cout << J_A_cube << std::endl << std::endl;
+
+  Eigen::MatrixXd J_A_B(5, plant.num_positions());
+  collider_A_B.Eval(context, &J_A_B);
+  std::cout << J_A_B << std::endl << std::endl;
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace dairlib
+
+
+int main(int argc, char **argv) {
+  dairlib::multibody::GeomGeomColliderTest();
+}


### PR DESCRIPTION
Adds a simple class to compute signed distances between geometries and their Jacobians, including a polytope representation of the frictional Jacobian. If useful, it would also be easy to add a variation which doesn't compute the polytope.

Drake has this existing functionality scattered about, but not all in one place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/283)
<!-- Reviewable:end -->
