### PR TITLE
seeking to first known message to set as start time

### DIFF
--- a/bindings/pydairlib/analysis/process_lcm_log.py
+++ b/bindings/pydairlib/analysis/process_lcm_log.py
@@ -16,6 +16,8 @@ def get_log_data(lcm_log, lcm_channels, start_time, duration, data_processing_ca
     data_to_process = {}
     print('Processing LCM log (this may take a while)...')
     lcm_log.seek(0)
+    while lcm_log.read_next_event().channel not in lcm_channels:
+        pass
     first_timestamp = lcm_log.read_next_event().timestamp
     start_timestamp = int(first_timestamp + start_time * 1e6)
     print('Start time: ' + str(start_time))


### PR DESCRIPTION
Previously we were setting the timestamp of ANY lcm message as the `start_time` for the log. This works fine if we don't need precise seeking for hardware logs as we start the logger around when we start the experiment. However, for sim logs when we're often inadvertently logging visualization messages, this makes it difficult to accurately seek to the actual start time of the experiment. 

This makes a simple change to have the `start_time` line up with the first KNOWN lcm message of the log as specified by `lcm_channels`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/335)
<!-- Reviewable:end -->
