### PR TITLE
python script for visualizing offline generated trajectories

### DIFF
--- a/bindings/pydairlib/lcm/visualization/BUILD.bazel
+++ b/bindings/pydairlib/lcm/visualization/BUILD.bazel
@@ -1,0 +1,52 @@
+    # -*- python -*-
+load("@drake//tools/install:install.bzl", "install")
+
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@drake//tools/skylark:pybind.bzl",
+    "drake_pybind_library",
+    "get_drake_py_installs",
+    "get_pybind_package_info",
+    "pybind_py_library",
+)
+
+py_binary(
+    name = "lcm_trajectory_plotter",
+    srcs = ["lcm_trajectory_plotter.py"],
+    deps = [
+        "//bindings/pydairlib/lcm",
+        "//lcmtypes:lcmtypes_robot_py",
+    ],
+)
+
+py_library(
+    name = "visualize_params",
+    srcs = ["visualize_params.py"],
+    deps = [],
+)
+
+py_binary(
+    name = "visualize_trajectory",
+    srcs = ["visualize_trajectory.py"],
+    deps = [
+        ":visualize_params",
+        "//bindings/pydairlib/lcm",
+        "//lcmtypes:lcmtypes_robot_py",
+        "//bindings/pydairlib/multibody",
+        "//bindings/pydairlib/common",
+        "//bindings/pydairlib/cassie:cassie_utils_py",
+    ],
+)
+
+py_binary(
+    name = "dircon_trajectory_plotter",
+    srcs = ["dircon_trajectory_plotter.py"],
+    deps = [
+        "//bindings/pydairlib/lcm",
+        "//bindings/pydairlib/common",
+        "//bindings/pydairlib/multibody:multibody_py",
+        "//bindings/pydairlib/cassie:cassie_utils_py",
+        "//lcmtypes:lcmtypes_robot_py",
+    ],
+)

