### PR TITLE
Call CalcForcedDiscreteVariableUpdate in LcmDrivenLoop

### DIFF
--- a/examples/Cassie/cassie_lcm_driven_loop.h
+++ b/examples/Cassie/cassie_lcm_driven_loop.h
@@ -282,6 +282,8 @@ class CassieLcmDrivenLoop {
         }
 
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedUnrestrictedUpdate(
+            diagram_context, &diagram_context.get_mutable_state());
         diagram_ptr_->CalcForcedDiscreteVariableUpdate(
             diagram_context, &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
@@ -312,6 +314,8 @@ class CassieLcmDrivenLoop {
         // the LCM message used here successfully arrives at the input port of
         // the other LcmSubscriberSystem
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedUnrestrictedUpdate(
+            diagram_context, &diagram_context.get_mutable_state());
         diagram_ptr_->CalcForcedDiscreteVariableUpdate(
             diagram_context, &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {

--- a/examples/Cassie/cassie_lcm_driven_loop.h
+++ b/examples/Cassie/cassie_lcm_driven_loop.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <iostream>
 #include <map>
 #include <string>
 #include <vector>
-#include <iostream>
 
 #include "dairlib/lcmt_controller_switch.hpp"
 
@@ -253,7 +253,8 @@ class CassieLcmDrivenLoop {
           last_input_msg_time_ = time;
         } else {
           // use the robot state to advance
-          if(state_sub_->message().utime * 1e-6 - last_input_msg_time_ > 0.005){
+          if (state_sub_->message().utime * 1e-6 - last_input_msg_time_ >
+              0.005) {
             time = state_sub_->message().utime * 1e-6;
           }
           state_sub_->clear();
@@ -263,12 +264,13 @@ class CassieLcmDrivenLoop {
         // (likely due to a restart of the driving clock)
         if (time > simulator_->get_context().get_time() + 1.0 ||
             time < simulator_->get_context().get_time()) {
-
-          if(time > simulator_->get_context().get_time() + 1.0){
-            std::cout << "input message time greater than driven loop time" << std::endl;
+          if (time > simulator_->get_context().get_time() + 1.0) {
+            std::cout << "input message time greater than driven loop time"
+                      << std::endl;
           }
-          if(time < simulator_->get_context().get_time()){
-            std::cout << "input message time less than driven loop time" << std::endl;
+          if (time < simulator_->get_context().get_time()) {
+            std::cout << "input message time less than driven loop time"
+                      << std::endl;
           }
           std::cout << diagram_name_ + " time is "
                     << simulator_->get_context().get_time()
@@ -280,6 +282,8 @@ class CassieLcmDrivenLoop {
         }
 
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedDiscreteVariableUpdate(
+            diagram_context, &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
           // Force-publish via the diagram
           diagram_ptr_->ForcedPublish(diagram_context);
@@ -308,6 +312,8 @@ class CassieLcmDrivenLoop {
         // the LCM message used here successfully arrives at the input port of
         // the other LcmSubscriberSystem
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedDiscreteVariableUpdate(
+            diagram_context, &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
           // Force-publish via the diagram
           diagram_ptr_->ForcedPublish(diagram_context);

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -260,6 +260,8 @@ class LcmDrivenLoop {
           simulator_->Initialize();
         }
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedDiscreteVariableUpdate(diagram_context,
+                                                       &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
           // Force-publish via the diagram
           diagram_ptr_->ForcedPublish(diagram_context);
@@ -288,6 +290,8 @@ class LcmDrivenLoop {
         // the LCM message used here successfully arrives at the input port of
         // the other LcmSubscriberSystem
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedDiscreteVariableUpdate(diagram_context,
+                                                       &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
           // Force-publish via the diagram
           diagram_ptr_->ForcedPublish(diagram_context);

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -260,6 +260,8 @@ class LcmDrivenLoop {
           simulator_->Initialize();
         }
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedUnrestrictedUpdate(
+            diagram_context, &diagram_context.get_mutable_state());
         diagram_ptr_->CalcForcedDiscreteVariableUpdate(diagram_context,
                                                        &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {
@@ -290,6 +292,8 @@ class LcmDrivenLoop {
         // the LCM message used here successfully arrives at the input port of
         // the other LcmSubscriberSystem
         simulator_->AdvanceTo(time);
+        diagram_ptr_->CalcForcedUnrestrictedUpdate(
+            diagram_context, &diagram_context.get_mutable_state());
         diagram_ptr_->CalcForcedDiscreteVariableUpdate(diagram_context,
                                                        &diagram_context.get_mutable_discrete_state());
         if (is_forced_publish_) {


### PR DESCRIPTION
Adding CalcForcedDiscreteVariableUpdate to driven loop to better control discrete updates.

Calling `simulator->AdvanceTo()` has the potential to call PerStepDiscreteUpdates multiple times, which can be quite costly if there's significant computation. Can also cause issues if there's manual discrete filters. To minimize the chance of a mistake, I'm adding  `CalcForcedDiscreteVariableUpdate` to the driven loop to ensure if we use `DeclareForcedDiscreteUpdateEvent`, it will only be called once per LcmDrivenLoop AdvanceTo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/345)
<!-- Reviewable:end -->
