### PR TITLE
Geom collider edits

### DIFF
--- a/multibody/geom_geom_collider.cc
+++ b/multibody/geom_geom_collider.cc
@@ -8,6 +8,7 @@ using drake::EigenPtr;
 using drake::MatrixX;
 using drake::geometry::GeometryId;
 using drake::geometry::SignedDistancePair;
+using drake::multibody::JacobianWrtVariable;
 using drake::multibody::MultibodyPlant;
 using drake::systems::Context;
 
@@ -17,33 +18,54 @@ namespace multibody {
 template <typename T>
 GeomGeomCollider<T>::GeomGeomCollider(
     const drake::multibody::MultibodyPlant<T>& plant,
-    const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
-    const int num_friction_directions)
+    const drake::SortedPair<drake::geometry::GeometryId> geometry_pair)
     : plant_(plant),
       geometry_id_A_(geometry_pair.first()),
-      geometry_id_B_(geometry_pair.second()),
-      num_friction_directions_(num_friction_directions) ,
-      planar_normal_(Vector3d::Zero()) {
-  if (num_friction_directions == 1) {
-    throw std::runtime_error(
-      "GeomGeomCollider cannot specificy 1 friction direction unless "
-          "using planar constructor");
-  }
+      geometry_id_B_(geometry_pair.second()) {
 }
 
 template <typename T>
-GeomGeomCollider<T>::GeomGeomCollider(
-    const drake::multibody::MultibodyPlant<T>& plant,
-    const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
-    const Eigen::Vector3d planar_normal)
-    : plant_(plant),
-      geometry_id_A_(geometry_pair.first()),
-      geometry_id_B_(geometry_pair.second()),
-      num_friction_directions_(1),
-      planar_normal_(planar_normal) {}
+std::pair<T, MatrixX<T>> GeomGeomCollider<T>::Eval(const Context<T>& context,
+                                                   JacobianWrtVariable wrt) {
+  return DoEval(context, Eigen::Matrix3d::Identity(), wrt);
+}
 
 template <typename T>
-std::pair<T, MatrixX<T>> GeomGeomCollider<T>::Eval(const Context<T>& context) {
+std::pair<T, MatrixX<T>> GeomGeomCollider<T>::EvalPolytope(
+    const Context<T>& context, int num_friction_directions,
+    JacobianWrtVariable wrt) {
+
+  if (num_friction_directions == 1) {
+    throw std::runtime_error(
+      "GeomGeomCollider cannot specificy 1 friction direction unless "
+          "using EvalPlanar.");
+  }
+
+  // Build friction basis
+  Matrix<double, Eigen::Dynamic, 3> force_basis(
+      2 * num_friction_directions + 1, 3);
+  force_basis.row(0) << 1, 0, 0;
+
+  for (int i = 0; i < num_friction_directions; i++) {
+    double theta = (M_PI * i) / num_friction_directions;
+    force_basis.row(2*i + 1) = Vector3d(0, cos(theta), sin(theta));
+    force_basis.row(2*i + 2) = -force_basis.col(2*i + 1);
+  }
+  return DoEval(context, force_basis, wrt);
+}
+
+template <typename T>
+std::pair<T, MatrixX<T>> GeomGeomCollider<T>::EvalPlanar(
+    const Context<T>& context, const Vector3d& planar_normal,
+    JacobianWrtVariable wrt) {
+  return DoEval(context, planar_normal.transpose(), wrt);
+}
+
+  // }
+template <typename T>
+std::pair<T, MatrixX<T>> GeomGeomCollider<T>::DoEval(
+    const Context<T>& context, Matrix<double, Eigen::Dynamic, 3> force_basis,
+    JacobianWrtVariable wrt) {
 
   const auto& query_port = plant_.get_geometry_query_input_port();
   const auto& query_object =
@@ -59,42 +81,42 @@ std::pair<T, MatrixX<T>> GeomGeomCollider<T>::Eval(const Context<T>& context) {
   const auto& frameA = plant_.GetBodyFromFrameId(frame_A_id)->body_frame();
   const auto& frameB = plant_.GetBodyFromFrameId(frame_B_id)->body_frame();
 
-  const Eigen::Vector3d& p_ACa =
+  const Vector3d& p_ACa =
       inspector.GetPoseInFrame(geometry_id_A_).template cast<T>() *
           signed_distance_pair.p_ACa;
 
   Matrix<double, 3, Eigen::Dynamic> J_v_BCa_W(3, plant_.num_velocities());
-  auto wrt = drake::multibody::JacobianWrtVariable::kV;
 
   plant_.CalcJacobianTranslationalVelocity(context, wrt,
                                             frameA, p_ACa, frameB,
                                             plant_.world_frame(), &J_v_BCa_W);
 
-  // Compute force basis
-  Matrix<double, 3, Eigen::Dynamic> force_basis(
-      3, 2 * num_friction_directions_ + 1);
-  force_basis.col(0) = signed_distance_pair.nhat_BA_W;
+  const auto& R_WC =
+      drake::math::RotationMatrix<T>::MakeFromOneVector(
+          signed_distance_pair.nhat_BA_W, 0);
 
-  if (num_friction_directions_ == 1) {
-    // Then we have a planar problem
-    force_basis.col(1) =
-        signed_distance_pair.nhat_BA_W.cross(planar_normal_);
-    force_basis.col(1).normalize();
-    force_basis.col(2) = -force_basis.col(1);
-  } else {
-    // Build friction basis
-    const auto& R_WC =
-        drake::math::RotationMatrix<T>::MakeFromOneVector(
-            signed_distance_pair.nhat_BA_W, 0);
-    for (int i = 0; i < num_friction_directions_; i++) {
-      double theta = (M_PI * i) / num_friction_directions_;
-      force_basis.col(2*i + 1) = R_WC * Vector3d(0, cos(theta), sin(theta));
-      force_basis.col(2*i + 2) = -force_basis.col(2*i + 1);
-    }
+  // if force_basis is a row vector, then this is a planar problem, and the
+  // basis is encoding the planar normal direction.
+  // These calculations cannot easily be moved to the EvalPlanar() method,
+  // since they depend so heavily on the contact normal.
+  // thus the somewhat awkward calculations here.
+  if (force_basis.rows() == 1) {
+    Vector3d planar_normal = force_basis.row(0);
+    force_basis.resize(3, 3);
+
+    // First row is the contact normal, projected to the plane
+    force_basis.row(0) = signed_distance_pair.nhat_BA_W -
+        planar_normal * planar_normal.dot(signed_distance_pair.nhat_BA_W);
+    force_basis.row(0).normalize();
+
+    // Second row is the cross product between contact normal and planar normal
+    force_basis.row(1) = signed_distance_pair.nhat_BA_W.cross(planar_normal);
+    force_basis.row(1).normalize();
+    force_basis.row(2) = -force_basis.row(1);
   }
-
-  return std::pair<T, MatrixX<T>>(signed_distance_pair.distance,
-                                  force_basis.transpose() * J_v_BCa_W);
+    // Standard case
+  auto J = force_basis * R_WC.matrix().transpose() * J_v_BCa_W;
+  return std::pair<T, MatrixX<T>>(signed_distance_pair.distance, J);
 }
 
 }  // namespace multibody

--- a/multibody/geom_geom_collider.h
+++ b/multibody/geom_geom_collider.h
@@ -22,7 +22,8 @@ class GeomGeomCollider {
       const drake::SortedPair<drake::geometry::GeometryId> geometry_pair);
 
   /// Calculates the distance and contact frame Jacobian.
-  /// Jacobian is ordered [J_n; J_t], and has shape 3 x (nq)
+  /// Jacobian is ordered [J_n; J_t], and has shape 3 x (nq or nv), depending
+  /// on the choice of JacobianWrtVariable.
   /// @param context The context for the MultibodyPlant
   /// @return A pair with <distance as a scalar, J>
   std::pair<T, drake::MatrixX<T>> Eval(
@@ -33,7 +34,9 @@ class GeomGeomCollider {
 
   /// Calculates the distance and contact frame Jacobian.
   /// Jacobian is ordered [J_n; J_t], and has shape
-  ///     3 x (2*num_friction_directions + 1)
+  ////   (2*num_friction_directions + 1) x (nq or nv), depending
+  /// on the choice of JacobianWrtVariable.
+  ///
   /// Specifies the number of friction directions, used to
   /// construct a polytope representation of friction with
   /// (2 * num_friction_directions) faces.
@@ -67,7 +70,7 @@ class GeomGeomCollider {
   std::pair<T, drake::MatrixX<T>> DoEval(
       const drake::systems::Context<T>& context,
       Eigen::Matrix<double, Eigen::Dynamic, 3> force_basis,
-      drake::multibody::JacobianWrtVariable wrt);
+      drake::multibody::JacobianWrtVariable wrt, bool planar = false);
 
   const drake::multibody::MultibodyPlant<T>& plant_;
   const drake::geometry::GeometryId geometry_id_A_;

--- a/multibody/geom_geom_collider.h
+++ b/multibody/geom_geom_collider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/sorted_pair.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace dairlib {
@@ -25,8 +26,7 @@ class GeomGeomCollider {
   /// @param num_friction_directions
   GeomGeomCollider(
       const drake::multibody::MultibodyPlant<T>& plant,
-      const drake::geometry::GeometryId geometry_id_A,
-      const drake::geometry::GeometryId geometry_id_B,
+      const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
       const int num_friction_directions);
 
   /// This is an alternate constructor for planar systems
@@ -40,8 +40,7 @@ class GeomGeomCollider {
   /// @param planar_normal
   GeomGeomCollider(
       const drake::multibody::MultibodyPlant<T>& plant,
-      const drake::geometry::GeometryId geometry_id_A,
-      const drake::geometry::GeometryId geometry_id_B,
+      const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
       const Eigen::Vector3d planar_normal);
 
   /// Calculates the distance and contact Jacobian, set via pointer
@@ -50,8 +49,8 @@ class GeomGeomCollider {
   /// @param context
   /// @param J
   /// @return the distance as a scalar
-  T Eval(const drake::systems::Context<T>& context,
-         drake::EigenPtr<drake::MatrixX<T>> J);
+  std::pair<T, drake::MatrixX<T>> Eval(
+      const drake::systems::Context<T>& context);
 
  private:
   const drake::multibody::MultibodyPlant<T>& plant_;

--- a/multibody/geom_geom_collider.h
+++ b/multibody/geom_geom_collider.h
@@ -13,51 +13,65 @@ class GeomGeomCollider {
  public:
   /// Default constructor
   /// Specifies the MultibodyPlant object, as well as the two geometries
-  /// Additionally specifies the number of friction directions, used to
-  /// construct a polytope representation of friction with
-  /// (2 * num_friction_dirctions) faces.
-  /// Setting this to 0 is acceptable for frictionless contact
-  /// With this constructor, it cannot be set to "1", as this would not be
-  /// well-defined in 3D. See alternate constructor below.
   ///
   /// @param plant
   /// @param geometry_id_A
   /// @param geometry_id_B
-  /// @param num_friction_directions
   GeomGeomCollider(
       const drake::multibody::MultibodyPlant<T>& plant,
-      const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
-      const int num_friction_directions);
+      const drake::SortedPair<drake::geometry::GeometryId> geometry_pair);
 
-  /// This is an alternate constructor for planar systems
-  /// Sets num_friction_directions_ = 1
-  /// The planar system is defined by a vector, in the world frame,
-  /// which is normal to the plane of interest.
-  ///
-  /// @param plant
-  /// @param geometry_id_A
-  /// @param geometry_id_B
-  /// @param planar_normal
-  GeomGeomCollider(
-      const drake::multibody::MultibodyPlant<T>& plant,
-      const drake::SortedPair<drake::geometry::GeometryId> geometry_pair,
-      const Eigen::Vector3d planar_normal);
-
-  /// Calculates the distance and contact Jacobian, set via pointer
-  /// Jacobian is ordered [J_n; J_t], and has shape
-  /// (1 + 2 * num_friction_directions_) x (nq)
-  /// @param context
-  /// @param J
-  /// @return the distance as a scalar
+  /// Calculates the distance and contact frame Jacobian.
+  /// Jacobian is ordered [J_n; J_t], and has shape 3 x (nq)
+  /// @param context The context for the MultibodyPlant
+  /// @return A pair with <distance as a scalar, J>
   std::pair<T, drake::MatrixX<T>> Eval(
-      const drake::systems::Context<T>& context);
+      const drake::systems::Context<T>& context,
+      drake::multibody::JacobianWrtVariable wrt =
+          drake::multibody::JacobianWrtVariable::kV);
+
+
+  /// Calculates the distance and contact frame Jacobian.
+  /// Jacobian is ordered [J_n; J_t], and has shape
+  ///     3 x (2*num_friction_directions + 1)
+  /// Specifies the number of friction directions, used to
+  /// construct a polytope representation of friction with
+  /// (2 * num_friction_directions) faces.
+  /// Setting this to 0 is acceptable for frictionless contact
+  /// num_friction_directions != 1, as this would not be
+  /// well-defined in 3D.
+  ///
+  /// @param context The context for the MultibodyPlant
+  /// @param num_friction_directions
+  /// @return A pair with <distance as a scalar, J>
+  std::pair<T, drake::MatrixX<T>> EvalPolytope(
+      const drake::systems::Context<T>& context,
+      int num_friction_directions,
+      drake::multibody::JacobianWrtVariable wrt =
+          drake::multibody::JacobianWrtVariable::kV);
+
+
+  /// Calculates the distance and contact frame Jacobian for a 2D planar problem
+  /// Jacobian is ordered [J_n; +J_t; -J_t], and has shape 3 x (nq).
+  /// J_t refers to the (contact_normal x planar_normal) direction
+  /// @param context The context for the MultibodyPlant
+  /// @param planar_normal The normal vector to the planar system
+  /// @return A pair with <distance as a scalar, J>
+  std::pair<T, drake::MatrixX<T>> EvalPlanar(
+      const drake::systems::Context<T>& context,
+      const Eigen::Vector3d& planar_normal,
+      drake::multibody::JacobianWrtVariable wrt =
+          drake::multibody::JacobianWrtVariable::kV);
 
  private:
+  std::pair<T, drake::MatrixX<T>> DoEval(
+      const drake::systems::Context<T>& context,
+      Eigen::Matrix<double, Eigen::Dynamic, 3> force_basis,
+      drake::multibody::JacobianWrtVariable wrt);
+
   const drake::multibody::MultibodyPlant<T>& plant_;
   const drake::geometry::GeometryId geometry_id_A_;
   const drake::geometry::GeometryId geometry_id_B_;
-  const int num_friction_directions_;
-  const Eigen::Vector3d planar_normal_;
 };
 
 }  // namespace multibody

--- a/multibody/test/geom_geom_collider_test.cc
+++ b/multibody/test/geom_geom_collider_test.cc
@@ -2,8 +2,6 @@
 #include "multibody/geom_geom_collider.h"
 #include "common/find_resource.h"
 
-#include "drake/common/sorted_pair.h"
-#include "drake/multibody/plant/calc_distance_and_time_derivative.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -12,6 +10,7 @@ namespace dairlib {
 namespace multibody {
 namespace {
 
+using drake::SortedPair;
 using drake::geometry::GeometryId;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
@@ -55,10 +54,8 @@ void GeomGeomColliderTest() {
   auto geom_A = finger_lower_link_0_geoms[0];
   auto geom_B = finger_lower_link_120_geoms[0];
 
-  GeomGeomCollider collider_A_B(plant, geom_A, geom_B, 2);
-  GeomGeomCollider collider_A_cube(plant, geom_A, cube_geoms[0], 4);
-
-  auto geometry_pair = drake::SortedPair<GeometryId>(geom_A, cube_geoms[0]);
+  GeomGeomCollider collider_A_B(plant, SortedPair(geom_A, geom_B), 2);
+  GeomGeomCollider collider_A_cube(plant, SortedPair(geom_A, cube_geoms[0]), 4);
 
   auto diagram_context = diagram->CreateDefaultContext();
   auto& context = diagram->GetMutableSubsystemContext(plant,
@@ -85,12 +82,10 @@ void GeomGeomColliderTest() {
 
   plant.SetPositions(&context, q);
 
-  Eigen::MatrixXd J_A_cube(9, plant.num_positions());
-  collider_A_cube.Eval(context, &J_A_cube);
+  auto [phi_A_cube, J_A_cube] = collider_A_cube.Eval(context);
   std::cout << J_A_cube << std::endl << std::endl;
 
-  Eigen::MatrixXd J_A_B(5, plant.num_positions());
-  collider_A_B.Eval(context, &J_A_B);
+  auto [phi_A_B, J_A_B] = collider_A_B.Eval(context);
   std::cout << J_A_B << std::endl << std::endl;
 }
 

--- a/multibody/test/geom_geom_collider_test.cc
+++ b/multibody/test/geom_geom_collider_test.cc
@@ -54,8 +54,8 @@ void GeomGeomColliderTest() {
   auto geom_A = finger_lower_link_0_geoms[0];
   auto geom_B = finger_lower_link_120_geoms[0];
 
-  GeomGeomCollider collider_A_B(plant, SortedPair(geom_A, geom_B), 2);
-  GeomGeomCollider collider_A_cube(plant, SortedPair(geom_A, cube_geoms[0]), 4);
+  GeomGeomCollider collider_A_B(plant, SortedPair(geom_A, geom_B));
+  GeomGeomCollider collider_A_cube(plant, SortedPair(geom_A, cube_geoms[0]));
 
   auto diagram_context = diagram->CreateDefaultContext();
   auto& context = diagram->GetMutableSubsystemContext(plant,
@@ -82,11 +82,18 @@ void GeomGeomColliderTest() {
 
   plant.SetPositions(&context, q);
 
+  std::cout << "A-cube, standard basis" << std::endl;
   auto [phi_A_cube, J_A_cube] = collider_A_cube.Eval(context);
   std::cout << J_A_cube << std::endl << std::endl;
 
-  auto [phi_A_B, J_A_B] = collider_A_B.Eval(context);
+  std::cout << "A-B, 4-direction polytope" << std::endl;
+  auto [phi_A_B, J_A_B] = collider_A_B.EvalPolytope(context, 4);
   std::cout << J_A_B << std::endl << std::endl;
+
+  std::cout << "A-B, planar" << std::endl;
+  auto [phi_A_B_planar, J_A_B_planar] = collider_A_B.EvalPlanar(context,
+      Eigen::Vector3d(0, 1, 0));
+  std::cout << J_A_B_planar << std::endl << std::endl;
 }
 
 }  // namespace


### PR DESCRIPTION
Made a few changes from peer review and per use on the ADMM branch. Of note:

- Removed any reference to number of friction directions in the constructor. Now, this information is provided in the `EvalX` methods
- Three `EvalX` methods, one for the standard friction basis, one for a planar problem, and one for a polytope friction cone
- Now returns a `std::pair<phi, J>` rather than `J` by pointer. This should be simpler to use with pybind

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/285)
<!-- Reviewable:end -->