--- a/bindings/pydairlib/lcm/visualization/dircon_trajectory_plotter.py
+++ b/bindings/pydairlib/lcm/visualization/dircon_trajectory_plotter.py
@@ -1,0 +1,141 @@
+import sys
+import matplotlib.pyplot as plt
+from pydairlib.lcm import lcm_trajectory
+from pydairlib.common import FindResourceOrThrow
+from pydrake.trajectories import PiecewisePolynomial
+import numpy as np
+
+from pydrake.all import (DiagramBuilder, AddMultibodyPlantSceneGraph)
+from pydairlib.cassie.cassie_utils import AddCassieMultibody
+
+def main():
+
+  builder = DiagramBuilder()
+  plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+  AddCassieMultibody(plant, scene_graph,
+                     True, "examples/Cassie/urdf/cassie_fixed_springs.urdf", False, True)
+
+  plant.Finalize()
+  # Default filename for the example
+  # filename = FindResourceOrThrow("examples/Cassie/saved_trajectories/jumping_0.15h_0.3d")
+  filename = FindResourceOrThrow(
+    "examples/Cassie/saved_trajectories/jumping_0.0h_0.6d_4")
+  # filename = FindResourceOrThrow(
+  #   "examples/Cassie/saved_trajectories/jumping_box_0.5h_0.3d_1")
+  # filename = FindResourceOrThrow(
+  #   "examples/Cassie/saved_trajectories/jumping_box_0.4h_0.3d_5")
+
+  # filename = FindResourceOrThrow("examples/Cassie/saved_trajectories/" + sys.argv[1])
+  dircon_traj = lcm_trajectory.DirconTrajectory(plant, filename)
+
+  # Reconstructing state and input trajectory as piecewise polynomials
+  state_traj = dircon_traj.ReconstructStateTrajectory()
+  input_traj = dircon_traj.ReconstructInputTrajectory()
+  state_datatypes = dircon_traj.GetTrajectory("state_traj0").datatypes
+  input_datatypes = dircon_traj.GetTrajectory("input_traj").datatypes
+  force_samples = dircon_traj.GetTrajectory("force_vars2").datapoints
+  force_t_samples = dircon_traj.GetStateBreaks(0)
+  force_traj = dircon_traj.ReconstructLambdaTrajectory()
+  # force_datatypes = dircon_traj.GetTrajectory("force_vars0").datatypes
+  force_datatypes = dircon_traj.GetTrajectory("force_vars2").datatypes
+
+  # impulse_samples = dircon_traj.GetImpulseSamples(2)
+  collocation_force_points = dircon_traj.GetCollocationForceSamples(0)
+  # M = reflected_joints()
+  #
+  # mirror_traj = lcm_trajectory.Trajectory()
+  # mirror_traj.traj_name = 'mirror_matrix'
+  # mirror_traj.time_vector = np.zeros(M.shape[0])
+  # mirror_traj.datapoints = MCc
+  # mirror_traj.datatypes = [''] * M.shape[0]
+  #
+  # dircon_traj.AddTrajectory('mirror_matrix', mirror_traj)
+  # dircon_traj.WriteToFile(filename)
+
+
+  plot_only_at_knotpoints = False
+
+  n_points = 500
+  t = np.linspace(state_traj.start_time(), state_traj.end_time(), n_points)
+  if plot_only_at_knotpoints:
+    n_points = force_t_samples.shape[0]
+    t = force_t_samples
+  state_samples = np.zeros((n_points, state_traj.value(0).shape[0]))
+  state_derivative_samples = np.zeros((n_points, state_traj.value(0).shape[0]))
+  input_samples = np.zeros((n_points, input_traj.value(0).shape[0]))
+  # force_samples = np.zeros((n_points, force_traj[0].value(0).shape[0]))
+  for i in range(n_points):
+    state_samples[i] = state_traj.value(t[i])[:, 0]
+    state_derivative_samples[i] = state_traj.EvalDerivative(t[i], 1)[:, 0]
+    input_samples[i] = input_traj.value(t[i])[:, 0]
+    # force_samples[i] = force_traj[0].value(t[i])[:, 0]
+
+  # reflected_state_samples = state_samples @ M
+  # Plotting reconstructed state trajectories
+  plt.figure("state trajectory")
+  plt.plot(t, state_samples[:, 4:7])
+  # plt.plot(t, state_samples[:, 22:25])
+  # plt.plot(t + state_traj.end_time(), reflected_state_samples[:, 0:7])
+  # plt.plot(t, state_samples[:, -18:])
+  # plt.plot(t + state_traj.end_time(), reflected_state_samples[:, 7:13])
+  # plt.plot(t, state_samples[:, 25:31])
+  # plt.plot(t + state_traj.end_time(), reflected_state_samples[:, 25:31])
+  plt.legend(state_datatypes[4:7])
+  # plt.legend(state_datatypes[22:25])
+
+  # Velocity Error
+  # plt.figure('velocity_error')
+  # import pdb; pdb.set_trace()
+  # plt.plot(t, (state_samples[:, (19 + 3):] - state_derivative_samples[:, 4:19]))
+  # plt.plot(t, (state_samples[:, -2:] - state_derivative_samples[:, 21:23]))
+  # plt.legend(state_datatypes[26:])
+  # plt.plot(t, state_samples[:, (23 + 3):])
+
+
+  plt.figure("input trajectory")
+  print(np.diff(input_samples[:, 7]))
+  plt.plot(t, input_samples[:, :])
+  plt.legend(input_datatypes[:])
+
+  plt.figure("force trajectory")
+  # plt.plot(t, force_samples[:, :12])
+  plt.plot(force_t_samples, force_samples.T)
+  plt.legend(force_datatypes)
+
+  plt.show()
+
+def reflected_joints():
+
+  mirror = np.zeros((37, 37))
+  mirror[0:7, 0:7] = np.eye(7)
+  mirror[19:25, 19:25] = np.eye(6)
+  joint_slice = range(7, 19, 2)
+  joint_vel_slice = range(19 + 6, 19 + 18, 2)
+  asy_indices = {7, 9, 25, 27}
+  mirror[1, 1] = -1
+  mirror[3, 3] = -1
+  mirror[5, 5] = -1
+
+  mirror[19, 19] = -1
+  mirror[21, 21] = -1
+  mirror[23, 23] = -1
+  for i in joint_slice:
+    if(i in asy_indices):
+      mirror[i,i+1] = -1
+      mirror[i+1,i] = -1
+    else:
+      mirror[i,i+1] = 1
+      mirror[i+1,i] = 1
+  for i in joint_vel_slice:
+    if(i in asy_indices):
+      mirror[i,i+1] = -1
+      mirror[i+1,i] = -1
+    else:
+      mirror[i,i+1] = 1
+      mirror[i+1,i] = 1
+  return mirror
+
+if __name__ == "__main__":
+  main()
+
+

