### PR TITLE
Fix bug where fast_osqp_solver doesn't set solver result

### DIFF
--- a/solvers/fast_osqp_solver.cc
+++ b/solvers/fast_osqp_solver.cc
@@ -346,7 +346,7 @@ void FastOsqpSolver::DoSolve(const MathematicalProgram& prog,
         "OsqpSolver doesn't support the feature of variable scaling.");
   }
 
-  auto solver_details = result->SetSolverDetailsType<OsqpSolverDetails>();
+  OsqpSolverDetails& solver_details = result->SetSolverDetailsType<OsqpSolverDetails>();
 
   // OSQP solves a convex quadratic programming problem
   // min 0.5 xᵀPx + qᵀx


### PR DESCRIPTION
Fixes a bug where FastOsqpSolver didn't set the result details correctly due to not accessing prog->OsqPSolverDetails by reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/289)
<!-- Reviewable:end -->
