### PR TITLE
Fix bugs in WorldPointEvaluator and CassieFixedPointSolver

### DIFF
--- a/multibody/kinematic/test/kinematic_evaluator_test.cc
+++ b/multibody/kinematic/test/kinematic_evaluator_test.cc
@@ -112,9 +112,9 @@ TEST_F(KinematicEvaluatorTest, WorldPointEvaluatorTest) {
       frame, Vector3d({1, 0, 0}), Vector3d({1, 2, 3}), true);
 
   auto new_phi = new_evaluator.EvalFull(*context);
-  EXPECT_TRUE(CompareMatrices(Vector3d({-4, -2, 1}), new_phi, tolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3d({4, -2, -1}), new_phi, tolerance));
   auto new_phi_active = new_evaluator.EvalActive(*context);
-  EXPECT_TRUE(CompareMatrices(Vector3d({-4, -2, 1}), new_phi_active,
+  EXPECT_TRUE(CompareMatrices(Vector3d({4, -2, -1}), new_phi_active,
       tolerance));  
 }
 

--- a/multibody/kinematic/test/kinematic_evaluator_test.cc
+++ b/multibody/kinematic/test/kinematic_evaluator_test.cc
@@ -1,29 +1,31 @@
+#include "multibody/kinematic/kinematic_evaluator.h"
+
 #include <memory>
 #include <utility>
-#include <gtest/gtest.h>
 
-#include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/multibody/plant/multibody_plant.h"
-#include "drake/multibody/parsing/parser.h"
+#include <gtest/gtest.h>
 
 #include "common/find_resource.h"
 #include "multibody/kinematic/distance_evaluator.h"
-#include "multibody/kinematic/kinematic_evaluator.h"
 #include "multibody/kinematic/world_point_evaluator.h"
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
 
 namespace dairlib {
 namespace multibody {
 namespace {
 
 using drake::CompareMatrices;
-using drake::multibody::MultibodyPlant;
 using drake::geometry::SceneGraph;
 using drake::multibody::Body;
+using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
 
+using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
-using Eigen::MatrixXd;
 
 class KinematicEvaluatorTest : public ::testing::Test {
  protected:
@@ -36,9 +38,8 @@ class KinematicEvaluatorTest : public ::testing::Test {
 
     parser.AddModelFromFile(full_name);
 
-    plant_->WeldFrames(
-        plant_->world_frame(), plant_->GetFrameByName("base"),
-        drake::math::RigidTransform<double>());
+    plant_->WeldFrames(plant_->world_frame(), plant_->GetFrameByName("base"),
+                       drake::math::RigidTransform<double>());
 
     plant_->Finalize();
   }
@@ -46,15 +47,18 @@ class KinematicEvaluatorTest : public ::testing::Test {
   std::unique_ptr<MultibodyPlant<double>> plant_;
 };
 
-TEST_F(KinematicEvaluatorTest, WorldPointEvaluatorTest) {
+TEST_F(KinematicEvaluatorTest,
+       WorldPointEvaluatorFullRotationSpecificationTest) {
   const double tolerance = 1e-10;
 
   Vector3d pt_A({0, 0, -.5});
   const auto& frame = plant_->GetFrameByName("right_lower_leg");
 
-  // Default evaluator: vertical normal, zero offset
-  auto evaluator = WorldPointEvaluator<double>(*plant_, pt_A, frame,
-      Vector3d({0, 0, 1}), Vector3d::Zero(), false);
+  // Default evaluator: identity ground frame, zero offset
+  std::vector<int> active_directions = {2};
+  auto evaluator = WorldPointEvaluator<double>(
+      *plant_, pt_A, frame, Eigen::Matrix3d::Identity(), Vector3d::Zero(),
+      active_directions);
 
   auto context = plant_->CreateDefaultContext();
 
@@ -75,8 +79,8 @@ TEST_F(KinematicEvaluatorTest, WorldPointEvaluatorTest) {
 
   auto J = evaluator.EvalFullJacobian(*context);
   MatrixXd J_expected(3, 6);
-  J_expected.row(0) << 0, 0, 0, 0, 0, 0;
-  J_expected.row(1) << -1, 0, 1, 0, 1, .5;
+  J_expected.row(0) << 1, 0, -1, 0, -1, -0.5;
+  J_expected.row(1) << 0, 0, 0, 0, 0, 0;
   J_expected.row(2) << 0, 1, 0, 0, 0, 0;
   EXPECT_TRUE(CompareMatrices(J, J_expected, tolerance));
 
@@ -87,14 +91,14 @@ TEST_F(KinematicEvaluatorTest, WorldPointEvaluatorTest) {
 
   auto phidot = evaluator.EvalFullTimeDerivative(*context);
   VectorXd phidot_expected(3);
-  phidot_expected << 0, 1.5, 1;
+  phidot_expected << -1.5, 0, 1;
   EXPECT_TRUE(CompareMatrices(phidot, phidot_expected, tolerance));
 
   auto phidot_active = evaluator.EvalActiveTimeDerivative(*context);
   VectorXd phidot_active_expected(1);
   phidot_active_expected << 1;
-  EXPECT_TRUE(CompareMatrices(phidot_active, phidot_active_expected,
-      tolerance));
+  EXPECT_TRUE(
+      CompareMatrices(phidot_active, phidot_active_expected, tolerance));
 
   auto Jdotv = evaluator.EvalFullJacobianDotTimesV(*context);
   VectorXd Jdotv_expected(3);
@@ -108,14 +112,94 @@ TEST_F(KinematicEvaluatorTest, WorldPointEvaluatorTest) {
 
   // Non-default evaluator: non-vertical normal, non-zero offset
   // Performing minimal tests
-  auto new_evaluator = WorldPointEvaluator<double>(*plant_, pt_A,
-      frame, Vector3d({1, 0, 0}), Vector3d({1, 2, 3}), true);
+  auto new_evaluator = WorldPointEvaluator<double>(
+      *plant_, pt_A, frame, Vector3d({1, 0, 0}), Vector3d({1, 2, 3}), true);
 
   auto new_phi = new_evaluator.EvalFull(*context);
   EXPECT_TRUE(CompareMatrices(Vector3d({4, -2, -1}), new_phi, tolerance));
   auto new_phi_active = new_evaluator.EvalActive(*context);
-  EXPECT_TRUE(CompareMatrices(Vector3d({4, -2, -1}), new_phi_active,
-      tolerance));  
+  EXPECT_TRUE(
+      CompareMatrices(Vector3d({4, -2, -1}), new_phi_active, tolerance));
+}
+
+TEST_F(KinematicEvaluatorTest,
+       WorldPointEvaluatorGroundNormalSpecificationTest) {
+  const double tolerance = 1e-10;
+
+  Vector3d pt_A({0, 0, -.5});
+  const auto& frame = plant_->GetFrameByName("right_lower_leg");
+
+  // Default evaluator: vertical normal, zero offset
+  auto evaluator = WorldPointEvaluator<double>(
+      *plant_, pt_A, frame, Vector3d({0, 0, 1}), Vector3d::Zero(), false);
+
+  auto context = plant_->CreateDefaultContext();
+
+  // Test q = 0, legs straight down
+  VectorXd q = VectorXd::Zero(plant_->num_positions());
+  plant_->SetPositions(context.get(), q);
+  VectorXd v = Eigen::VectorXd::Constant(plant_->num_velocities(), 1);
+  plant_->SetVelocities(context.get(), v);
+
+  // We construct WorldPointEvaluator's rotation matrix by the normal vector of
+  // ground plane, so we don't have control over the tangent directions, so we
+  // don't compare x and y component (the first two rows) of phi, J, phidot,
+  // JdotV.
+  auto phi = evaluator.EvalFull(*context);
+  EXPECT_TRUE(
+      CompareMatrices(Vector3d({0, 0, -1}).row(2), phi.row(2), tolerance));
+
+  auto phi_active = evaluator.EvalActive(*context);
+
+  VectorXd phi_active_expected(1);
+  phi_active_expected << -1;
+  EXPECT_TRUE(CompareMatrices(phi_active_expected, phi_active, tolerance));
+
+  auto J = evaluator.EvalFullJacobian(*context);
+  MatrixXd J_expected(3, 6);
+  J_expected.row(0) << 1, 0, -1, 0, -1, -0.5;
+  J_expected.row(1) << 0, 0, 0, 0, 0, 0;
+  J_expected.row(2) << 0, 1, 0, 0, 0, 0;
+  EXPECT_TRUE(CompareMatrices(J.row(2), J_expected.row(2), tolerance));
+
+  auto J_active = evaluator.EvalActiveJacobian(*context);
+  MatrixXd J_active_expected(1, 6);
+  J_active_expected << 0, 1, 0, 0, 0, 0;
+  EXPECT_TRUE(CompareMatrices(J_active, J_active_expected, tolerance));
+
+  auto phidot = evaluator.EvalFullTimeDerivative(*context);
+  VectorXd phidot_expected(3);
+  phidot_expected << -1.5, 0, 1;
+  EXPECT_TRUE(
+      CompareMatrices(phidot.row(2), phidot_expected.row(2), tolerance));
+
+  auto phidot_active = evaluator.EvalActiveTimeDerivative(*context);
+  VectorXd phidot_active_expected(1);
+  phidot_active_expected << 1;
+  EXPECT_TRUE(
+      CompareMatrices(phidot_active, phidot_active_expected, tolerance));
+
+  auto Jdotv = evaluator.EvalFullJacobianDotTimesV(*context);
+  VectorXd Jdotv_expected(3);
+  Jdotv_expected << 0, 0, 6.5;
+  EXPECT_TRUE(CompareMatrices(Jdotv.row(2), Jdotv_expected.row(2), tolerance));
+
+  auto Jdotv_active = evaluator.EvalActiveJacobianDotTimesV(*context);
+  VectorXd Jdotv_active_expected(1);
+  Jdotv_active_expected << 6.5;
+  EXPECT_TRUE(CompareMatrices(Jdotv_active, Jdotv_active_expected, tolerance));
+
+  // Non-default evaluator: non-vertical normal, non-zero offset
+  // Performing minimal tests
+  auto new_evaluator = WorldPointEvaluator<double>(
+      *plant_, pt_A, frame, Vector3d({1, 0, 0}), Vector3d({1, 2, 3}), true);
+
+  auto new_phi = new_evaluator.EvalFull(*context);
+  EXPECT_TRUE(
+      CompareMatrices(Vector3d({4, -2, -1}).row(2), new_phi.row(2), tolerance));
+  auto new_phi_active = new_evaluator.EvalActive(*context);
+  EXPECT_TRUE(
+      CompareMatrices(Vector3d({4, -2, -1}), new_phi_active, tolerance));
 }
 
 TEST_F(KinematicEvaluatorTest, DistanceEvaluatorTest) {
@@ -127,14 +211,14 @@ TEST_F(KinematicEvaluatorTest, DistanceEvaluatorTest) {
   const auto& frame_B = plant_->GetFrameByName("left_lower_leg");
 
   // Default evaluator: vertical normal, zero offset
-  auto evaluator = DistanceEvaluator<double>(*plant_, pt_A, frame_A, pt_B,
-      frame_B, .5);
+  auto evaluator =
+      DistanceEvaluator<double>(*plant_, pt_A, frame_A, pt_B, frame_B, .5);
 
   auto context = plant_->CreateDefaultContext();
 
   // Test q = pi/2, legs straight down
   VectorXd q = VectorXd::Zero(plant_->num_positions());
-  q(4) = M_PI/2.0;
+  q(4) = M_PI / 2.0;
   plant_->SetPositions(context.get(), q);
   VectorXd v = Eigen::VectorXd::Random(plant_->num_velocities());
   plant_->SetVelocities(context.get(), v);
@@ -153,7 +237,6 @@ TEST_F(KinematicEvaluatorTest, DistanceEvaluatorTest) {
   auto phi_perturbed = evaluator.EvalFull(*context);
   EXPECT_TRUE(CompareMatrices(J * v, (phi_perturbed - phi) / dt, dt * 100));
 
-  
   // Compare Jdotv using numerical approximation
   auto J_perturbed = evaluator.EvalFullJacobian(*context);
   auto Jdot_approx = (J_perturbed - J) / dt;
@@ -164,7 +247,7 @@ TEST_F(KinematicEvaluatorTest, DistanceEvaluatorTest) {
 }  // namespace multibody
 }  // namespace dairlib
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/multibody/kinematic/world_point_evaluator.cc
+++ b/multibody/kinematic/world_point_evaluator.cc
@@ -19,47 +19,46 @@ namespace dairlib {
 namespace multibody {
 
 template <typename T>
-WorldPointEvaluator<T>::WorldPointEvaluator(const MultibodyPlant<T>& plant,
-                                            Vector3d pt_A,
-                                            const Frame<T>& frame_A,
-                                            const Matrix3d rotation,
-                                            const Vector3d offset,
-                                            std::vector<int> active_directions)
+WorldPointEvaluator<T>::WorldPointEvaluator(
+    const MultibodyPlant<T>& plant, const Vector3d& pt_A,
+    const Frame<T>& frame_A, const Matrix3d& ground_frame_rotation_mat,
+    const Vector3d& offset, std::vector<int> active_directions)
     : KinematicEvaluator<T>(plant, 3),
       pt_A_(pt_A),
       frame_A_(frame_A),
       offset_(offset),
-      rotation_(rotation) {
+      rotation_(ground_frame_rotation_mat.transpose()) {
   this->set_active_inds(active_directions);
 }
 
 template <typename T>
 WorldPointEvaluator<T>::WorldPointEvaluator(
-    const MultibodyPlant<T>& plant, Vector3d pt_A, const Frame<T>& frame_A,
-    const multibody::ViewFrame<T>& view_frame,
-    const Matrix3d rotation, const Vector3d offset,
+    const MultibodyPlant<T>& plant, const Vector3d& pt_A,
+    const Frame<T>& frame_A, const multibody::ViewFrame<T>& view_frame,
+    const Matrix3d& ground_frame_rotation_mat, const Vector3d& offset,
     std::vector<int> active_directions)
     : KinematicEvaluator<T>(plant, 3),
       pt_A_(pt_A),
       frame_A_(frame_A),
       offset_(offset),
-      rotation_(rotation),
+      rotation_(ground_frame_rotation_mat.transpose()),
       view_frame_(&view_frame) {
   this->set_active_inds(active_directions);
 }
 
 template <typename T>
 WorldPointEvaluator<T>::WorldPointEvaluator(const MultibodyPlant<T>& plant,
-                                            const Vector3d pt_A,
+                                            const Vector3d& pt_A,
                                             const Frame<T>& frame_A,
-                                            const Vector3d normal,
-                                            const Vector3d offset,
+                                            const Vector3d& normal,
+                                            const Vector3d& offset,
                                             bool tangent_active)
     : KinematicEvaluator<T>(plant, 3),
       pt_A_(pt_A),
       frame_A_(frame_A),
       offset_(offset),
-      rotation_(RotationMatrix<double>::MakeFromOneVector(normal, 2)) {
+      rotation_(
+          RotationMatrix<double>::MakeFromOneVector(normal, 2).transpose()) {
   if (!tangent_active) {
     this->set_active_inds({2});  // only z is active
   }

--- a/multibody/kinematic/world_point_evaluator.cc
+++ b/multibody/kinematic/world_point_evaluator.cc
@@ -21,13 +21,13 @@ namespace multibody {
 template <typename T>
 WorldPointEvaluator<T>::WorldPointEvaluator(
     const MultibodyPlant<T>& plant, const Vector3d& pt_A,
-    const Frame<T>& frame_A, const Matrix3d& ground_frame_rotation_mat,
+    const Frame<T>& frame_A, const Matrix3d& R_GW,
     const Vector3d& offset, std::vector<int> active_directions)
     : KinematicEvaluator<T>(plant, 3),
       pt_A_(pt_A),
       frame_A_(frame_A),
       offset_(offset),
-      rotation_(ground_frame_rotation_mat.transpose()) {
+      rotation_(R_GW.transpose()) {
   this->set_active_inds(active_directions);
 }
 
@@ -35,13 +35,13 @@ template <typename T>
 WorldPointEvaluator<T>::WorldPointEvaluator(
     const MultibodyPlant<T>& plant, const Vector3d& pt_A,
     const Frame<T>& frame_A, const multibody::ViewFrame<T>& view_frame,
-    const Matrix3d& ground_frame_rotation_mat, const Vector3d& offset,
+    const Matrix3d& R_GW, const Vector3d& offset,
     std::vector<int> active_directions)
     : KinematicEvaluator<T>(plant, 3),
       pt_A_(pt_A),
       frame_A_(frame_A),
       offset_(offset),
-      rotation_(ground_frame_rotation_mat.transpose()),
+      rotation_(R_GW.transpose()),
       view_frame_(&view_frame) {
   this->set_active_inds(active_directions);
 }

--- a/multibody/kinematic/world_point_evaluator.h
+++ b/multibody/kinematic/world_point_evaluator.h
@@ -97,7 +97,7 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   const Eigen::Vector3d pt_A_;
   const drake::multibody::Frame<T>& frame_A_;
   const Eigen::Vector3d offset_;
-  const drake::math::RotationMatrix<double> rotation_;
+  const drake::math::RotationMatrix<double> R_WB_;
   const multibody::ViewFrame<T>* view_frame_ = nullptr;
   bool is_frictional_ = false;
 };

--- a/multibody/kinematic/world_point_evaluator.h
+++ b/multibody/kinematic/world_point_evaluator.h
@@ -18,8 +18,9 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   /// @param plant
   /// @param pt_A the contact point on the body
   /// @param frame_A the frame of reference for pt_A
-  /// @param rotation The rotation matrix R representing the ground frame s.t.
-  ////   the evaluation is R^T * r_A_world (default identity matrix)
+  /// @param R_GW The rotation matrix R representing the ground frame G s.t.
+  ////   the evaluation is R^T * r_A_world (transforming `r_A_world` from the
+  ////   world frame W to the ground frame G)
   /// @param offset The nominal world location of pt_A (default [0;0;0])
   /// @param active_directions The directions, a subset of {0,1,2} to be
   ///    considered active. These will correspond to rows of the rotation matrix
@@ -28,8 +29,7 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   WorldPointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
                       const Eigen::Vector3d& pt_A,
                       const drake::multibody::Frame<T>& frame_A,
-                      const Eigen::Matrix3d& ground_frame_rotation_mat =
-                          Eigen::Matrix3d::Identity(),
+                      const Eigen::Matrix3d& R_GW = Eigen::Matrix3d::Identity(),
                       const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
                       std::vector<int> active_directions = {0, 1, 2});
 
@@ -43,8 +43,7 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
                       const Eigen::Vector3d& pt_A,
                       const drake::multibody::Frame<T>& frame_A,
                       const multibody::ViewFrame<T>& view_frame,
-                      const Eigen::Matrix3d& ground_frame_rotation_mat =
-                          Eigen::Matrix3d::Identity(),
+                      const Eigen::Matrix3d& R_GW = Eigen::Matrix3d::Identity(),
                       const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
                       std::vector<int> active_directions = {0, 1, 2});
 

--- a/multibody/kinematic/world_point_evaluator.h
+++ b/multibody/kinematic/world_point_evaluator.h
@@ -18,33 +18,35 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   /// @param plant
   /// @param pt_A the contact point on the body
   /// @param frame_A the frame of reference for pt_A
-  /// @param rotation The rotation matrix R s.t. the evaluation is R * r_A_world
-  ////   (default identity matrix)
+  /// @param rotation The rotation matrix R representing the ground frame s.t.
+  ////   the evaluation is R^T * r_A_world (default identity matrix)
   /// @param offset The nominal world location of pt_A (default [0;0;0])
   /// @param active_directions The directions, a subset of {0,1,2} to be
   ///    considered active. These will correspond to rows of the rotation matrix
   ////   Default is {0,1,2}.
 
-  WorldPointEvaluator(
-      const drake::multibody::MultibodyPlant<T>& plant,
-      const Eigen::Vector3d pt_A, const drake::multibody::Frame<T>& frame_A,
-      const Eigen::Matrix3d rotation = Eigen::Matrix3d::Identity(),
-      const Eigen::Vector3d offset = Eigen::Vector3d::Zero(),
-      std::vector<int> active_directions = {0, 1, 2});
+  WorldPointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
+                      const Eigen::Vector3d& pt_A,
+                      const drake::multibody::Frame<T>& frame_A,
+                      const Eigen::Matrix3d& ground_frame_rotation_mat =
+                          Eigen::Matrix3d::Identity(),
+                      const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
+                      std::vector<int> active_directions = {0, 1, 2});
 
   /// The same constructor as the above one except for the argument
-  /// `view_frame`. 
+  /// `view_frame`.
   /// `WorldPointEvaluator` computes position, Jacobian and JdotV in the world
   /// frame, and expresses them in `ViewFrame` (i.e. rotates the vectors and
-  /// matrix). 
+  /// matrix).
 
-  WorldPointEvaluator(
-      const drake::multibody::MultibodyPlant<T>& plant,
-      const Eigen::Vector3d pt_A, const drake::multibody::Frame<T>& frame_A,
-      const multibody::ViewFrame<T>& view_frame,
-      const Eigen::Matrix3d rotation = Eigen::Matrix3d::Identity(),
-      const Eigen::Vector3d offset = Eigen::Vector3d::Zero(),
-      std::vector<int> active_directions = {0, 1, 2});
+  WorldPointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
+                      const Eigen::Vector3d& pt_A,
+                      const drake::multibody::Frame<T>& frame_A,
+                      const multibody::ViewFrame<T>& view_frame,
+                      const Eigen::Matrix3d& ground_frame_rotation_mat =
+                          Eigen::Matrix3d::Identity(),
+                      const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
+                      std::vector<int> active_directions = {0, 1, 2});
 
   /// Constructor for WorldPointEvaluator, defined via a normal direction
   /// This will automatically construct an appropriate rotation matrix.
@@ -54,7 +56,7 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   /// @param plant
   /// @param pt_A the contact point on the body
   /// @param frame_A the frame of reference for pt_A
-  /// @param normal The normal unit vector (must be specified)
+  /// @param normal The normal unit vector of the ground (must be specified)
   /// @param offset The nominal world location of pt_A
   /// @param xy_active If true, then the tangential directions are active
   ///    If false, they be inactive, and thus still appear in
@@ -62,10 +64,10 @@ class WorldPointEvaluator : public KinematicEvaluator<T> {
   ///    Note that this defaults to true.
 
   WorldPointEvaluator(const drake::multibody::MultibodyPlant<T>& plant,
-                      const Eigen::Vector3d pt_A,
+                      const Eigen::Vector3d& pt_A,
                       const drake::multibody::Frame<T>& frame_A,
-                      const Eigen::Vector3d normal,
-                      const Eigen::Vector3d offset = Eigen::Vector3d::Zero(),
+                      const Eigen::Vector3d& normal,
+                      const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
                       bool tangent_active = true);
 
   drake::VectorX<T> EvalFull(


### PR DESCRIPTION
Thanks Diego for catching the bug in `WorldPointEvaluator`!

This PR fix a bug in the rotation matrix creation from ground normal direction in `WorldPointEvaluator`. Another bug related to ground incline was found in `CassieFixedPointSolver` during testing. 

New changes were tested and visualized in cassie sim. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/290)
<!-- Reviewable:end -->