--- a/bindings/pydairlib/lcm/visualization/lcm_trajectory_plotter.py
+++ b/bindings/pydairlib/lcm/visualization/lcm_trajectory_plotter.py
@@ -1,0 +1,188 @@
+import matplotlib.pyplot as plt
+from pydairlib.lcm import lcm_trajectory
+import numpy as np
+from pydrake.trajectories import PiecewisePolynomial
+
+
+def main():
+    loadedTrajs = lcm_trajectory.LcmTrajectory()
+    # loadedTrajs.LoadFromFile(
+    #     "/home/yangwill/workspace/dairlib/examples/Cassie/saved_trajectories/jumping_0.15h_0.3d_processed")
+    # loadedTrajs.LoadFromFile(
+    #     "/home/yangwill/workspace/dairlib/examples/Cassie/saved_trajectories/walking_0.16.0_processed")
+    loadedTrajs.LoadFromFile(
+        "/home/yangwill/workspace/dairlib/examples/Cassie/saved_trajectories/running_0.00_processed_rel")
+
+    lcm_left_foot_traj = loadedTrajs.GetTrajectory("left_foot_trajectory0")
+    lcm_right_foot_traj = loadedTrajs.GetTrajectory("right_foot_trajectory0")
+    lcm_left_hip_traj = loadedTrajs.GetTrajectory("left_hip_trajectory0")
+    lcm_right_hip_traj = loadedTrajs.GetTrajectory("right_hip_trajectory0")
+    lcm_pelvis_traj = loadedTrajs.GetTrajectory("pelvis_trans_trajectory0")
+    # lcm_pelvis_traj = loadedTrajs.GetTrajectory("pelvis_rot_trajectory0")
+
+    x_slice = slice(0, 6)
+    xdot_slice = slice(3, 9)
+    left_foot_traj = PiecewisePolynomial.CubicHermite(lcm_left_foot_traj.time_vector,
+                                                      lcm_left_foot_traj.datapoints[x_slice],
+                                                      lcm_left_foot_traj.datapoints[xdot_slice])
+    right_foot_traj = PiecewisePolynomial.CubicHermite(lcm_right_foot_traj.time_vector,
+                                                       lcm_right_foot_traj.datapoints[x_slice],
+                                                       lcm_right_foot_traj.datapoints[xdot_slice])
+    left_hip_traj = PiecewisePolynomial.CubicHermite(lcm_left_hip_traj.time_vector,
+                                                     lcm_left_hip_traj.datapoints[x_slice],
+                                                     lcm_left_hip_traj.datapoints[xdot_slice])
+    right_hip_traj = PiecewisePolynomial.CubicHermite(lcm_right_hip_traj.time_vector,
+                                                      lcm_right_hip_traj.datapoints[x_slice],
+                                                      lcm_right_hip_traj.datapoints[xdot_slice])
+    pelvis_traj = PiecewisePolynomial.CubicHermite(lcm_pelvis_traj.time_vector, lcm_pelvis_traj.datapoints[x_slice],
+                                                   lcm_pelvis_traj.datapoints[xdot_slice])
+    for mode in range(1, 6):
+        lcm_left_foot_traj = loadedTrajs.GetTrajectory("left_foot_trajectory" + str(mode))
+        lcm_right_foot_traj = loadedTrajs.GetTrajectory("right_foot_trajectory" + str(mode))
+        lcm_left_hip_traj = loadedTrajs.GetTrajectory("left_hip_trajectory" + str(mode))
+        lcm_right_hip_traj = loadedTrajs.GetTrajectory("right_hip_trajectory" + str(mode))
+        lcm_pelvis_traj = loadedTrajs.GetTrajectory("pelvis_trans_trajectory" + str(mode))
+
+        left_foot_traj.ConcatenateInTime(
+            PiecewisePolynomial.CubicHermite(lcm_left_foot_traj.time_vector, lcm_left_foot_traj.datapoints[x_slice],
+                                             lcm_left_foot_traj.datapoints[xdot_slice]))
+        right_foot_traj.ConcatenateInTime(
+            PiecewisePolynomial.CubicHermite(lcm_right_foot_traj.time_vector, lcm_right_foot_traj.datapoints[x_slice],
+                                             lcm_right_foot_traj.datapoints[xdot_slice]))
+        left_hip_traj.ConcatenateInTime(
+            PiecewisePolynomial.CubicHermite(lcm_left_hip_traj.time_vector, lcm_left_hip_traj.datapoints[x_slice],
+                                             lcm_left_hip_traj.datapoints[xdot_slice]))
+        right_hip_traj.ConcatenateInTime(
+            PiecewisePolynomial.CubicHermite(lcm_right_hip_traj.time_vector, lcm_right_hip_traj.datapoints[x_slice],
+                                             lcm_right_hip_traj.datapoints[xdot_slice]))
+        pelvis_traj.ConcatenateInTime(
+            PiecewisePolynomial.CubicHermite(lcm_pelvis_traj.time_vector, lcm_pelvis_traj.datapoints[x_slice],
+                                             lcm_pelvis_traj.datapoints[xdot_slice]))
+
+    # plt.figure('accel')
+    # plt.plot(lcm_left_foot_traj.time_vector, lcm_left_foot_traj.datapoints.T[:,2:3])
+    # plt.plot(lcm_left_foot_traj.time_vector, lcm_left_foot_traj.datapoints.T[:,5:6])
+    # plt.plot(times, accel[:, -1])
+    # plt.figure("left_foot pos")
+    # plt.plot(lcm_left_foot_traj.time_vector, lcm_left_foot_traj.datapoints.T[:,0:3])
+    # plt.legend(['x','y','z'])
+    # plt.figure("left_foot vel")
+    # plt.plot(lcm_left_foot_traj.time_vector, lcm_left_foot_traj.datapoints.T[:,3:6])
+    # plt.legend(['x','y','z'])
+    # plt.figure("right_foot pos")
+    # plt.plot(lcm_right_foot_traj.time_vector, lcm_right_foot_traj.datapoints.T[:,0:3])
+    # plt.legend(['x','y','z'])
+    # plt.figure("right_foot vel")
+    # plt.plot(lcm_right_foot_traj.time_vector, lcm_right_foot_traj.datapoints.T[:,3:6])
+    # plt.legend(['x','y','z'])
+
+    # reconstruct_trajectory(left_foot_traj)
+    reconstruct_trajectory_left_ft(left_foot_traj)
+
+    # plot_trajectory(pelvis_traj, 'pelvis')
+    # plot_trajectory(left_foot_traj - left_hip_traj, 'left_foot')
+    # plot_trajectory(right_foot_traj, 'right_foot')
+    plt.show()
+
+
+def plot_trajectory(traj_of_interest, traj_name):
+    times = np.arange(traj_of_interest.start_time(), traj_of_interest.end_time(), 5e-4)
+    # times = np.arange(traj_of_interest.start_time(), 0.2, 0.001)
+    y_dim = 3
+    accel = np.zeros((times.shape[0], y_dim))
+    pos = np.zeros((times.shape[0], y_dim))
+    vel = np.zeros((times.shape[0], y_dim))
+    for i in range(times.shape[0]):
+        pos[i, :] = traj_of_interest.value(times[i])[:3, 0]
+        vel[i, :] = traj_of_interest.EvalDerivative(times[i], 1)[:3, 0]
+        accel[i, :] = traj_of_interest.EvalDerivative(times[i], 2)[-3:, 0]
+
+    plt.figure(traj_name + "_pos")
+    plt.plot(times, pos)
+    plt.legend(['x', 'y', 'z', 'xdot', 'ydot', 'zdot'])
+    plt.figure(traj_name + "xz")
+    plt.plot(pos[:, 0], pos[:, 2])
+    plt.legend(['xz'])
+    plt.figure(traj_name + "yz")
+    plt.plot(pos[:, 1], pos[:, 2])
+    plt.legend(['yz'])
+    plt.figure(traj_name + "_vel")
+    plt.plot(times, vel)
+    plt.legend(['xdot', 'ydot', 'zdot', 'xddot', 'yddot', 'zddot'])
+    plt.figure(traj_name + "_acc")
+    plt.plot(times, accel)
+    plt.legend(['xdot', 'ydot', 'zdot', 'xddot', 'yddot', 'zddot'])
+    # plt.legend(['pos','vel','accel'])
+
+
+def reconstruct_trajectory(trajectory):
+    T_waypoints = np.array([0.4, 0.8, 1.0])
+    Y = np.zeros((3, 3))
+    start_pos = np.array([0, 0, 0])
+    end_pos = np.array([0.2, 0.1, 0])
+    Y[0] = start_pos
+    Y[1] = start_pos + 0.85 * (end_pos - start_pos)
+    Y[1, 2] += 0.05
+    Y[2] = end_pos
+    Y = Y.T
+    print(Y)
+
+    Ydot_start = np.zeros(3)
+    Ydot_end = np.zeros(3)
+
+    # traj = PiecewisePolynomial.CubicShapePreserving(T_waypoints, Y, True)
+    # traj = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(T_waypoints, Y, Ydot_start, Ydot_end)
+    traj = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(T_waypoints, Y, Ydot_start, Ydot_end)
+
+    plot_trajectory(traj, "reconstructed_trajectory")
+    return traj
+
+
+def reconstruct_trajectory_left_ft(trajectory):
+    ref = reconstruct_trajectory(trajectory)
+
+    T_waypoints_0 = np.array([0.0, 0.3, 0.5])
+    T_waypoints_midpoint = np.array([0.5, 0.9])
+    T_waypoints_1 = np.array([0.9, 1.0])
+    Y = np.zeros((3, 3))
+
+    start_pos = ref.value(0.5)[:, 0]
+    mid_pos = ref.value(0.8)[:, 0]
+    # end_pos = np.array([0.2, 0.1, 0])
+    end_pos = ref.value(1.0)[:, 0]
+    Y[0] = start_pos
+    Y[1] = mid_pos
+    Y[2] = end_pos
+    Y = Y.T
+    print(Y)
+
+    segment_0_start = ref.value(0.5)[:, 0]
+    segment_0_midpoint = ref.value(0.8)[:, 0]
+    segment_0_end = ref.value(1.0)[:, 0]
+    d_segment_0_start = ref.EvalDerivative(0.5, 1)[:, 0]
+    d_segment_0_midpoint = ref.EvalDerivative(0.8, 1)[:, 0]
+    d_segment_0_end = ref.EvalDerivative(1.0, 1)[:, 0]
+    segment_1_start = ref.value(0.4)[:, 0]
+    segment_1_end = ref.value(0.5)[:, 0]
+    d_segment_1_start = ref.EvalDerivative(0.4, 1)[:, 0]
+    d_segment_1_end = ref.EvalDerivative(0.5, 1)[:, 0]
+
+    Ydot_start = np.zeros(3)
+    Ydot_end = np.zeros(3)
+
+    print(np.array([end_pos, segment_1_start]))
+    # traj = PiecewisePolynomial.CubicShapePreserving(T_waypoints, Y, True)
+    traj_0 = PiecewisePolynomial.CubicHermite(T_waypoints_0,
+                                              np.array([segment_0_start, segment_0_midpoint, segment_0_end]).T,
+                                              np.array([d_segment_0_start, d_segment_0_midpoint, d_segment_0_end]).T)
+    traj_midpoint = PiecewisePolynomial.ZeroOrderHold(T_waypoints_midpoint, np.array([end_pos, end_pos]).T)
+    traj_1 = PiecewisePolynomial.CubicHermite(T_waypoints_1, np.array([segment_1_start, segment_1_end]).T,
+                                              np.array([d_segment_1_start, d_segment_1_end]).T)
+
+    traj_0.ConcatenateInTime(traj_midpoint)
+    traj_0.ConcatenateInTime(traj_1)
+    plot_trajectory(traj_0, "reconstructed_trajectory_left")
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/pydairlib/lcm/visualization/visualize_configs/long_jump.yaml
+++ b/bindings/pydairlib/lcm/visualization/visualize_configs/long_jump.yaml
@@ -1,0 +1,8 @@
+filename: examples/Cassie/saved_trajectories/jumping_0.0h_0.75d_2
+spring_urdf: examples/Cassie/urdf/cassie_v2_shells.urdf
+fixed_spring_urdf: examples/Cassie/urdf/cassie_fixed_springs.urdf
+visualize_mode: 1
+realtime_rate: 0.2
+num_poses: 10
+use_transparency: 1
+use_springs: 1

