### PR TITLE
improved fsm visualization

### DIFF
--- a/bindings/pydairlib/analysis/mbp_plotting_utils.py
+++ b/bindings/pydairlib/analysis/mbp_plotting_utils.py
@@ -412,8 +412,7 @@ def add_fsm_to_plot(ps, fsm_time, fsm_signal, scale=1):
     ax = ps.fig.axes[0]
     ymin, ymax = ax.get_ylim()
 
-    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 0), alpha=0.1, color=ps.blue)
-    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 1), alpha=0.1, color=ps.blue)
-    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 2), alpha=0.1, color=ps.grey)
-    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 3), alpha=0.1, color=ps.grey)
+    # uses default color map
+    for i in np.unique(fsm_signal):
+        ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == i), alpha=0.2)
     ax.relim()

--- a/bindings/pydairlib/analysis/mbp_plotting_utils.py
+++ b/bindings/pydairlib/analysis/mbp_plotting_utils.py
@@ -409,3 +409,11 @@ def plot_epsilon_sol(osc_debug, time_slice, epsilon_slice):
 
 def add_fsm_to_plot(ps, fsm_time, fsm_signal, scale=1):
     ps.plot(fsm_time, scale*fsm_signal)
+    ax = ps.fig.axes[0]
+    ymin, ymax = ax.get_ylim()
+
+    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 0), alpha=0.1, color=ps.blue)
+    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 1), alpha=0.1, color=ps.blue)
+    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 2), alpha=0.1, color=ps.grey)
+    ax.fill_between(fsm_time, ymin, ymax, where=(fsm_signal == 3), alpha=0.1, color=ps.grey)
+    ax.relim()

--- a/bindings/pydairlib/analysis/mbp_plotting_utils.py
+++ b/bindings/pydairlib/analysis/mbp_plotting_utils.py
@@ -407,8 +407,7 @@ def plot_epsilon_sol(osc_debug, time_slice, epsilon_slice):
     return ps
 
 
-def add_fsm_to_plot(ps, fsm_time, fsm_signal, scale=1):
-    ps.plot(fsm_time, scale*fsm_signal)
+def add_fsm_to_plot(ps, fsm_time, fsm_signal):
     ax = ps.fig.axes[0]
     ymin, ymax = ax.get_ylim()
 


### PR DESCRIPTION
Small change to improve adding the fsm to the plot

This plots the fsm state as a shaded band like in this example. Open to color suggestions or other visualizations

![screenshot_20220405_151711](https://user-images.githubusercontent.com/10571141/161832585-d4d14e9e-7d9f-402a-986b-dee89a437a66.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/295)
<!-- Reviewable:end -->
