### PR TITLE
fixing naming convention in multibody utils

### DIFF
--- a/bindings/pydairlib/cassie/cassie_utils_py.cc
+++ b/bindings/pydairlib/cassie/cassie_utils_py.cc
@@ -29,7 +29,7 @@ PYBIND11_MODULE(cassie_utils, m) {
            &dairlib::LeftLoopClosureEvaluator<double>, py::arg("plant"))
       .def("RightLoopClosureEvaluator",
            &dairlib::RightLoopClosureEvaluator<double>, py::arg("plant"))
-      .def("addCassieMultibody", &dairlib::addCassieMultibody, py::arg("plant"),
+      .def("AddCassieMultibody", &dairlib::AddCassieMultibody, py::arg("plant"),
            py::arg("scene_graph"), py::arg("floating_base"),
            py::arg("filename"), py::arg("add_leaf_springs"),
            py::arg("add_loop_closure"));

--- a/bindings/pydairlib/multibody/multibody_py.cc
+++ b/bindings/pydairlib/multibody/multibody_py.cc
@@ -24,21 +24,21 @@ PYBIND11_MODULE(multibody, m) {
       .def(py::init<std::string, int, Eigen::VectorXd, std::string>())
       .def("DrawPoses", &MultiposeVisualizer::DrawPoses, py::arg("poses"));
 
-  m.def("makeNameToPositionsMap",
-        &dairlib::multibody::makeNameToPositionsMap<double>, py::arg("plant"))
-      .def("makeNameToVelocitiesMap",
-           &dairlib::multibody::makeNameToVelocitiesMap<double>,
+  m.def("MakeNameToPositionsMaps",
+        &dairlib::multibody::MakeNameToPositionsMaps<double>, py::arg("plant"))
+      .def("MakeNameToVelocitiesMap",
+           &dairlib::multibody::MakeNameToVelocitiesMap<double>,
            py::arg("plant"))
-      .def("makeNameToActuatorsMap",
-           &dairlib::multibody::makeNameToActuatorsMap<double>,
+      .def("MakeNameToActuatorsMap",
+           &dairlib::multibody::MakeNameToActuatorsMap<double>,
            py::arg("plant"))
-      .def("createStateNameVectorFromMap",
-           &dairlib::multibody::createStateNameVectorFromMap<double>,
+      .def("CreateStateNameVectorFromMap",
+           &dairlib::multibody::CreateStateNameVectorFromMap<double>,
            py::arg("plant"))
-      .def("createActuatorNameVectorFromMap",
-           &dairlib::multibody::createActuatorNameVectorFromMap<double>,
+      .def("CreateActuatorNameVectorFromMap",
+           &dairlib::multibody::CreateActuatorNameVectorFromMap<double>,
            py::arg("plant"))
-      .def("addFlatTerrain", &dairlib::multibody::addFlatTerrain<double>,
+      .def("AddFlatTerrain", &dairlib::multibody::AddFlatTerrain<double>,
            py::arg("plant"), py::arg("scene_graph"), py::arg("mu_static"),
            py::arg("mu_kinetic"),
            py::arg("normal_W") = Eigen::Vector3d(0, 0, 1),

--- a/examples/Cassie/cassie_encoder.cc
+++ b/examples/Cassie/cassie_encoder.cc
@@ -12,8 +12,8 @@ CassieEncoder::CassieEncoder(
     const drake::multibody::MultibodyPlant<double>& plant)
     : num_positions_(plant.num_positions()),
       num_velocities_(plant.num_velocities()) {
-  auto pos_map = multibody::makeNameToPositionsMap(plant);
-  auto vel_map = multibody::makeNameToVelocitiesMap(plant);
+  auto pos_map = multibody::MakeNameToPositionsMaps(plant);
+  auto vel_map = multibody::MakeNameToVelocitiesMap(plant);
 
   for (int i = 0; i < plant.num_joints(); ++i) {
     auto& joint = plant.get_joint(drake::multibody::JointIndex(i));

--- a/examples/Cassie/cassie_fixed_point_solver.cc
+++ b/examples/Cassie/cassie_fixed_point_solver.cc
@@ -77,7 +77,7 @@ void CassieFixedPointSolver(
 
   std::cout << "N***** " << evaluators.count_active() << std::endl;
 
-  auto positions_map = multibody::makeNameToPositionsMap(plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(plant);
   auto q = program.AddPositionVariables();
   auto u = program.AddInputVariables();
   auto lambda = program.AddConstraintForceVariables(evaluators);
@@ -213,7 +213,7 @@ void CassieFixedBaseFixedPointSolver(
 
   auto program = multibody::MultibodyProgram(plant);
 
-  auto positions_map = multibody::makeNameToPositionsMap(plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(plant);
   auto q = program.AddPositionVariables();
   auto u = program.AddInputVariables();
   auto lambda = program.AddConstraintForceVariables(evaluators);
@@ -297,7 +297,7 @@ void VdotConstraint::EvaluateConstraint(
       plant_.num_positions() + plant_.num_velocities() + plant_.num_actuators(),
       evaluators_.count_full());
   const auto& vdot = vars.tail(plant_.num_velocities());
-  multibody::setContext<double>(plant_, x, u, context_.get());
+  multibody::SetContext<double>(plant_, x, u, context_.get());
 
   *y = vdot - evaluators_.EvalActiveSecondTimeDerivative(context_.get(), lambda)
                   .tail(n_v_);
@@ -382,7 +382,7 @@ void CassieInitStateSolver(
 
   auto program = multibody::MultibodyProgram(plant);
 
-  auto positions_map = multibody::makeNameToPositionsMap(plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(plant);
   auto q = program.AddPositionVariables();
   auto u = program.AddInputVariables();
   auto lambda = program.AddConstraintForceVariables(evaluators);
@@ -390,7 +390,7 @@ void CassieInitStateSolver(
   program.AddJointLimitConstraints(q);
 
   // Velocity part
-  auto vel_map = multibody::makeNameToVelocitiesMap(plant);
+  auto vel_map = multibody::MakeNameToVelocitiesMap(plant);
   int n_v = plant.num_velocities();
   auto v = program.NewContinuousVariables(n_v, "v");
 

--- a/examples/Cassie/cassie_state_estimator.cc
+++ b/examples/Cassie/cassie_state_estimator.cc
@@ -51,7 +51,7 @@ CassieStateEstimator::CassieStateEstimator(
       left_contact_evaluator_(left_contact_evaluator),
       right_contact_evaluator_(right_contact_evaluator),
       world_(plant_.world_frame()),
-      is_floating_base_(multibody::isQuaternion(plant)),
+      is_floating_base_(multibody::HasQuaternion(plant)),
       context_(plant_.CreateDefaultContext()),
       toe_frames_({&plant.GetFrameByName("toe_left"),
                    &plant.GetFrameByName("toe_right")}),
@@ -84,9 +84,9 @@ CassieStateEstimator::CassieStateEstimator(
           .get_index();
 
   // Initialize index maps
-  actuator_idx_map_ = multibody::makeNameToActuatorsMap(plant);
-  position_idx_map_ = multibody::makeNameToPositionsMap(plant);
-  velocity_idx_map_ = multibody::makeNameToVelocitiesMap(plant);
+  actuator_idx_map_ = multibody::MakeNameToActuatorsMap(plant);
+  position_idx_map_ = multibody::MakeNameToPositionsMaps(plant);
+  velocity_idx_map_ = multibody::MakeNameToVelocitiesMap(plant);
 
   if (is_floating_base_) {
     contact_output_port_ =

--- a/examples/Cassie/cassie_utils.cc
+++ b/examples/Cassie/cassie_utils.cc
@@ -104,7 +104,7 @@ multibody::DistanceEvaluator<T> RightLoopClosureEvaluator(
 /// Add a fixed base cassie to the given multibody plant and scene graph
 /// These methods are to be used rather that direct construction of the plant
 /// from the URDF to centralize any modeling changes or additions
-void addCassieMultibody(MultibodyPlant<double>* plant,
+void AddCassieMultibody(MultibodyPlant<double>* plant,
                         SceneGraph<double>* scene_graph, bool floating_base,
                         std::string filename, bool add_leaf_springs,
                         bool add_loop_closure) {

--- a/examples/Cassie/cassie_utils.h
+++ b/examples/Cassie/cassie_utils.h
@@ -66,7 +66,7 @@ multibody::DistanceEvaluator<T> RightLoopClosureEvaluator(
 ///     Default = true
 /// @param add_loop_closure_springs Whether or not to add the loop closure
 ///     distance constraint via stiff springs. Default = true.
-void addCassieMultibody(
+void AddCassieMultibody(
     drake::multibody::MultibodyPlant<double>* plant,
     drake::geometry::SceneGraph<double>* scene_graph = nullptr,
     bool floating_base = true,

--- a/examples/Cassie/dispatcher_robot_in.cc
+++ b/examples/Cassie/dispatcher_robot_in.cc
@@ -74,7 +74,7 @@ int do_main(int argc, char* argv[]) {
 
   // Build Cassie MBP
   drake::multibody::MultibodyPlant<double> plant(0.0);
-  addCassieMultibody(&plant, nullptr, FLAGS_floating_base /*floating base*/,
+  AddCassieMultibody(&plant, nullptr, FLAGS_floating_base /*floating base*/,
                      "examples/Cassie/urdf/cassie_v2_conservative.urdf",
                      true /*spring model*/, false /*loop closure*/);
   plant.Finalize();

--- a/examples/Cassie/dispatcher_robot_out.cc
+++ b/examples/Cassie/dispatcher_robot_out.cc
@@ -163,7 +163,7 @@ int do_main(int argc, char* argv[]) {
 
   // Build Cassie MBP
   drake::multibody::MultibodyPlant<double> plant(0.0);
-  addCassieMultibody(&plant, nullptr, FLAGS_floating_base /*floating base*/,
+  AddCassieMultibody(&plant, nullptr, FLAGS_floating_base /*floating base*/,
                      "examples/Cassie/urdf/cassie_v2.urdf",
                      true /*spring model*/, false /*loop closure*/);
   plant.Finalize();

--- a/examples/Cassie/find_fixed_point.cc
+++ b/examples/Cassie/find_fixed_point.cc
@@ -25,7 +25,7 @@ int do_main(int argc, char* argv[]) {
   }
 
   drake::multibody::MultibodyPlant<double> plant(0.0);
-  addCassieMultibody(&plant, nullptr, true, urdf, FLAGS_spring_model, false);
+  AddCassieMultibody(&plant, nullptr, true, urdf, FLAGS_spring_model, false);
   plant.Finalize();
 
   Eigen::VectorXd q, u, lambda;

--- a/examples/Cassie/multibody_sim.cc
+++ b/examples/Cassie/multibody_sim.cc
@@ -81,7 +81,7 @@ int do_main(int argc, char* argv[]) {
   const double time_step = FLAGS_time_stepping ? FLAGS_dt : 0.0;
   MultibodyPlant<double>& plant = *builder.AddSystem<MultibodyPlant>(time_step);
   if (FLAGS_floating_base) {
-    multibody::addFlatTerrain(&plant, &scene_graph, .8, .8);
+    multibody::AddFlatTerrain(&plant, &scene_graph, .8, .8);
   }
 
   std::string urdf;
@@ -91,7 +91,7 @@ int do_main(int argc, char* argv[]) {
     urdf = "examples/Cassie/urdf/cassie_fixed_springs.urdf";
   }
 
-  addCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
+  AddCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
                      FLAGS_spring_model, true);
   plant.Finalize();
 
@@ -159,7 +159,7 @@ int do_main(int argc, char* argv[]) {
   // diagram is built, plant.get_actuation_input_port().HasValue(*context)
   // throws a segfault error
   drake::multibody::MultibodyPlant<double> plant_for_solver(0.0);
-  addCassieMultibody(&plant_for_solver, nullptr,
+  AddCassieMultibody(&plant_for_solver, nullptr,
                      FLAGS_floating_base /*floating base*/, urdf,
                      FLAGS_spring_model, true);
   plant_for_solver.Finalize();

--- a/examples/Cassie/multibody_sim_w_ground_incline.cc
+++ b/examples/Cassie/multibody_sim_w_ground_incline.cc
@@ -150,7 +150,7 @@ int do_main(int argc, char* argv[]) {
   drake::multibody::MultibodyPlant<double>& plant =
       *builder.AddSystem<drake::multibody::MultibodyPlant>(time_step);
   if (FLAGS_floating_base) {
-    multibody::addFlatTerrain(&plant, &scene_graph, .8, .8, ground_normal);
+    multibody::AddFlatTerrain(&plant, &scene_graph, .8, .8, ground_normal);
   }
 
   std::string urdf;
@@ -160,7 +160,7 @@ int do_main(int argc, char* argv[]) {
     urdf = "examples/Cassie/urdf/cassie_fixed_springs.urdf";
   }
 
-  addCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
+  AddCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
                      FLAGS_spring_model, true);
   plant.Finalize();
 
@@ -257,7 +257,7 @@ int do_main(int argc, char* argv[]) {
   // diagram is built, plant.get_actuation_input_port().HasValue(*context)
   // throws a segfault error
   drake::multibody::MultibodyPlant<double> plant_for_solver(0.0);
-  addCassieMultibody(&plant_for_solver, nullptr,
+  AddCassieMultibody(&plant_for_solver, nullptr,
                      FLAGS_floating_base /*floating base*/, urdf,
                      FLAGS_spring_model, true);
   plant_for_solver.Finalize();

--- a/examples/Cassie/multibody_sim_w_platform.cc
+++ b/examples/Cassie/multibody_sim_w_platform.cc
@@ -83,7 +83,7 @@ int do_main(int argc, char* argv[]) {
   const double time_step = FLAGS_dt;
   MultibodyPlant<double>& plant = *builder.AddSystem<MultibodyPlant>(time_step);
   if (FLAGS_floating_base) {
-    multibody::addFlatTerrain(&plant, &scene_graph, .8, .8);
+    multibody::AddFlatTerrain(&plant, &scene_graph, .8, .8);
   }
 
   std::string urdf = FLAGS_spring_model
@@ -104,7 +104,7 @@ int do_main(int argc, char* argv[]) {
   plant.set_penetration_allowance(FLAGS_penetration_allowance);
   plant.set_stiction_tolerance(FLAGS_v_stiction);
 
-  addCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
+  AddCassieMultibody(&plant, &scene_graph, FLAGS_floating_base, urdf,
                      FLAGS_spring_model, true);
 
   plant.Finalize();
@@ -114,10 +114,11 @@ int do_main(int argc, char* argv[]) {
   int nx = nq + nv;
 
   // Create maps for joints
-  std::map<std::string, int> pos_map = multibody::makeNameToPositionsMap(plant);
+  std::map<std::string, int> pos_map =
+      multibody::MakeNameToPositionsMaps(plant);
   std::map<std::string, int> vel_map =
-      multibody::makeNameToVelocitiesMap(plant);
-  std::map<std::string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+      multibody::MakeNameToVelocitiesMap(plant);
+  std::map<std::string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   // Create lcm systems.
   auto lcm = builder.AddSystem<drake::systems::lcm::LcmInterfaceSystem>();

--- a/examples/Cassie/networking/cassie_input_translator.cc
+++ b/examples/Cassie/networking/cassie_input_translator.cc
@@ -22,7 +22,7 @@ namespace {
 CassieInputTranslator::CassieInputTranslator(
     const MultibodyPlant<double>& plant) {
   std::map<std::string, int> actuatorIndexMap =
-    multibody::makeNameToActuatorsMap(plant);
+      multibody::MakeNameToActuatorsMap(plant);
   // build index map
   DRAKE_ASSERT(kNumActuators == cassieEffortNames.size());
   for (auto const& name : cassieEffortNames) {

--- a/examples/Cassie/osc_jump/convert_traj_for_controller.cc
+++ b/examples/Cassie/osc_jump/convert_traj_for_controller.cc
@@ -54,9 +54,9 @@ int DoMain() {
   plant.Finalize();
 
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
 

--- a/examples/Cassie/run_dircon_jumping.cc
+++ b/examples/Cassie/run_dircon_jumping.cc
@@ -137,7 +137,7 @@ class JointAccelCost : public solvers::NonlinearCost<double> {
     const auto u0 = x.segment(n_x_, n_u_);
     VectorXd l0 = x.segment(n_x_ + n_u_, n_lambda_);
 
-    multibody::setContext<double>(plant_, x0, u0, context_.get());
+    multibody::SetContext<double>(plant_, x0, u0, context_.get());
     const VectorX<double> xdot0 =
         constraints_->CalcTimeDerivatives(*context_, &l0);
 
@@ -171,7 +171,7 @@ void DoMain() {
     file_name = "examples/Cassie/urdf/cassie_v2_conservative.urdf";
   }
 
-  addCassieMultibody(&plant, nullptr, true, file_name, FLAGS_use_springs,
+  AddCassieMultibody(&plant, nullptr, true, file_name, FLAGS_use_springs,
                      false);
 
   Parser parser_vis(&plant_vis, &scene_graph);
@@ -195,9 +195,9 @@ void DoMain() {
   }
 
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   // Set up contact/distance constraints
   auto left_toe_pair = LeftToeFront(plant);
@@ -393,7 +393,7 @@ void DoMain() {
             << std::endl;
   drake::trajectories::PiecewisePolynomial<double> optimal_traj =
       trajopt.ReconstructStateTrajectory(result);
-  multibody::connectTrajectoryVisualizer(&plant_vis, &builder, &scene_graph,
+  multibody::ConnectTrajectoryVisualizer(&plant_vis, &builder, &scene_graph,
                                          optimal_traj);
 
   auto diagram = builder.Build();
@@ -409,9 +409,9 @@ void DoMain() {
 void SetKinematicConstraints(Dircon<double>* trajopt,
                              const MultibodyPlant<double>& plant) {
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   int n_q = plant.num_positions();
   int n_v = plant.num_velocities();
@@ -697,9 +697,9 @@ void AddCosts(Dircon<double>* trajopt, const MultibodyPlant<double>& plant,
   auto x = trajopt->state();
   auto u = trajopt->input();
 
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   int n_v = plant.num_velocities();
   int n_u = plant.num_actuators();
@@ -818,9 +818,9 @@ void AddCostsSprings(Dircon<double>* trajopt,
   auto x = trajopt->state();
   auto u = trajopt->input();
 
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   int n_v = plant.num_velocities();
   int n_u = plant.num_actuators();

--- a/examples/Cassie/run_dircon_squatting.cc
+++ b/examples/Cassie/run_dircon_squatting.cc
@@ -110,9 +110,9 @@ void DoMain(double duration, int max_iter, const string& data_directory,
   plant_vis.Finalize();
 
   // Create maps for joints
-  map<string, int> positions_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> velocities_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> actuators_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> positions_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> velocities_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> actuators_map = multibody::MakeNameToActuatorsMap(plant);
 
   int base_qw_idx = positions_map.at("base_qw");
   int base_qx_idx = positions_map.at("base_qx");

--- a/examples/Cassie/run_dircon_walking.cc
+++ b/examples/Cassie/run_dircon_walking.cc
@@ -110,7 +110,7 @@ vector<VectorXd> GetInitGuessForQ(int N, double stride_length,
   int n_q = plant.num_positions();
   int n_v = plant.num_velocities();
   int n_x = n_q + n_v;
-  map<string, int> positions_map = multibody::makeNameToPositionsMap(plant);
+  map<string, int> positions_map = multibody::MakeNameToPositionsMaps(plant);
 
   vector<VectorXd> q_init_guess;
   VectorXd q_ik_guess = VectorXd::Zero(n_q);
@@ -200,7 +200,7 @@ vector<VectorXd> GetInitGuessForQ(int N, double stride_length,
       scene_graph_ik.set_name("scene_graph_ik");
       MultibodyPlant<double> plant_ik(0.0);
       Vector3d ground_normal(sin(ground_incline), 0, cos(ground_incline));
-      multibody::addFlatTerrain(&plant_ik, &scene_graph_ik, .8, .8,
+      multibody::AddFlatTerrain(&plant_ik, &scene_graph_ik, .8, .8,
                                 ground_normal);
       Parser parser(&plant_ik, &scene_graph_ik);
       string full_name =
@@ -213,7 +213,7 @@ vector<VectorXd> GetInitGuessForQ(int N, double stride_length,
       x_const.head(n_q) = q_sol;
       PiecewisePolynomial<double> pp_xtraj(x_const);
 
-      multibody::connectTrajectoryVisualizer(&plant_ik, &builder_ik,
+      multibody::ConnectTrajectoryVisualizer(&plant_ik, &builder_ik,
                                              &scene_graph_ik, pp_xtraj);
       auto diagram = builder_ik.Build();
       drake::systems::Simulator<double> simulator(*diagram);
@@ -291,7 +291,7 @@ void DoMain(double duration, double stride_length, double ground_incline,
   MultibodyPlant<double> plant(0.0);
 
   Vector3d ground_normal(sin(ground_incline), 0, cos(ground_incline));
-  multibody::addFlatTerrain(&plant, &scene_graph, 1, 1, ground_normal);
+  multibody::AddFlatTerrain(&plant, &scene_graph, 1, 1, ground_normal);
 
   Parser parser(&plant, &scene_graph);
 
@@ -301,9 +301,9 @@ void DoMain(double duration, double stride_length, double ground_incline,
   plant.Finalize();
 
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   int n_q = plant.num_positions();
   int n_v = plant.num_velocities();

--- a/examples/Cassie/run_lqr_balancing.cc
+++ b/examples/Cassie/run_lqr_balancing.cc
@@ -58,7 +58,7 @@ int do_main(int argc, char* argv[]) {
   }
 
   MultibodyPlant<double> plant(0.0);
-  addCassieMultibody(&plant, nullptr, true, urdf, FLAGS_spring_model, false);
+  AddCassieMultibody(&plant, nullptr, true, urdf, FLAGS_spring_model, false);
   plant.Finalize();
 
   std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_ad =
@@ -151,7 +151,7 @@ int do_main(int argc, char* argv[]) {
       + plant.num_velocities(), plant.num_actuators());
 
   auto context_autodiff =
-      multibody::createContext<AutoDiffXd>(*plant_ad, x_ad, u_ad);
+      multibody::CreateContext<AutoDiffXd>(*plant_ad, x_ad, u_ad);
 
   // controller gains
   Eigen::MatrixXd Q =

--- a/examples/Cassie/run_osc_jumping_controller.cc
+++ b/examples/Cassie/run_osc_jumping_controller.cc
@@ -95,7 +95,7 @@ int DoMain(int argc, char* argv[]) {
 
   // Built the Cassie MBPs
   drake::multibody::MultibodyPlant<double> plant_w_spr(0.0);
-  addCassieMultibody(&plant_w_spr, nullptr, true,
+  AddCassieMultibody(&plant_w_spr, nullptr, true,
                      "examples/Cassie/urdf/cassie_v2_conservative.urdf",
                      false /*spring model*/, false /*loop closure*/);
   plant_w_spr.Finalize();
@@ -111,9 +111,9 @@ int DoMain(int argc, char* argv[]) {
   int nv = plant_w_spr.num_velocities();
 
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant_w_spr);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant_w_spr);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant_w_spr);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant_w_spr);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant_w_spr);
 
   std::vector<std::pair<const Vector3d, const drake::multibody::Frame<double>&>>
       feet_contact_points = {left_toe, right_toe};
@@ -328,8 +328,8 @@ int DoMain(int argc, char* argv[]) {
   evaluators.add_evaluator(&right_loop);
 
   // Fix the springs in the dynamics
-  auto pos_idx_map = multibody::makeNameToPositionsMap(plant_w_spr);
-  auto vel_idx_map = multibody::makeNameToVelocitiesMap(plant_w_spr);
+  auto pos_idx_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
+  auto vel_idx_map = multibody::MakeNameToVelocitiesMap(plant_w_spr);
   auto left_fixed_knee_spring =
       FixedJointEvaluator(plant_w_spr, pos_idx_map.at("knee_joint_left"),
                           vel_idx_map.at("knee_joint_leftdot"), 0);

--- a/examples/Cassie/run_osc_standing_controller.cc
+++ b/examples/Cassie/run_osc_standing_controller.cc
@@ -109,13 +109,13 @@ int DoMain(int argc, char* argv[]) {
 
   // Build Cassie MBP
   drake::multibody::MultibodyPlant<double> plant_w_springs(0.0);
-  addCassieMultibody(&plant_w_springs, nullptr, true /*floating base*/,
+  AddCassieMultibody(&plant_w_springs, nullptr, true /*floating base*/,
                      "examples/Cassie/urdf/cassie_v2.urdf",
                      true /*spring model*/, false /*loop closure*/);
   plant_w_springs.Finalize();
   // Build fix-spring Cassie MBP
   drake::multibody::MultibodyPlant<double> plant_wo_springs(0.0);
-  addCassieMultibody(&plant_wo_springs, nullptr, true,
+  AddCassieMultibody(&plant_wo_springs, nullptr, true,
                      "examples/Cassie/urdf/cassie_fixed_springs.urdf", false,
                      false);
   plant_wo_springs.Finalize();

--- a/examples/Cassie/run_osc_walking_controller.cc
+++ b/examples/Cassie/run_osc_walking_controller.cc
@@ -97,11 +97,11 @@ int DoMain(int argc, char* argv[]) {
   // Build Cassie MBP
   drake::multibody::MultibodyPlant<double> plant_w_spr(0.0);
   if (FLAGS_spring_model) {
-    addCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_v2.urdf",
                        true /*spring model*/, false /*loop closure*/);
   } else {
-    addCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_fixed_springs.urdf",
                        false /*spring model*/, false /*loop closure*/);
   }
@@ -344,7 +344,7 @@ int DoMain(int argc, char* argv[]) {
                   swing_ft_traj_generator->get_input_port_sc());
 
   // Swing toe joint trajectory
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant_w_spr);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
   vector<std::pair<const Vector3d, const Frame<double>&>> left_foot_points = {
       left_heel, left_toe};
   vector<std::pair<const Vector3d, const Frame<double>&>> right_foot_points = {
@@ -388,8 +388,8 @@ int DoMain(int argc, char* argv[]) {
   std::unique_ptr<FixedJointEvaluator<double>> left_fixed_ankle_spring;
   std::unique_ptr<FixedJointEvaluator<double>> right_fixed_ankle_spring;
   if (FLAGS_spring_model) {
-    auto pos_idx_map = multibody::makeNameToPositionsMap(plant_w_spr);
-    auto vel_idx_map = multibody::makeNameToVelocitiesMap(plant_w_spr);
+    auto pos_idx_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
+    auto vel_idx_map = multibody::MakeNameToVelocitiesMap(plant_w_spr);
     left_fixed_knee_spring = std::make_unique<FixedJointEvaluator<double>>(
         plant_w_spr, pos_idx_map.at("knee_joint_left"),
         vel_idx_map.at("knee_joint_leftdot"), 0);

--- a/examples/Cassie/run_osc_walking_controller_alip.cc
+++ b/examples/Cassie/run_osc_walking_controller_alip.cc
@@ -99,11 +99,11 @@ int DoMain(int argc, char* argv[]) {
   // Build Cassie MBP
   drake::multibody::MultibodyPlant<double> plant_w_spr(0.0);
   if (FLAGS_spring_model) {
-    addCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_v2.urdf",
                        true /*spring model*/, false /*loop closure*/);
   } else {
-    addCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_w_spr, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_fixed_springs.urdf",
                        false /*spring model*/, false /*loop closure*/);
   }
@@ -327,7 +327,7 @@ int DoMain(int argc, char* argv[]) {
                   swing_ft_traj_generator->get_input_port_vdes());
 
   // Swing toe joint trajectory
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant_w_spr);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
   vector<std::pair<const Vector3d, const Frame<double>&>> left_foot_points = {
       left_heel, left_toe};
   vector<std::pair<const Vector3d, const Frame<double>&>> right_foot_points = {
@@ -371,8 +371,8 @@ int DoMain(int argc, char* argv[]) {
   std::unique_ptr<FixedJointEvaluator<double>> left_fixed_ankle_spring;
   std::unique_ptr<FixedJointEvaluator<double>> right_fixed_ankle_spring;
   if (FLAGS_spring_model) {
-    auto pos_idx_map = multibody::makeNameToPositionsMap(plant_w_spr);
-    auto vel_idx_map = multibody::makeNameToVelocitiesMap(plant_w_spr);
+    auto pos_idx_map = multibody::MakeNameToPositionsMaps(plant_w_spr);
+    auto vel_idx_map = multibody::MakeNameToVelocitiesMap(plant_w_spr);
     left_fixed_knee_spring = std::make_unique<FixedJointEvaluator<double>>(
         plant_w_spr, pos_idx_map.at("knee_joint_left"),
         vel_idx_map.at("knee_joint_leftdot"), 0);

--- a/examples/Cassie/run_pd_controller.cc
+++ b/examples/Cassie/run_pd_controller.cc
@@ -47,7 +47,7 @@ int doMain(int argc, char* argv[]) {
   scene_graph.set_name("scene_graph");
 
   MultibodyPlant<double>& plant = *builder_null.AddSystem<MultibodyPlant>(1.0);
-  addCassieMultibody(&plant, &scene_graph_null, FLAGS_floating_base);
+  AddCassieMultibody(&plant, &scene_graph_null, FLAGS_floating_base);
   plant.Finalize();
 
   const std::string channel_x = FLAGS_channel_x;

--- a/examples/Cassie/sim_cassie_sensor_aggregator.cc
+++ b/examples/Cassie/sim_cassie_sensor_aggregator.cc
@@ -18,9 +18,9 @@ SimCassieSensorAggregator::SimCassieSensorAggregator(
   num_positions_ = plant.num_positions();
   num_velocities_ = plant.num_velocities();
 
-  positionIndexMap_ = multibody::makeNameToPositionsMap(plant);
-  velocityIndexMap_ = multibody::makeNameToVelocitiesMap(plant);
-  actuatorIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  positionIndexMap_ = multibody::MakeNameToPositionsMaps(plant);
+  velocityIndexMap_ = multibody::MakeNameToVelocitiesMap(plant);
+  actuatorIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
 
   input_input_port_ =
       this->DeclareVectorInputPort("u", BasicVector<double>(10)).get_index();

--- a/examples/Cassie/standalone_multibody_sim.cc
+++ b/examples/Cassie/standalone_multibody_sim.cc
@@ -48,15 +48,15 @@ int do_main(int argc, char* argv[]) {
       *builder.AddSystem<MultibodyPlant>(time_step);
 
   if (FLAGS_floating_base) {
-    multibody::addFlatTerrain(&plant, &scene_graph, .8, .8);
+    multibody::AddFlatTerrain(&plant, &scene_graph, .8, .8);
   }
 
-  addCassieMultibody(&plant, &scene_graph, FLAGS_floating_base);
+  AddCassieMultibody(&plant, &scene_graph, FLAGS_floating_base);
 
   plant.Finalize();
 
   std::map<std::string, int> actuatorIndexMap =
-    multibody::makeNameToActuatorsMap(plant);
+      multibody::MakeNameToActuatorsMap(plant);
 
   for (auto const& x : actuatorIndexMap) {
     std::cout << x.first  // string (key)

--- a/examples/Cassie/test/cassie_state_estimator_test.cc
+++ b/examples/Cassie/test/cassie_state_estimator_test.cc
@@ -28,7 +28,7 @@ class ContactEstimationTest : public ::testing::Test {
  protected:
   ContactEstimationTest()
       : plant_(drake::multibody::MultibodyPlant<double>(1e-3)) {
-    addCassieMultibody(&plant_, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_v2.urdf",
                        true /*spring model*/, false /*loop closure*/);
     plant_.Finalize();
@@ -117,7 +117,7 @@ TEST_F(ContactEstimationTest, solveFourbarLinkageTest) {
 
   // Get the fix joint indices
   std::map<std::string, int> positionIndexMap =
-      multibody::makeNameToPositionsMap(plant_);
+      multibody::MakeNameToPositionsMaps(plant_);
   std::vector<int> fixed_joint_inds;
   fixed_joint_inds.push_back(positionIndexMap.at("knee_left"));
   fixed_joint_inds.push_back(positionIndexMap.at("knee_joint_left"));

--- a/examples/Cassie/test/input_supervisor_test.cc
+++ b/examples/Cassie/test/input_supervisor_test.cc
@@ -18,7 +18,7 @@ class InputSupervisorTest : public ::testing::Test {
  protected:
   InputSupervisorTest()
       : plant_(drake::multibody::MultibodyPlant<double>(0.0)) {
-    addCassieMultibody(&plant_, nullptr, true /*floating base*/,
+    AddCassieMultibody(&plant_, nullptr, true /*floating base*/,
                        "examples/Cassie/urdf/cassie_v2.urdf",
                        true /*spring model*/, false /*loop closure*/);
     plant_.Finalize();

--- a/examples/Cassie/test/parse_log_test.cc
+++ b/examples/Cassie/test/parse_log_test.cc
@@ -23,7 +23,7 @@ using systems::VectorAggregator;
 
 int ParseLog(string filename) {
   drake::multibody::MultibodyPlant<double> plant(0.0);
-  addCassieMultibody(&plant);
+  AddCassieMultibody(&plant);
   
   drake::lcm::DrakeLcmLog r_log(filename, false);
 

--- a/examples/Cassie/visualize_trajectory.cc
+++ b/examples/Cassie/visualize_trajectory.cc
@@ -56,8 +56,8 @@ int DoMain() {
   int nv = plant.num_positions();
   int nx = nq + nv;
 
-  auto pos_map = multibody::makeNameToPositionsMap(plant);
-  auto vel_map = multibody::makeNameToVelocitiesMap(plant);
+  auto pos_map = multibody::MakeNameToPositionsMaps(plant);
+  auto vel_map = multibody::MakeNameToVelocitiesMap(plant);
 
   std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
 
@@ -96,7 +96,7 @@ int DoMain() {
   }
 
   if (FLAGS_visualize_mode == 0 || FLAGS_visualize_mode == 1) {
-    multibody::connectTrajectoryVisualizer(&plant, &builder, &scene_graph,
+    multibody::ConnectTrajectoryVisualizer(&plant, &builder, &scene_graph,
                                            optimal_traj);
 
     auto diagram = builder.Build();

--- a/examples/Cassie/visualizer.cc
+++ b/examples/Cassie/visualizer.cc
@@ -56,12 +56,12 @@ int do_main(int argc, char* argv[]) {
 
   MultibodyPlant<double> plant(0.0);
 
-  addCassieMultibody(&plant, &scene_graph, FLAGS_floating_base);
+  AddCassieMultibody(&plant, &scene_graph, FLAGS_floating_base);
   if (FLAGS_floating_base) {
     // Ground direction
     Eigen::Vector3d ground_normal(sin(FLAGS_ground_incline), 0,
                                   cos(FLAGS_ground_incline));
-    multibody::addFlatTerrain(&plant, &scene_graph, 0.8, 0.8, ground_normal);
+    multibody::AddFlatTerrain(&plant, &scene_graph, 0.8, 0.8, ground_normal);
   }
 
   plant.Finalize();

--- a/examples/PlanarWalker/run_gait_dircon.cc
+++ b/examples/PlanarWalker/run_gait_dircon.cc
@@ -62,8 +62,8 @@ void runDircon(
   SceneGraph<double>& scene_graph =
       *builder.AddSystem(std::move(scene_graph_ptr));
 
-  auto positions_map = multibody::makeNameToPositionsMap(plant);
-  auto velocities_map = multibody::makeNameToVelocitiesMap(plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(plant);
+  auto velocities_map = multibody::MakeNameToVelocitiesMap(plant);
 
   for (auto const& element : positions_map)
     cout << element.first << " = " << element.second << endl;
@@ -202,8 +202,8 @@ void runDircon(
   // visualizer
   const drake::trajectories::PiecewisePolynomial<double> pp_xtraj =
       trajopt.ReconstructStateTrajectory(result);
-  multibody::connectTrajectoryVisualizer(plant_double_ptr,
-      &builder, &scene_graph, pp_xtraj);
+  multibody::ConnectTrajectoryVisualizer(plant_double_ptr, &builder,
+                                         &scene_graph, pp_xtraj);
   auto diagram = builder.Build();
 
   while (true) {

--- a/examples/impact_invariant_control/five_link_biped_sim.cc
+++ b/examples/impact_invariant_control/five_link_biped_sim.cc
@@ -83,7 +83,7 @@ int do_main(int argc, char* argv[]) {
   parser.AddModelFromFile(full_name);
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"),
                    drake::math::RigidTransform<double>());
-  multibody::addFlatTerrain(&plant, &scene_graph, .8, .8);  // Add ground
+  multibody::AddFlatTerrain(&plant, &scene_graph, .8, .8);  // Add ground
   plant.Finalize();
 
   int nv = plant.num_velocities();

--- a/examples/impact_invariant_control/run_dircon_walking.cc
+++ b/examples/impact_invariant_control/run_dircon_walking.cc
@@ -84,8 +84,8 @@ drake::trajectories::PiecewisePolynomial<double> run_traj_opt(
     vector<PiecewisePolynomial<double>> init_l_traj,
     vector<PiecewisePolynomial<double>> init_lc_traj,
     vector<PiecewisePolynomial<double>> init_vc_traj) {
-  auto positions_map = multibody::makeNameToPositionsMap(*plant);
-  auto velocities_map = multibody::makeNameToVelocitiesMap(*plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(*plant);
+  auto velocities_map = multibody::MakeNameToVelocitiesMap(*plant);
 
   // Start of constraint specification
   const Body<double>& left_lower_leg = plant->GetBodyByName("left_lower_leg");
@@ -348,7 +348,7 @@ int doMain(int argc, char* argv[]) {
   drake::trajectories::PiecewisePolynomial<double> optimal_traj =
       run_traj_opt(&plant, init_x_traj, init_u_traj, init_l_traj, init_lc_traj,
                    init_vc_traj);
-  multibody::connectTrajectoryVisualizer(&plant, &builder, &scene_graph,
+  multibody::ConnectTrajectoryVisualizer(&plant, &builder, &scene_graph,
                                          optimal_traj);
   return 0;
 }

--- a/examples/impact_invariant_control/run_joint_space_walking_controller.cc
+++ b/examples/impact_invariant_control/run_joint_space_walking_controller.cc
@@ -86,9 +86,9 @@ int DoMain(int argc, char* argv[]) {
   int nv = plant.num_velocities();
 
   // Create maps for joints
-  map<string, int> pos_map = multibody::makeNameToPositionsMap(plant);
-  map<string, int> vel_map = multibody::makeNameToVelocitiesMap(plant);
-  map<string, int> act_map = multibody::makeNameToActuatorsMap(plant);
+  map<string, int> pos_map = multibody::MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  map<string, int> act_map = multibody::MakeNameToActuatorsMap(plant);
 
   /**** Convert the gains from the yaml struct to Eigen Matrices ****/
   JointSpaceWalkingGains gains =
@@ -148,7 +148,7 @@ int DoMain(int argc, char* argv[]) {
   osc->AddStateAndContactPoint(1, &right_foot_evaluator);
 
   // Create maps for joints
-  map<string, int> pos_map_wo_spr = multibody::makeNameToPositionsMap(plant);
+  map<string, int> pos_map_wo_spr = multibody::MakeNameToPositionsMaps(plant);
 
   std::vector<BasicTrajectoryPassthrough*> joint_trajs;
   std::vector<std::shared_ptr<JointSpaceTrackingData>> joint_tracking_data_vec;

--- a/lcm/dircon_saved_trajectory.cc
+++ b/lcm/dircon_saved_trajectory.cc
@@ -36,14 +36,14 @@ DirconTrajectory::DirconTrajectory(
     state_traj.traj_name = "state_traj" + std::to_string(mode);
     state_traj.datapoints = x[mode];
     state_traj.time_vector = state_breaks[mode];
-    state_traj.datatypes = multibody::createStateNameVectorFromMap(plant);
+    state_traj.datatypes = multibody::CreateStateNameVectorFromMap(plant);
 
     state_derivative_traj.traj_name =
         "state_derivative_traj" + std::to_string(mode);
     state_derivative_traj.datapoints = xdot[mode];
     state_derivative_traj.time_vector = state_breaks[mode];
     state_derivative_traj.datatypes =
-        multibody::createStateNameVectorFromMap(plant);
+        multibody::CreateStateNameVectorFromMap(plant);
 
     // Force vars
     force_traj.traj_name = "force_vars" + std::to_string(mode);
@@ -124,7 +124,7 @@ DirconTrajectory::DirconTrajectory(
   input_traj.traj_name = "input_traj";
   input_traj.datapoints = dircon.GetInputSamples(result);
   input_traj.time_vector = dircon.GetSampleTimes(result);
-  input_traj.datatypes = multibody::createActuatorNameVectorFromMap(plant);
+  input_traj.datatypes = multibody::CreateActuatorNameVectorFromMap(plant);
   AddTrajectory(input_traj.traj_name, input_traj);
   u_ = &input_traj;
 
@@ -163,14 +163,14 @@ DirconTrajectory::DirconTrajectory(
     state_traj.traj_name = "state_traj" + std::to_string(mode);
     state_traj.datapoints = x[mode];
     state_traj.time_vector = state_breaks[mode];
-    state_traj.datatypes = multibody::createStateNameVectorFromMap(plant);
+    state_traj.datatypes = multibody::CreateStateNameVectorFromMap(plant);
 
     state_derivative_traj.traj_name =
         "state_derivative_traj" + std::to_string(mode);
     state_derivative_traj.datapoints = xdot[mode];
     state_derivative_traj.time_vector = state_breaks[mode];
     state_derivative_traj.datatypes =
-        multibody::createStateNameVectorFromMap(plant);
+        multibody::CreateStateNameVectorFromMap(plant);
 
     // Force vars
     force_traj.traj_name = "force_vars" + std::to_string(mode);
@@ -248,7 +248,7 @@ DirconTrajectory::DirconTrajectory(
   input_traj.traj_name = "input_traj";
   input_traj.datapoints = dircon.GetInputSamples(result);
   input_traj.time_vector = dircon.GetSampleTimes(result);
-  input_traj.datatypes = multibody::createActuatorNameVectorFromMap(plant);
+  input_traj.datatypes = multibody::CreateActuatorNameVectorFromMap(plant);
   AddTrajectory(input_traj.traj_name, input_traj);
   u_ = &input_traj;
 
@@ -451,9 +451,9 @@ void DirconTrajectory::LoadFromFileWithPlant(const MultibodyPlant<double>& plant
   // Finished loading in trajectories, now constructing maps to be compatible
   // with old trajectories
 
-  auto pos_map = multibody::makeNameToPositionsMap(plant);
-  auto vel_map = multibody::makeNameToVelocitiesMap(plant);
-  auto act_map = multibody::makeNameToActuatorsMap(plant);
+  auto pos_map = multibody::MakeNameToPositionsMaps(plant);
+  auto vel_map = multibody::MakeNameToVelocitiesMap(plant);
+  auto act_map = multibody::MakeNameToActuatorsMap(plant);
   state_map_ = MatrixXd::Zero(plant.num_positions() + plant.num_velocities(),
                               x_[0]->datapoints.rows());
   int nq = plant.num_positions();

--- a/multibody/kinematic/kinematic_constraints.cc
+++ b/multibody/kinematic/kinematic_constraints.cc
@@ -145,7 +145,7 @@ void KinematicAccelerationConstraint<T>::EvaluateConstraint(
   const auto& u = vars.segment(plant_.num_positions() + plant_.num_velocities(),
       plant_.num_actuators());
   const auto& lambda = vars.tail(evaluators_.count_full());
-  multibody::setContext<T>(plant_, x, u, context_);
+  multibody::SetContext<T>(plant_, x, u, context_);
 
   *y = evaluators_.EvalActiveSecondTimeDerivative(context_, lambda);
 }

--- a/multibody/multibody_solvers.cc
+++ b/multibody/multibody_solvers.cc
@@ -119,7 +119,7 @@ void FixedPointConstraint<T>::EvaluateConstraint(
   x << input.head(plant_.num_positions()),
       VectorX<T>::Zero(plant_.num_velocities());
   // input order is x, u, lambda
-  setContext<T>(plant_, x, u, context_);
+  SetContext<T>(plant_, x, u, context_);
 
   *y = evaluators_.CalcMassMatrixTimesVDot(*context_, lambda);  
   // std::cout << *y << std::endl << std::endl;

--- a/multibody/multibody_utils.cc
+++ b/multibody/multibody_utils.cc
@@ -52,7 +52,7 @@ bool AreVectorsEqual(const Eigen::Ref<const VectorXd>& a,
 }
 
 template <typename T>
-VectorX<T> getInput(const MultibodyPlant<T>& plant, const Context<T>& context) {
+VectorX<T> GetInput(const MultibodyPlant<T>& plant, const Context<T>& context) {
   if (plant.num_actuators() > 0) {
     VectorX<T> input = plant.get_actuation_input_port().Eval(context);
     return input;
@@ -62,7 +62,7 @@ VectorX<T> getInput(const MultibodyPlant<T>& plant, const Context<T>& context) {
 }
 
 template <typename T>
-std::unique_ptr<Context<T>> createContext(
+std::unique_ptr<Context<T>> CreateContext(
     const MultibodyPlant<T>& plant, const Eigen::Ref<const VectorX<T>>& state,
     const Eigen::Ref<const VectorX<T>>& input) {
   auto context = plant.CreateDefaultContext();
@@ -73,7 +73,7 @@ std::unique_ptr<Context<T>> createContext(
 }
 
 template <typename T>
-void setContext(const MultibodyPlant<T>& plant,
+void SetContext(const MultibodyPlant<T>& plant,
                 const Eigen::Ref<const VectorX<T>>& state,
                 const Eigen::Ref<const VectorX<T>>& input,
                 Context<T>* context) {
@@ -119,7 +119,7 @@ void SetInputsIfNew(const MultibodyPlant<T>& plant,
 }
 
 template <typename T>
-void addFlatTerrain(MultibodyPlant<T>* plant, SceneGraph<T>* scene_graph,
+void AddFlatTerrain(MultibodyPlant<T>* plant, SceneGraph<T>* scene_graph,
                     double mu_static, double mu_kinetic,
                     Eigen::Vector3d normal_W, bool show_ground) {
   if (!plant->geometry_source_is_registered()) {
@@ -149,7 +149,7 @@ void addFlatTerrain(MultibodyPlant<T>* plant, SceneGraph<T>* scene_graph,
 ///  -Others are included as "position[ind]""
 ///  -Index mapping can also be used as a state mapping (assumes x = [q;v])
 template <typename T>
-map<string, int> makeNameToPositionsMap(const MultibodyPlant<T>& plant) {
+map<string, int> MakeNameToPositionsMaps(const MultibodyPlant<T>& plant) {
   map<string, int> name_to_index_map;
   std::set<int> index_set;
   for (JointIndex i(0); i < plant.num_joints(); ++i) {
@@ -218,7 +218,7 @@ map<string, int> makeNameToPositionsMap(const MultibodyPlant<T>& plant) {
 ///  -Index mapping can also be used as a state mapping, AFTER
 ///     an offset of num_positions is applied (assumes x = [q;v])
 template <typename T>
-map<string, int> makeNameToVelocitiesMap(const MultibodyPlant<T>& plant) {
+map<string, int> MakeNameToVelocitiesMap(const MultibodyPlant<T>& plant) {
   map<string, int> name_to_index_map;
   std::set<int> index_set;
 
@@ -280,7 +280,7 @@ map<string, int> makeNameToVelocitiesMap(const MultibodyPlant<T>& plant) {
 }
 
 template <typename T>
-map<string, int> makeNameToActuatorsMap(const MultibodyPlant<T>& plant) {
+map<string, int> MakeNameToActuatorsMap(const MultibodyPlant<T>& plant) {
   map<string, int> name_to_index_map;
   for (JointActuatorIndex i(0); i < plant.num_actuators(); ++i) {
     const drake::multibody::JointActuator<T>& actuator =
@@ -314,10 +314,10 @@ map<string, int> makeNameToActuatorsMap(const MultibodyPlant<T>& plant) {
 }
 
 template <typename T>
-vector<string> createStateNameVectorFromMap(
+vector<string> CreateStateNameVectorFromMap(
     const MultibodyPlant<T>& plant) {
-  map<string, int> pos_map = makeNameToPositionsMap(plant);
-  map<string, int> vel_map = makeNameToVelocitiesMap(plant);
+  map<string, int> pos_map = MakeNameToPositionsMaps(plant);
+  map<string, int> vel_map = MakeNameToVelocitiesMap(plant);
   vector<string> state_names(pos_map.size() + vel_map.size());
 
   for (const auto& name_index_pair : pos_map) {
@@ -331,9 +331,9 @@ vector<string> createStateNameVectorFromMap(
 }
 
 template <typename T>
-vector<string> createActuatorNameVectorFromMap(
+vector<string> CreateActuatorNameVectorFromMap(
     const MultibodyPlant<T>& plant) {
-  map<string, int> act_map = makeNameToActuatorsMap(plant);
+  map<string, int> act_map = MakeNameToActuatorsMap(plant);
   vector<string> actuator_names(act_map.size());
 
   for (const auto& name_index_pair : act_map) {
@@ -347,9 +347,9 @@ Eigen::MatrixXd CreateWithSpringsToWithoutSpringsMapPos(
     const drake::multibody::MultibodyPlant<T>& plant_w_spr,
     const drake::multibody::MultibodyPlant<T>& plant_wo_spr) {
   const std::map<string, int>& pos_map_w_spr =
-      multibody::makeNameToPositionsMap(plant_w_spr);
+      multibody::MakeNameToPositionsMaps(plant_w_spr);
   const std::map<string, int>& pos_map_wo_spr =
-      multibody::makeNameToPositionsMap(plant_wo_spr);
+      multibody::MakeNameToPositionsMaps(plant_wo_spr);
 
   // Initialize the mapping from spring to no spring
   Eigen::MatrixXd ret = Eigen::MatrixXd::Zero(plant_wo_spr.num_positions(),
@@ -373,9 +373,9 @@ Eigen::MatrixXd CreateWithSpringsToWithoutSpringsMapVel(
     const drake::multibody::MultibodyPlant<T>& plant_w_spr,
     const drake::multibody::MultibodyPlant<T>& plant_wo_spr) {
   const std::map<string, int>& vel_map_w_spr =
-      multibody::makeNameToVelocitiesMap(plant_w_spr);
+      multibody::MakeNameToVelocitiesMap(plant_w_spr);
   const std::map<string, int>& vel_map_wo_spr =
-      multibody::makeNameToVelocitiesMap(plant_wo_spr);
+      multibody::MakeNameToVelocitiesMap(plant_wo_spr);
 
   // Initialize the mapping from spring to no spring
   Eigen::MatrixXd ret = Eigen::MatrixXd::Zero(plant_wo_spr.num_velocities(),
@@ -438,7 +438,7 @@ int QuaternionStartIndex(const MultibodyPlant<T>& plant) {
 }
 
 template <typename T>
-bool isQuaternion(const MultibodyPlant<T>& plant) {
+bool HasQuaternion(const MultibodyPlant<T>& plant) {
   return QuaternionStartIndex(plant) != -1;
 }
 
@@ -495,29 +495,29 @@ template int QuaternionStartIndex(const MultibodyPlant<double>& plant);  // NOLI
 template int QuaternionStartIndex(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
 template std::vector<int> QuaternionStartIndices(const MultibodyPlant<double>& plant);  // NOLINT
 template std::vector<int> QuaternionStartIndices(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
-template bool isQuaternion(const MultibodyPlant<double>& plant);  // NOLINT
-template bool isQuaternion(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
+template bool HasQuaternion(const MultibodyPlant<double>& plant);  // NOLINT
+template bool HasQuaternion(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
 template Vector3d ReExpressWorldVector3InBodyYawFrame(const MultibodyPlant<double>& plant, const Context<double>& context, const std::string& body_name, const Vector3d& vec); //NOLINT
 template Vector2d ReExpressWorldVector2InBodyYawFrame(const MultibodyPlant<double>& plant, const Context<double>& context, const std::string& body_name, const Vector2d& vec); //NOLINT
-template map<string, int> makeNameToPositionsMap<double>(const MultibodyPlant<double>& plant);  // NOLINT
-template map<string, int> makeNameToPositionsMap<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
-template map<string, int> makeNameToVelocitiesMap<double>(const MultibodyPlant<double>& plant);  // NOLINT
-template map<string, int> makeNameToVelocitiesMap<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
-template map<string, int> makeNameToActuatorsMap<double>(const MultibodyPlant<double>& plant);  // NOLINT
-template map<string, int> makeNameToActuatorsMap<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
-template vector<string> createStateNameVectorFromMap(const MultibodyPlant<double>& plant);  // NOLINT
-template vector<string> createStateNameVectorFromMap(const MultibodyPlant<AutoDiffXd>& plant);   // NOLINT
-template vector<string> createActuatorNameVectorFromMap(const MultibodyPlant<double>& plant);  // NOLINT
-template vector<string> createActuatorNameVectorFromMap(const MultibodyPlant<AutoDiffXd>& plant);   // NOLINT
+template map<string, int> MakeNameToPositionsMaps<double>(const MultibodyPlant<double>& plant);  // NOLINT
+template map<string, int> MakeNameToPositionsMaps<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
+template map<string, int> MakeNameToVelocitiesMap<double>(const MultibodyPlant<double>& plant);  // NOLINT
+template map<string, int> MakeNameToVelocitiesMap<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
+template map<string, int> MakeNameToActuatorsMap<double>(const MultibodyPlant<double>& plant);  // NOLINT
+template map<string, int> MakeNameToActuatorsMap<AutoDiffXd>(const MultibodyPlant<AutoDiffXd>& plant);  // NOLINT
+template vector<string> CreateStateNameVectorFromMap(const MultibodyPlant<double>& plant);  // NOLINT
+template vector<string> CreateStateNameVectorFromMap(const MultibodyPlant<AutoDiffXd>& plant);   // NOLINT
+template vector<string> CreateActuatorNameVectorFromMap(const MultibodyPlant<double>& plant);  // NOLINT
+template vector<string> CreateActuatorNameVectorFromMap(const MultibodyPlant<AutoDiffXd>& plant);   // NOLINT
 template Eigen::MatrixXd CreateWithSpringsToWithoutSpringsMapPos(const drake::multibody::MultibodyPlant<double>& plant_w_spr, const drake::multibody::MultibodyPlant<double>& plant_wo_spr);   // NOLINT
 template Eigen::MatrixXd CreateWithSpringsToWithoutSpringsMapVel(const drake::multibody::MultibodyPlant<double>& plant_w_spr, const drake::multibody::MultibodyPlant<double>& plant_wo_spr);   // NOLINT
-template void addFlatTerrain<double>(MultibodyPlant<double>* plant, SceneGraph<double>* scene_graph, double mu_static, double mu_kinetic, Eigen::Vector3d normal_W, bool show_ground);   // NOLINT
-template VectorX<double> getInput(const MultibodyPlant<double>& plant, const Context<double>& context);  // NOLINT
-template VectorX<AutoDiffXd> getInput(const MultibodyPlant<AutoDiffXd>& plant, const Context<AutoDiffXd>& context);  // NOLINT
-template std::unique_ptr<Context<double>> createContext(const MultibodyPlant<double>& plant, const Eigen::Ref<const VectorXd>& state, const Eigen::Ref<const VectorXd>& input);  // NOLINT
-template std::unique_ptr<Context<AutoDiffXd>> createContext(const MultibodyPlant<AutoDiffXd>& plant, const Eigen::Ref<const AutoDiffVecXd>& state, const Eigen::Ref<const AutoDiffVecXd>& input);  // NOLINT
-template void setContext(const MultibodyPlant<double>& plant, const Eigen::Ref<const VectorXd>& state, const Eigen::Ref<const VectorXd>&, Context<double>* context);  // NOLINT
-template void setContext(const MultibodyPlant<AutoDiffXd>& plant, const Eigen::Ref<const AutoDiffVecXd>& state, const Eigen::Ref<const AutoDiffVecXd>&, Context<AutoDiffXd>* context);  // NOLINT
+template void AddFlatTerrain<double>(MultibodyPlant<double>* plant, SceneGraph<double>* scene_graph, double mu_static, double mu_kinetic, Eigen::Vector3d normal_W, bool show_ground);   // NOLINT
+template VectorX<double> GetInput(const MultibodyPlant<double>& plant, const Context<double>& context);  // NOLINT
+template VectorX<AutoDiffXd> GetInput(const MultibodyPlant<AutoDiffXd>& plant, const Context<AutoDiffXd>& context);  // NOLINT
+template std::unique_ptr<Context<double>> CreateContext(const MultibodyPlant<double>& plant, const Eigen::Ref<const VectorXd>& state, const Eigen::Ref<const VectorXd>& input);  // NOLINT
+template std::unique_ptr<Context<AutoDiffXd>> CreateContext(const MultibodyPlant<AutoDiffXd>& plant, const Eigen::Ref<const AutoDiffVecXd>& state, const Eigen::Ref<const AutoDiffVecXd>& input);  // NOLINT
+template void SetContext(const MultibodyPlant<double>& plant, const Eigen::Ref<const VectorXd>& state, const Eigen::Ref<const VectorXd>&, Context<double>* context);  // NOLINT
+template void SetContext(const MultibodyPlant<AutoDiffXd>& plant, const Eigen::Ref<const AutoDiffVecXd>& state, const Eigen::Ref<const AutoDiffVecXd>&, Context<AutoDiffXd>* context);  // NOLINT
 template void SetPositionsAndVelocitiesIfNew(const MultibodyPlant<AutoDiffXd>&, const Eigen::Ref<const AutoDiffVecXd>&, Context<AutoDiffXd>*);  // NOLINT
 template void SetPositionsAndVelocitiesIfNew(const MultibodyPlant<double>&, const Eigen::Ref<const VectorXd>&, Context<double>*);  // NOLINT
 template void SetPositionsIfNew(const MultibodyPlant<AutoDiffXd>&, const Eigen::Ref<const AutoDiffVecXd>&, Context<AutoDiffXd>*);  // NOLINT

--- a/multibody/multibody_utils.h
+++ b/multibody/multibody_utils.h
@@ -9,13 +9,13 @@ namespace dairlib {
 namespace multibody {
 
 template <typename T>
-drake::VectorX<T> getInput(const drake::multibody::MultibodyPlant<T>& plant,
+drake::VectorX<T> GetInput(const drake::multibody::MultibodyPlant<T>& plant,
                            const drake::systems::Context<T>& context);
 
 /// Create a new MultibodyPlant context and set the corresponding state and
 /// input values. Note, this is potentially an expensive operation!
 template <typename T>
-std::unique_ptr<drake::systems::Context<T>> createContext(
+std::unique_ptr<drake::systems::Context<T>> CreateContext(
     const drake::multibody::MultibodyPlant<T>& plant,
     const Eigen::Ref<const drake::VectorX<T>>& state,
     const Eigen::Ref<const drake::VectorX<T>>& input);
@@ -24,7 +24,7 @@ std::unique_ptr<drake::systems::Context<T>> createContext(
 /// input values.
 /// Will only set values that have changed.
 template <typename T>
-void setContext(const drake::multibody::MultibodyPlant<T>& plant,
+void SetContext(const drake::multibody::MultibodyPlant<T>& plant,
                 const Eigen::Ref<const drake::VectorX<T>>& state,
                 const Eigen::Ref<const drake::VectorX<T>>& input,
                 drake::systems::Context<T>* context);
@@ -64,37 +64,37 @@ void SetInputsIfNew(const drake::multibody::MultibodyPlant<T>& plant,
 /// default direction)
 // TODO: we might want to add other types of terrain in the future
 template <typename T>
-void addFlatTerrain(drake::multibody::MultibodyPlant<T>* plant,
+void AddFlatTerrain(drake::multibody::MultibodyPlant<T>* plant,
                     drake::geometry::SceneGraph<T>* scene_graph,
                     double mu_static, double mu_kinetic,
                     Eigen::Vector3d normal_W = Eigen::Vector3d(0, 0, 1),
                     bool show_ground = true);
 
-/// Given a MultiBodyTree, builds a map from position name to position index
+/// Given a MultibodyPlant, builds a map from position name to position index
 template <typename T>
-std::map<std::string, int> makeNameToPositionsMap(
+std::map<std::string, int> MakeNameToPositionsMaps(
     const drake::multibody::MultibodyPlant<T>& plant);
 
 /// Given a MultiBodyTree, builds a map from velocity name to velocity index
 template <typename T>
-std::map<std::string, int> makeNameToVelocitiesMap(
+std::map<std::string, int> MakeNameToVelocitiesMap(
     const drake::multibody::MultibodyPlant<T>& plant);
 
 /// Given a MultiBodyTree, builds a map from actuator name to actuator index
 template <typename T>
-std::map<std::string, int> makeNameToActuatorsMap(
+std::map<std::string, int> MakeNameToActuatorsMap(
     const drake::multibody::MultibodyPlant<T>& plant);
 
 /// Given a set of maps constructed from the above functions, construct a
 /// vector of state and actuator names in order of their index
 template <typename T>
-std::vector<std::string> createStateNameVectorFromMap(
+std::vector<std::string> CreateStateNameVectorFromMap(
     const drake::multibody::MultibodyPlant<T>& plant);
 
 /// Given a set of maps constructed from the above functions, construct a
 /// vector of state and actuator names in order of their index
 template <typename T>
-std::vector<std::string> createActuatorNameVectorFromMap(
+std::vector<std::string> CreateActuatorNameVectorFromMap(
     const drake::multibody::MultibodyPlant<T>& plant);
 
 /// \param plant_w_spr
@@ -110,10 +110,6 @@ template <typename T>
 Eigen::MatrixXd CreateWithSpringsToWithoutSpringsMapVel(
     const drake::multibody::MultibodyPlant<T>& plant_w_spr,
     const drake::multibody::MultibodyPlant<T>& plant_wo_spr);
-
-// TODO: The following two functions need to be implemented as a part of
-// RBT/Multibody and not as separate functions that take in RBTs. Make the
-// change once the codebase shifts to using multibody.
 
 // Given a MultibodyPlant and a state vector, checks if the states are within
 // the joint limits
@@ -139,7 +135,7 @@ int QuaternionStartIndex(const drake::multibody::MultibodyPlant<T>& plant);
 /// Throws an error if there are multiple quaternion floating base joints.
 /// TODO: this method should be deprecated
 template <typename T>
-bool isQuaternion(const drake::multibody::MultibodyPlant<T>& plant);
+bool HasQuaternion(const drake::multibody::MultibodyPlant<T>& plant);
 
 template <typename T>
 Eigen::Vector3d ReExpressWorldVector3InBodyYawFrame(

--- a/multibody/test/geom_geom_collider_test.cc
+++ b/multibody/test/geom_geom_collider_test.cc
@@ -62,7 +62,7 @@ void GeomGeomColliderTest() {
                                                       diagram_context.get());
 
   VectorXd q = VectorXd::Zero(plant.num_positions());
-  auto q_map = makeNameToPositionsMap(plant);
+  auto q_map = MakeNameToPositionsMaps(plant);
 
   q(q_map.at("finger_base_to_upper_joint_0")) = 0;
   q(q_map.at("finger_upper_to_middle_joint_0")) = -1;

--- a/multibody/test/multibody_utils_test.cc
+++ b/multibody/test/multibody_utils_test.cc
@@ -33,11 +33,11 @@ class MultibodyUtilsTest : public ::testing::Test {
 // Test that maps can be constructed without errrors caught by the functions
 // themselves
 TEST_F(MultibodyUtilsTest, StateAndActuatorMappingTest) {
-  auto positions_map = makeNameToPositionsMap(plant_);
+  auto positions_map = MakeNameToPositionsMaps(plant_);
 
-  auto velocities_map = makeNameToVelocitiesMap(plant_);
+  auto velocities_map = MakeNameToVelocitiesMap(plant_);
 
-  auto actuators_map = makeNameToActuatorsMap(plant_);
+  auto actuators_map = MakeNameToActuatorsMap(plant_);
 }
 
 TEST_F(MultibodyUtilsTest, ContextTest) {
@@ -49,10 +49,10 @@ TEST_F(MultibodyUtilsTest, ContextTest) {
   u(0) = 2;
   u(3) = -3.1;
 
-  auto context = createContext<double>(plant_, x, u);
+  auto context = CreateContext<double>(plant_, x, u);
 
   VectorXd x_context = plant_.GetPositionsAndVelocities(*context);
-  VectorXd u_context = getInput(plant_, *context);
+  VectorXd u_context = GetInput(plant_, *context);
 
   EXPECT_EQ(x, x_context);
   EXPECT_EQ(u, u_context);

--- a/multibody/visualization_utils.cc
+++ b/multibody/visualization_utils.cc
@@ -31,17 +31,17 @@ std::unique_ptr<MultibodyPlant<double>> ConstructBallPlant(
   return ball_plant;
 }
 
-void connectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizer(
     const MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,
     const Trajectory<double>& trajectory) {
   auto empty_plant = std::make_unique<MultibodyPlant<double>>(0.0);
-  connectTrajectoryVisualizer(plant, builder, scene_graph, trajectory,
+  ConnectTrajectoryVisualizer(plant, builder, scene_graph, trajectory,
                               *empty_plant);
 }
 
-void connectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizer(
     const MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,

--- a/multibody/visualization_utils.h
+++ b/multibody/visualization_utils.h
@@ -22,12 +22,12 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> ConstructBallPlant(
 ///  2. if you want to visualize the center of mass position, provide ball_plant
 ///     as an input. The ball can be constructed by the function
 ///     ConstructBallPlant().
-void connectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizer(
     const drake::multibody::MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,
     const drake::trajectories::Trajectory<double>& trajectory);
-void connectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizer(
     const drake::multibody::MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,

--- a/systems/controllers/constrained_lqr_controller.cc
+++ b/systems/controllers/constrained_lqr_controller.cc
@@ -122,7 +122,7 @@ ConstrainedLQRController::ConstrainedLQRController(
   AutoDiffVecXd u_ad = xu_ad.segment(plant_.num_positions()
       + plant_.num_velocities(), plant_.num_actuators());
 
-  auto context_ad = multibody::createContext<AutoDiffXd>(plant_, x_ad, u_ad);
+  auto context_ad = multibody::CreateContext<AutoDiffXd>(plant_, x_ad, u_ad);
 
   AutoDiffVecXd xdot = evaluators_.CalcTimeDerivatives(*context_ad);
 

--- a/systems/controllers/osc/joint_space_tracking_data.cc
+++ b/systems/controllers/osc/joint_space_tracking_data.cc
@@ -14,8 +14,8 @@ using drake::systems::Context;
 
 namespace dairlib::systems::controllers {
 
-using multibody::makeNameToPositionsMap;
-using multibody::makeNameToVelocitiesMap;
+using multibody::MakeNameToPositionsMaps;
+using multibody::MakeNameToVelocitiesMap;
 
 /**** JointSpaceTrackingData ****/
 JointSpaceTrackingData::JointSpaceTrackingData(
@@ -36,13 +36,17 @@ void JointSpaceTrackingData::AddStateAndJointToTrack(
     const std::string& joint_vel_name) {
   AddFiniteStateToTrack(fsm_state);
   joint_pos_idx_w_spr_[fsm_state] =
-      {makeNameToPositionsMap(plant_w_spr_).at(joint_pos_name)};
+      {
+      MakeNameToPositionsMaps(plant_w_spr_).at(joint_pos_name)};
   joint_vel_idx_w_spr_[fsm_state] =
-      {makeNameToVelocitiesMap(plant_w_spr_).at(joint_vel_name)};
+      {
+      MakeNameToVelocitiesMap(plant_w_spr_).at(joint_vel_name)};
   joint_pos_idx_wo_spr_[fsm_state] =
-      {makeNameToPositionsMap(plant_wo_spr_).at(joint_pos_name)};
+      {
+      MakeNameToPositionsMaps(plant_wo_spr_).at(joint_pos_name)};
   joint_vel_idx_wo_spr_[fsm_state] =
-      {makeNameToVelocitiesMap(plant_wo_spr_).at(joint_vel_name)};
+      {
+      MakeNameToVelocitiesMap(plant_wo_spr_).at(joint_vel_name)};
 }
 
 void JointSpaceTrackingData::AddJointsToTrack(
@@ -57,22 +61,22 @@ void JointSpaceTrackingData::AddStateAndJointsToTrack(
   AddFiniteStateToTrack(fsm_state);
   std::vector<int> ordered_index_set;
   for (const auto& mem : joint_pos_names) {
-    ordered_index_set.push_back(makeNameToPositionsMap(plant_w_spr_).at(mem));
+    ordered_index_set.push_back(MakeNameToPositionsMaps(plant_w_spr_).at(mem));
   }
   joint_pos_idx_w_spr_[fsm_state] = ordered_index_set;
   ordered_index_set.clear();
   for (const auto& mem : joint_vel_names) {
-    ordered_index_set.push_back(makeNameToVelocitiesMap(plant_w_spr_).at(mem));
+    ordered_index_set.push_back(MakeNameToVelocitiesMap(plant_w_spr_).at(mem));
   }
   joint_vel_idx_w_spr_[fsm_state] = ordered_index_set;
   ordered_index_set.clear();
   for (const auto& mem : joint_pos_names) {
-    ordered_index_set.push_back(makeNameToPositionsMap(plant_wo_spr_).at(mem));
+    ordered_index_set.push_back(MakeNameToPositionsMaps(plant_wo_spr_).at(mem));
   }
   joint_pos_idx_wo_spr_[fsm_state] = ordered_index_set;
   ordered_index_set.clear();
   for (const auto& mem : joint_vel_names) {
-    ordered_index_set.push_back(makeNameToVelocitiesMap(plant_wo_spr_).at(mem));
+    ordered_index_set.push_back(MakeNameToVelocitiesMap(plant_wo_spr_).at(mem));
   }
   joint_vel_idx_wo_spr_[fsm_state] = ordered_index_set;
 }

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -18,7 +18,7 @@ using Eigen::MatrixXd;
 using Eigen::Vector2d;
 using Eigen::VectorXd;
 
-using dairlib::multibody::createContext;
+using dairlib::multibody::CreateContext;
 using drake::multibody::JacobianWrtVariable;
 using drake::multibody::JointActuatorIndex;
 using drake::multibody::JointIndex;
@@ -39,7 +39,7 @@ namespace dairlib::systems::controllers {
 
 using multibody::CreateWithSpringsToWithoutSpringsMapPos;
 using multibody::CreateWithSpringsToWithoutSpringsMapVel;
-using multibody::makeNameToVelocitiesMap;
+using multibody::MakeNameToVelocitiesMap;
 using multibody::SetPositionsIfNew;
 using multibody::SetVelocitiesIfNew;
 using multibody::WorldPointEvaluator;
@@ -104,7 +104,7 @@ OperationalSpaceControl::OperationalSpaceControl(
           .get_index();
 
   const std::map<string, int>& vel_map_wo_spr =
-      multibody::makeNameToVelocitiesMap(plant_wo_spr);
+      multibody::MakeNameToVelocitiesMap(plant_wo_spr);
 
   // Initialize the mapping from spring to no spring
   map_position_from_spring_to_no_spring_ =
@@ -154,7 +154,7 @@ OperationalSpaceControl::OperationalSpaceControl(
   q_max_ = q_max;
 
   // Check if the model is floating based
-  is_quaternion_ = multibody::isQuaternion(plant_w_spr);
+  is_quaternion_ = multibody::HasQuaternion(plant_w_spr);
 }
 
 // Optional features
@@ -175,7 +175,7 @@ void OperationalSpaceControl::AddAccelerationCost(
   if (W_joint_accel_.size() == 0) {
     W_joint_accel_ = Eigen::MatrixXd::Zero(n_v_, n_v_);
   }
-  int idx = makeNameToVelocitiesMap(plant_wo_spr_).at(joint_vel_name);
+  int idx = MakeNameToVelocitiesMap(plant_wo_spr_).at(joint_vel_name);
   W_joint_accel_(idx, idx) += w;
 }
 

--- a/systems/controllers/osc/osc_tracking_data.cc
+++ b/systems/controllers/osc/osc_tracking_data.cc
@@ -23,8 +23,8 @@ using std::vector;
 
 namespace dairlib::systems::controllers {
 
-using multibody::makeNameToPositionsMap;
-using multibody::makeNameToVelocitiesMap;
+using multibody::MakeNameToPositionsMaps;
+using multibody::MakeNameToVelocitiesMap;
 
 /**** OscTrackingData ****/
 OscTrackingData::OscTrackingData(const string& name, int n_y, int n_ydot,

--- a/systems/controllers/pd_config_lcm.cc
+++ b/systems/controllers/pd_config_lcm.cc
@@ -15,7 +15,7 @@ using std::map;
 
 // methods implementation for CassiePDConfigReceiver.
 PDConfigReceiver::PDConfigReceiver(const MultibodyPlant<double>& plant) {
-  actuatorIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  actuatorIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
 
   num_positions_ = plant.num_positions();
   num_velocities_ = plant.num_velocities();

--- a/systems/log_parser/test/parse_generic_log_test.cc
+++ b/systems/log_parser/test/parse_generic_log_test.cc
@@ -10,7 +10,7 @@ int main() {
   Eigen::MatrixXd x;
 
   drake::multibody::MultibodyPlant<double> plant(0.0);
-  dairlib::addCassieMultibody(&plant);
+  dairlib::AddCassieMultibody(&plant);
 
   std::string channel = "CASSIE_INPUT";
   std::string filename =

--- a/systems/robot_lcm_systems.cc
+++ b/systems/robot_lcm_systems.cc
@@ -32,9 +32,9 @@ RobotOutputReceiver::RobotOutputReceiver(
   num_positions_ = plant.num_positions();
   num_velocities_ = plant.num_velocities();
   num_efforts_ = plant.num_actuators();
-  positionIndexMap_ = multibody::makeNameToPositionsMap(plant);
-  velocityIndexMap_ = multibody::makeNameToVelocitiesMap(plant);
-  effortIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  positionIndexMap_ = multibody::MakeNameToPositionsMaps(plant);
+  velocityIndexMap_ = multibody::MakeNameToVelocitiesMap(plant);
+  effortIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
   this->DeclareAbstractInputPort("lcmt_robot_output",
                                  drake::Value<dairlib::lcmt_robot_output>{});
   this->DeclareVectorOutputPort(
@@ -91,9 +91,9 @@ RobotOutputSender::RobotOutputSender(
   num_velocities_ = plant.num_velocities();
   num_efforts_ = plant.num_actuators();
 
-  positionIndexMap_ = multibody::makeNameToPositionsMap(plant);
-  velocityIndexMap_ = multibody::makeNameToVelocitiesMap(plant);
-  effortIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  positionIndexMap_ = multibody::MakeNameToPositionsMaps(plant);
+  velocityIndexMap_ = multibody::MakeNameToVelocitiesMap(plant);
+  effortIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
 
   // Loop through the maps to extract ordered names
   for (int i = 0; i < num_positions_; ++i) {
@@ -197,7 +197,7 @@ void RobotOutputSender::Output(const Context<double>& context,
 RobotInputReceiver::RobotInputReceiver(
     const drake::multibody::MultibodyPlant<double>& plant) {
   num_actuators_ = plant.num_actuators();
-  actuatorIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  actuatorIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
   this->DeclareAbstractInputPort("lcmt_robot_input",
                                  drake::Value<dairlib::lcmt_robot_input>{});
   this->DeclareVectorOutputPort("u, t",
@@ -227,7 +227,7 @@ void RobotInputReceiver::CopyInputOut(const Context<double>& context,
 RobotCommandSender::RobotCommandSender(
     const drake::multibody::MultibodyPlant<double>& plant) {
   num_actuators_ = plant.num_actuators();
-  actuatorIndexMap_ = multibody::makeNameToActuatorsMap(plant);
+  actuatorIndexMap_ = multibody::MakeNameToActuatorsMap(plant);
 
   for (JointActuatorIndex i(0); i < plant.num_actuators(); ++i) {
     ordered_actuator_names_.push_back(plant.get_joint_actuator(i).name());

--- a/systems/trajectory_optimization/dircon/dircon.cc
+++ b/systems/trajectory_optimization/dircon/dircon.cc
@@ -627,7 +627,7 @@ void Dircon<T>::GetStateAndDerivativeSamples(
 
       VectorX<T> xk = result.GetSolution(state_vars(mode, j));
       VectorX<T> uk = result.GetSolution(input_vars(mode, j));
-      auto context = multibody::createContext<T>(plant_, xk, uk);
+      auto context = multibody::CreateContext<T>(plant_, xk, uk);
 
       states_i.col(j) = drake::math::DiscardGradient(xk);
       auto xdot = get_mode(mode).evaluators().CalcTimeDerivativesWithForce(
@@ -772,7 +772,7 @@ void Dircon<T>::ScaleTimeVariables(double scale) {
 
 template <typename T>
 void Dircon<T>::ScaleQuaternionSlackVariables(double scale) {
-  DRAKE_DEMAND(multibody::isQuaternion(plant_));
+  DRAKE_DEMAND(multibody::HasQuaternion(plant_));
   for (int i_mode = 0; i_mode < num_modes(); i_mode++) {
     for (int j = 0; j < mode_length(i_mode) - 1; j++) {
       const auto& vars = quaternion_slack_vars(i_mode, j);

--- a/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon/dircon_opt_constraints.cc
@@ -85,8 +85,8 @@ void DirconCollocationConstraint<T>::EvaluateConstraint(
       x.segment(1 + 2 * (n_x_ + n_u_) + 4 * n_l_, quat_start_indices_.size());
 
   // Evaluate dynamics at k and k+1
-  multibody::setContext<T>(plant_, x0, u0, context_0_);
-  multibody::setContext<T>(plant_, x1, u1, context_1_);
+  multibody::SetContext<T>(plant_, x0, u0, context_0_);
+  multibody::SetContext<T>(plant_, x1, u1, context_1_);
   const auto& xdot0 = CalcTimeDerivativesWithForce(context_0_, l0);
   const auto& xdot1 = CalcTimeDerivativesWithForce(context_1_, l1);
 
@@ -98,7 +98,7 @@ void DirconCollocationConstraint<T>::EvaluateConstraint(
   drake::MatrixX<T> J(evaluators_.count_full(), plant_.num_velocities());
 
   // Evaluate dynamics at colocation point
-  multibody::setContext<T>(plant_, xcol, ucol, context_col_.get());
+  multibody::SetContext<T>(plant_, xcol, ucol, context_col_.get());
   auto g = CalcTimeDerivativesWithForce(context_col_.get(), lc);
 
   // Add velocity slack contribution, J^T * gamma
@@ -194,7 +194,7 @@ void CachedAccelerationConstraint<T>::EvaluateConstraint(
   const auto& u = vars.segment(plant_.num_positions() + plant_.num_velocities(),
                                plant_.num_actuators());
   const auto& lambda = vars.tail(evaluators_.count_full());
-  multibody::setContext<T>(plant_, x, u, context_);
+  multibody::SetContext<T>(plant_, x, u, context_);
 
   if (cache_) {
     const auto& xdot = cache_->CalcTimeDerivativesWithForce(context_, lambda);

--- a/systems/trajectory_optimization/dircon/test/passive_constrained_pendulum_dircon.cc
+++ b/systems/trajectory_optimization/dircon/test/passive_constrained_pendulum_dircon.cc
@@ -109,8 +109,8 @@ void runDircon() {
   trajopt.AddRunningCost(u.transpose()*R*u);
 
 
-  auto positions_map = multibody::makeNameToPositionsMap(plant);
-  auto velocities_map = multibody::makeNameToVelocitiesMap(plant);
+  auto positions_map = multibody::MakeNameToPositionsMaps(plant);
+  auto velocities_map = multibody::MakeNameToVelocitiesMap(plant);
   // // Print out position names
   // for (const auto& it : positions_map) {
   //   std::cout << it.first << std::endl;
@@ -175,7 +175,7 @@ void runDircon() {
   // visualizer
   const drake::trajectories::PiecewisePolynomial<double> pp_xtraj =
       trajopt.ReconstructStateTrajectory(result);
-  multibody::connectTrajectoryVisualizer(&plant_vis, &builder, &scene_graph,
+  multibody::ConnectTrajectoryVisualizer(&plant_vis, &builder, &scene_graph,
                                          pp_xtraj);
   auto diagram = builder.Build();
 

--- a/systems/trajectory_optimization/dircon_kinematic_data_set.cc
+++ b/systems/trajectory_optimization/dircon_kinematic_data_set.cc
@@ -70,7 +70,7 @@ void DirconKinematicDataSet<T>::updateData(const Context<T>& context,
   const VectorX<T> q = state.head(num_positions_);
   const VectorX<T> v = state.tail(num_velocities_);
 
-  VectorX<T> input = multibody::getInput(plant_, context);
+  VectorX<T> input = multibody::GetInput(plant_, context);
 
   // Create a CacheKey element by discarding gradient information (if AutoDiff)
   CacheKey<T> key{state, forces, input};

--- a/systems/trajectory_optimization/dircon_opt_constraints.cc
+++ b/systems/trajectory_optimization/dircon_opt_constraints.cc
@@ -52,7 +52,7 @@ DirconDynamicConstraint<T>::DirconDynamicConstraint(
   // If the MBP is in quaternion floating-base, demand that the quaternion
   // is located at the first four element of the generalized position
   if (is_quaternion) {
-    map<string, int> positions_map = multibody::makeNameToPositionsMap(plant);
+    map<string, int> positions_map = multibody::MakeNameToPositionsMaps(plant);
     DRAKE_DEMAND(positions_map.at("base_qw") == 0);
     DRAKE_DEMAND(positions_map.at("base_qx") == 1);
     DRAKE_DEMAND(positions_map.at("base_qy") == 2);
@@ -119,11 +119,11 @@ void DirconDynamicConstraint<T>::EvaluateConstraint(
                 num_kinematic_constraints_wo_skipping_);
   const VectorX<T> gamma = x.tail(num_quat_slack_);
 
-  multibody::setContext<T>(plant_, x0, u0, context_.get());
+  multibody::SetContext<T>(plant_, x0, u0, context_.get());
   constraints_->updateData(*context_, l0);
   const VectorX<T> xdot0 = constraints_->getXDot();
 
-  multibody::setContext<T>(plant_, x1, u1, context_.get());
+  multibody::SetContext<T>(plant_, x1, u1, context_.get());
   constraints_->updateData(*context_, l1);
   const VectorX<T> xdot1 = constraints_->getXDot();
 
@@ -132,7 +132,7 @@ void DirconDynamicConstraint<T>::EvaluateConstraint(
   const VectorX<T> xdotcol = -1.5 * (x0 - x1) / h - .25 * (xdot0 + xdot1);
   const VectorX<T> ucol = 0.5 * (u0 + u1);
 
-  multibody::setContext<T>(plant_, xcol, ucol, context_.get());
+  multibody::SetContext<T>(plant_, xcol, ucol, context_.get());
   constraints_->updateData(*context_, lc);
   auto g = constraints_->getXDot();
   VectorX<T> vc_in_qdot_space(num_positions_);
@@ -294,7 +294,7 @@ void DirconKinematicConstraint<T>::EvaluateConstraint(
   const VectorX<T> offset = x.segment(
       num_states_ + num_inputs_ + num_kinematic_constraints_wo_skipping_,
       n_relative_);
-  multibody::setContext<T>(plant_, state, input, context_.get());
+  multibody::SetContext<T>(plant_, state, input, context_.get());
   constraints_->updateData(*context_, force);
   switch (type_) {
     case kAll:
@@ -364,7 +364,7 @@ void DirconImpactConstraint<T>::EvaluateConstraint(
   const VectorX<T> u =
       VectorXd::Zero(plant_.num_actuators()).template cast<T>();
 
-  multibody::setContext<T>(plant_, x0, u, context_.get());
+  multibody::SetContext<T>(plant_, x0, u, context_.get());
 
   constraints_->updateData(*context_, impulse);
 

--- a/systems/trajectory_optimization/hybrid_dircon.cc
+++ b/systems/trajectory_optimization/hybrid_dircon.cc
@@ -54,7 +54,7 @@ HybridDircon<T>::HybridDircon(const MultibodyPlant<T>& plant,
   DRAKE_ASSERT(constraints.size() == num_modes_);
   DRAKE_ASSERT(options.size() == num_modes_);
 
-  bool is_quaternion = multibody::isQuaternion(plant);
+  bool is_quaternion = multibody::HasQuaternion(plant);
 
   // Initialization is looped over the modes
   int counter = 0;
@@ -385,7 +385,7 @@ void HybridDircon<T>::GetStateAndDerivativeSamples(
 
       VectorX<T> xk = result.GetSolution(state_vars_by_mode(i, j));
       VectorX<T> uk = result.GetSolution(input(k_data));
-      auto context = multibody::createContext<T>(plant_, xk, uk);
+      auto context = multibody::CreateContext<T>(plant_, xk, uk);
       constraints_[i]->updateData(*context, result.GetSolution(force(i, j)));
 
       states_i.col(j) = drake::math::DiscardGradient(xk);
@@ -487,7 +487,7 @@ void HybridDircon<T>::ScaleTimeVariables(double scale) {
 }
 template <typename T>
 void HybridDircon<T>::ScaleQuaternionSlackVariables(double scale) {
-  DRAKE_DEMAND(multibody::isQuaternion(plant_));
+  DRAKE_DEMAND(multibody::HasQuaternion(plant_));
   for (size_t mode = 0; mode < mode_lengths_.size(); mode++) {
     for (int j = 0; j < mode_lengths_[mode] - 1; j++) {
       prog().SetVariableScaling(quaternion_slack_vars_[mode](j), scale);

--- a/systems/trajectory_optimization/test/passive_constrained_pendulum_dircon.cc
+++ b/systems/trajectory_optimization/test/passive_constrained_pendulum_dircon.cc
@@ -120,7 +120,7 @@ void runDircon() {
   // visualizer
   const drake::trajectories::PiecewisePolynomial<double> pp_xtraj =
       trajopt->ReconstructStateTrajectory(result);
-  multibody::connectTrajectoryVisualizer(&plant, &builder, &scene_graph,
+  multibody::ConnectTrajectoryVisualizer(&plant, &builder, &scene_graph,
                                          pp_xtraj);
   auto diagram = builder.Build();
 


### PR DESCRIPTION
Only change is to rename the functions in multibody utils to use the correct naming convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/302)
<!-- Reviewable:end -->