--- a/bindings/pydairlib/lcm/visualization/visualize_params.py
+++ b/bindings/pydairlib/lcm/visualization/visualize_params.py
@@ -1,0 +1,21 @@
+import io
+from yaml import load, dump
+
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+
+class DirconVisualizationParams():
+    def __init__(self, filename):
+        data = load(io.open(filename, 'r'), Loader=Loader)
+        self.filename = data['filename']
+        self.spring_urdf = data['spring_urdf']
+        self.fixed_spring_urdf = data['fixed_spring_urdf']
+        self.visualize_mode = data['visualize_mode']
+        self.realtime_rate = data['realtime_rate']
+        self.num_poses = data['num_poses']
+        self.use_transparency = data['use_transparency']
+        self.use_springs = data['use_springs']
+

--- a/bindings/pydairlib/lcm/visualization/visualize_trajectory.py
+++ b/bindings/pydairlib/lcm/visualization/visualize_trajectory.py
@@ -1,0 +1,74 @@
+import sys
+import matplotlib.pyplot as plt
+from pydairlib.lcm import lcm_trajectory
+from pydairlib.common import FindResourceOrThrow
+from pydrake.trajectories import PiecewisePolynomial
+import numpy as np
+
+from pydrake.all import (DiagramBuilder, AddMultibodyPlantSceneGraph, Simulator, SceneGraph, MultibodyPlant)
+from pydrake.geometry import MeshcatVisualizer, StartMeshcat, MeshcatVisualizerParams
+from pydairlib.cassie.cassie_utils import AddCassieMultibody
+from pydairlib.multibody import MultiposeVisualizer, ConnectTrajectoryVisualizer
+from visualize_params import DirconVisualizationParams
+
+
+def main():
+    visualization_config_file = 'bindings/pydairlib/lcm/visualization/visualize_configs/long_jump.yaml'
+    params = DirconVisualizationParams(visualization_config_file)
+
+    builder = DiagramBuilder()
+    scene_graph_wo_spr = builder.AddSystem(SceneGraph())
+    # plant_wo_spr, scene_graph_wo_spr = AddMultibodyPlantSceneGraph(builder, 0.0)
+    plant_wo_spr = MultibodyPlant(0.0)
+    AddCassieMultibody(plant_wo_spr, scene_graph_wo_spr,
+                       True, "examples/Cassie/urdf/cassie_fixed_springs.urdf",
+                       False, False)
+
+    plant_wo_spr.Finalize()
+    # plant_w_spr, scene_graph_w_spr = AddMultibodyPlantSceneGraph(builder, 0.0)
+    # AddCassieMultibody(plant_w_spr, scene_graph_w_spr,
+    #                    True, "examples/Cassie/urdf/cassie_v2_shells.urdf",
+    #                    False, False)
+    #
+    # plant_w_spr.Finalize()
+
+    nq = plant_wo_spr.num_positions()
+    nv = plant_wo_spr.num_velocities()
+    nx = nq + nv
+
+    filename = FindResourceOrThrow(params.filename)
+
+    dircon_traj = lcm_trajectory.DirconTrajectory(plant_wo_spr, filename)
+
+    optimal_traj = dircon_traj.ReconstructStateTrajectory()
+    t_vec = optimal_traj.get_segment_times()
+
+    if params.visualize_mode == 0 or params.visualize_mode == 1:
+        ConnectTrajectoryVisualizer(plant_wo_spr, builder, scene_graph_wo_spr,
+                                    optimal_traj)
+        meschat_params = MeshcatVisualizerParams()
+        meschat_params.publish_period = 1.0/60.0
+        meshcat = StartMeshcat()
+        visualizer = MeshcatVisualizer.AddToBuilder(
+            builder, scene_graph_wo_spr, meshcat, meschat_params)
+        diagram = builder.Build()
+
+        while params.visualize_mode == 1:
+            simulator = Simulator(diagram)
+            simulator.set_target_realtime_rate(params.realtime_rate)
+            simulator.Initialize()
+            simulator.AdvanceTo(optimal_traj.end_time())
+
+    elif params.visualize_mode == 2:
+        poses = np.zeros((params.num_poses, nx))
+        for i in range(params.num_poses):
+            poses[i] = optimal_traj.value(t_vec[int(i * len(t_vec) / params.num_poses)])[:, 0]
+        alpha_scale = np.linspace(0.2, 1.0, params.num_poses)
+        visualizer = MultiposeVisualizer(FindResourceOrThrow(
+            params.fixed_spring_urdf),
+            params.num_poses, np.square(alpha_scale), "")
+        visualizer.DrawPoses(poses.T)
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/pydairlib/multibody/BUILD.bazel
+++ b/bindings/pydairlib/multibody/BUILD.bazel
@@ -15,13 +15,14 @@ pybind_py_library(
     name = "multibody_py",
     cc_deps = [
         "//multibody:multipose_visualizer",
+        "//multibody:visualization_utils",
         "//multibody:utils",
         "@drake//:drake_shared_library",
     ],
     cc_so_name = "multibody",
     cc_srcs = ["multibody_py.cc"],
     py_deps = [
-        "@drake//bindings/pydrake",
+#        "@drake//bindings/pydrake",
         ":module_py",
     ],
     py_imports = ["."],

--- a/bindings/pydairlib/multibody/multibody_py.cc
+++ b/bindings/pydairlib/multibody/multibody_py.cc
@@ -5,6 +5,7 @@
 
 #include "multibody/multibody_utils.h"
 #include "multibody/multipose_visualizer.h"
+#include "multibody/visualization_utils.h"
 
 namespace py = pybind11;
 
@@ -24,6 +25,10 @@ PYBIND11_MODULE(multibody, m) {
       .def(py::init<std::string, int, Eigen::VectorXd, std::string>())
       .def("DrawPoses", &MultiposeVisualizer::DrawPoses, py::arg("poses"));
 
+  m.def("ConnectTrajectoryVisualizer",
+        &dairlib::multibody::ConnectTrajectoryVisualizer, py::arg("plant"),
+        py::arg("builder"), py::arg("scene_graph"), py::arg("trajectory"));
+
   m.def("MakeNameToPositionsMap",
         &dairlib::multibody::MakeNameToPositionsMap<double>, py::arg("plant"))
       .def("MakeNameToVelocitiesMap",
@@ -42,6 +47,7 @@ PYBIND11_MODULE(multibody, m) {
            py::arg("plant"), py::arg("scene_graph"), py::arg("mu_static"),
            py::arg("mu_kinetic"),
            py::arg("normal_W") = Eigen::Vector3d(0, 0, 1),
+           py::arg("stiffness") = 0, py::arg("dissipation_rate") = 0,
            py::arg("show_ground") = 1);
 }
 

--- a/multibody/kinematic/distance_evaluator.h
+++ b/multibody/kinematic/distance_evaluator.h
@@ -14,7 +14,7 @@ namespace multibody {
 /// The one exception is Jdotv, since Drake does not currently support
 /// MultibodyPlant.CalcBiasSpatialAcceleration with non-world frames,
 template <typename T>
-class DistanceEvaluator : public KinematicEvaluator<T> {
+class DistanceEvaluator final : public KinematicEvaluator<T> {
  public:
   /// Constructor for DistanceEvaluator
   /// @param plant

--- a/multibody/multipose_visualizer.cc
+++ b/multibody/multipose_visualizer.cc
@@ -2,6 +2,7 @@
 
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_interface_system.h"
 
@@ -88,6 +89,12 @@ MultiposeVisualizer::MultiposeVisualizer(string model_file, int num_poses,
     }
   }
 
+  drake::geometry::MeshcatVisualizerParams params;
+  params.publish_period = 1.0/60.0;
+  meshcat_ = std::make_shared<drake::geometry::Meshcat>();
+  meshcat_visualizer_ = &drake::geometry::MeshcatVisualizer<double>::AddToBuilder(
+      &builder, *scene_graph, meshcat_, std::move(params));
+
   DrakeVisualizer<double>::AddToBuilder(&builder, *scene_graph, lcm);
   diagram_ = builder.Build();
   diagram_context_ = diagram_->CreateDefaultContext();
@@ -106,6 +113,7 @@ void MultiposeVisualizer::DrawPoses(MatrixXd poses) {
 
   // Publish diagram
   diagram_->Publish(*diagram_context_);
+
 }
 
 }  // namespace multibody

--- a/multibody/multipose_visualizer.h
+++ b/multibody/multipose_visualizer.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/meshcat_visualizer.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram.h"
@@ -57,6 +58,8 @@ class MultiposeVisualizer {
   int num_poses_;
   drake::multibody::MultibodyPlant<double>* plant_;
   std::unique_ptr<drake::systems::Diagram<double>> diagram_;
+  std::shared_ptr<drake::geometry::Meshcat> meshcat_;
+  drake::geometry::MeshcatVisualizer<double>* meshcat_visualizer_;
   std::unique_ptr<drake::systems::Context<double>> diagram_context_;
   std::vector<drake::multibody::ModelInstanceIndex> model_indices_;
 };

--- a/multibody/visualization_utils.cc
+++ b/multibody/visualization_utils.cc
@@ -4,6 +4,8 @@
 #include "multibody/com_pose_system.h"
 #include "systems/primitives/subvector_pass_through.h"
 #include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/meshcat_visualizer.h"
+#include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/primitives/trajectory_source.h"
 
@@ -37,11 +39,11 @@ void ConnectTrajectoryVisualizer(
     drake::geometry::SceneGraph<double>* scene_graph,
     const Trajectory<double>& trajectory) {
   auto empty_plant = std::make_unique<MultibodyPlant<double>>(0.0);
-  ConnectTrajectoryVisualizer(plant, builder, scene_graph, trajectory,
+  ConnectTrajectoryVisualizerWithCoM(plant, builder, scene_graph, trajectory,
                               *empty_plant);
 }
 
-void ConnectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizerWithCoM(
     const MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,
@@ -82,6 +84,7 @@ void ConnectTrajectoryVisualizer(
   }
 
   DrakeVisualizer<double>::AddToBuilder(builder, *scene_graph);
+
 }
 
 }  // namespace multibody

--- a/multibody/visualization_utils.h
+++ b/multibody/visualization_utils.h
@@ -27,7 +27,7 @@ void ConnectTrajectoryVisualizer(
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,
     const drake::trajectories::Trajectory<double>& trajectory);
-void ConnectTrajectoryVisualizer(
+void ConnectTrajectoryVisualizerWithCoM(
     const drake::multibody::MultibodyPlant<double>* plant,
     drake::systems::DiagramBuilder<double>* builder,
     drake::geometry::SceneGraph<double>* scene_graph,


### PR DESCRIPTION
Visualization script similar to `visualize_trajectory.cc` written in Python for easier modification.

Supports visualization in both MeshCat and drake_visualizer. Meshcat support added to make additional visualization easier and to slowly deprecate drake_visualizer.

added `.yaml` to take the place of gflags to save visualization configurations and make modifications easier.