### PR TITLE
Add argument `add_reflected_inertia` to `addCassieMultibody`

### DIFF
--- a/bindings/pydairlib/cassie/cassie_utils_py.cc
+++ b/bindings/pydairlib/cassie/cassie_utils_py.cc
@@ -29,7 +29,7 @@ PYBIND11_MODULE(cassie_utils, m) {
            &dairlib::LeftLoopClosureEvaluator<double>, py::arg("plant"))
       .def("RightLoopClosureEvaluator",
            &dairlib::RightLoopClosureEvaluator<double>, py::arg("plant"))
-      .def("addCassieMultibody", &dairlib::addCassieMultibody, py::arg("plant"),
+      .def("AddCassieMultibody", &dairlib::AddCassieMultibody, py::arg("plant"),
            py::arg("scene_graph"), py::arg("floating_base"),
            py::arg("filename"), py::arg("add_leaf_springs"),
            py::arg("add_loop_closure"), py::arg("add_reflected_inertia"));

--- a/bindings/pydairlib/cassie/cassie_utils_py.cc
+++ b/bindings/pydairlib/cassie/cassie_utils_py.cc
@@ -29,10 +29,10 @@ PYBIND11_MODULE(cassie_utils, m) {
            &dairlib::LeftLoopClosureEvaluator<double>, py::arg("plant"))
       .def("RightLoopClosureEvaluator",
            &dairlib::RightLoopClosureEvaluator<double>, py::arg("plant"))
-      .def("AddCassieMultibody", &dairlib::AddCassieMultibody, py::arg("plant"),
+      .def("addCassieMultibody", &dairlib::addCassieMultibody, py::arg("plant"),
            py::arg("scene_graph"), py::arg("floating_base"),
            py::arg("filename"), py::arg("add_leaf_springs"),
-           py::arg("add_loop_closure"));
+           py::arg("add_loop_closure"), py::arg("add_reflected_inertia"));
 }
 
 }  // namespace pydairlib

--- a/examples/Cassie/cassie_utils.cc
+++ b/examples/Cassie/cassie_utils.cc
@@ -107,7 +107,7 @@ multibody::DistanceEvaluator<T> RightLoopClosureEvaluator(
 void AddCassieMultibody(MultibodyPlant<double>* plant,
                         SceneGraph<double>* scene_graph, bool floating_base,
                         std::string filename, bool add_leaf_springs,
-                        bool add_loop_closure) {
+                        bool add_loop_closure, bool add_reflected_inertia) {
   std::string full_name = FindResourceOrThrow(filename);
   Parser parser(plant, scene_graph);
   parser.AddModelFromFile(full_name);
@@ -162,7 +162,6 @@ void AddCassieMultibody(MultibodyPlant<double>* plant,
         kCassieAchillesLength, achilles_stiffness, achilles_damping);
   }
 
-  bool add_reflected_inertia = true;
   VectorXd rotor_inertias(10);
   rotor_inertias << 61, 61, 61, 61, 365, 365, 365, 365, 4.9, 4.9;
   rotor_inertias *= 1e-6;

--- a/examples/Cassie/cassie_utils.h
+++ b/examples/Cassie/cassie_utils.h
@@ -67,12 +67,15 @@ multibody::DistanceEvaluator<T> RightLoopClosureEvaluator(
 ///     Default = true
 /// @param add_loop_closure_springs Whether or not to add the loop closure
 ///     distance constraint via stiff springs. Default = true.
+/// @param add_loop_closure_springs Whether or not to add the reflected inertia
+///     of the motors. Default = true.
 void AddCassieMultibody(
     drake::multibody::MultibodyPlant<double>* plant,
     drake::geometry::SceneGraph<double>* scene_graph = nullptr,
     bool floating_base = true,
     std::string filename = "examples/Cassie/urdf/cassie_v2.urdf",
-    bool add_leaf_springs = true, bool add_loop_closure = true);
+    bool add_leaf_springs = true, bool add_loop_closure = true,
+    bool add_reflected_inertia = true);
 
 /// Add simulated gyroscope and accelerometer along with sensor aggregator,
 /// which creates and publishes a simulated lcmt_cassie_out LCM message.


### PR DESCRIPTION
Make `add_reflected_inertia` an input to the util function `addCassieMultibody` for `PinocchioPlant` (`PinocchioPlant` is in local branch and it cannot handle reflected inertia at least for now). 

I came across this conflict when merging with master branch. It would be great if `add_reflected_inertia` is an argument so that I don't get more conflicts in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dairlab/dairlib/328)
<!-- Reviewable:end -->
