### PR TITLE
typo in options_tracking_data

### DIFF
--- a/systems/controllers/osc/options_tracking_data.cc
+++ b/systems/controllers/osc/options_tracking_data.cc
@@ -125,9 +125,9 @@ void OptionsTrackingData::AddJointAndStateToIgnoreInJacobian(int joint_vel_idx,
                          active_fsm_states_.end(),
                          fsm_state) != active_fsm_states_.end());
   if (joint_idx_to_ignore_.count(fsm_state)) {
-    joint_idx_to_ignore_[fsm_state_].push_back(joint_vel_idx);
+    joint_idx_to_ignore_[fsm_state].push_back(joint_vel_idx);
   } else {
-    joint_idx_to_ignore_[fsm_state_] = {joint_vel_idx};
+    joint_idx_to_ignore_[fsm_state] = {joint_vel_idx};
   }
 }
 

--- a/systems/controllers/osc/options_tracking_data.h
+++ b/systems/controllers/osc/options_tracking_data.h
@@ -68,7 +68,7 @@ class OptionsTrackingData : public OscTrackingData {
   Eigen::VectorXd filtered_ydot_;
   double tau_ = -1;
   std::set<int> low_pass_filter_element_idx_;
-  std::map<int, std::vector<int>> joint_idx_to_ignore_;
+  std::unordered_map<int, std::vector<int>> joint_idx_to_ignore_;
   double last_timestamp_ = -1;
 };
 


### PR DESCRIPTION
Small typo:
should be `joint_idx_to_ignore[fsm_state]` instead of `joint_idx_to_ignore[fsm_state_]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/306)
<!-- Reviewable:end -->
