### PR TITLE
Osc options fix

### DIFF
--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -461,8 +461,8 @@ void OperationalSpaceControl::Build() {
     prog_->AddBoundingBoxConstraint(0, 0, epsilon_blend_);
   }
 
-  solver_ = std::make_unique<solvers::FastOsqpSolver>();
-  solver_->InitializeSolver(*prog_, solver_options_);
+  solver_ = std::make_unique<drake::solvers::OsqpSolver>();
+  prog_->SetSolverOptions(solver_options_);
 }
 
 drake::systems::EventStatus OperationalSpaceControl::DiscreteVariableUpdate(

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -748,10 +748,7 @@ VectorXd OperationalSpaceControl::SolveQp(
   }
 
   // Solve the QP
-//  const MathematicalProgramResult result = solver_->Solve(*prog_);
-  auto osqp_solver = drake::solvers::OsqpSolver();
-//  osqp_solver->S
-  const MathematicalProgramResult result = osqp_solver.Solve(*prog_);
+  const MathematicalProgramResult result = solver_->Solve(*prog_);
 
   solve_time_ = result.get_solver_details<OsqpSolver>().run_time;
 

--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -461,8 +461,8 @@ void OperationalSpaceControl::Build() {
     prog_->AddBoundingBoxConstraint(0, 0, epsilon_blend_);
   }
 
-  solver_ = std::make_unique<drake::solvers::OsqpSolver>();
-  prog_->SetSolverOptions(solver_options_);
+  solver_ = std::make_unique<solvers::FastOsqpSolver>();
+  solver_->InitializeSolver(*prog_, solver_options_);
 }
 
 drake::systems::EventStatus OperationalSpaceControl::DiscreteVariableUpdate(

--- a/systems/controllers/osc/operational_space_control.h
+++ b/systems/controllers/osc/operational_space_control.h
@@ -291,7 +291,7 @@ class OperationalSpaceControl : public drake::systems::LeafSystem<double> {
   bool is_quaternion_;
 
   // Solver
-  std::unique_ptr<drake::solvers::OsqpSolver> solver_;
+  std::unique_ptr<solvers::FastOsqpSolver> solver_;
   drake::solvers::SolverOptions solver_options_ =
       drake::yaml::LoadYamlFile<solvers::DairOsqpSolverOptions>(
           FindResourceOrThrow("solvers/osqp_options_default.yaml"))

--- a/systems/controllers/osc/operational_space_control.h
+++ b/systems/controllers/osc/operational_space_control.h
@@ -291,7 +291,7 @@ class OperationalSpaceControl : public drake::systems::LeafSystem<double> {
   bool is_quaternion_;
 
   // Solver
-  std::unique_ptr<solvers::FastOsqpSolver> solver_;
+  std::unique_ptr<drake::solvers::OsqpSolver> solver_;
   drake::solvers::SolverOptions solver_options_ =
       drake::yaml::LoadYamlFile<solvers::DairOsqpSolverOptions>(
           FindResourceOrThrow("solvers/osqp_options_default.yaml"))


### PR DESCRIPTION
This PR fixes a bug introduced in #308 - We switched the OSC from `FastOsqpSolver` to `drake::solvers::OsqpSolver `after drake updates rendered `FastOsqpSolver` incompatible with `MathematicalProgram`, but we no longer set the osqp solver options.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/314)
<!-- Reviewable:end -->
