### PR TITLE
Change LcmDrivenLoop to accept a System* instead of a LeafSystem* as the lcm_parser

### DIFF
--- a/bindings/pydairlib/systems/framework_py.cc
+++ b/bindings/pydairlib/systems/framework_py.cc
@@ -21,7 +21,7 @@ PYBIND11_MODULE(framework, m) {
 py::class_<LcmOutputDrivenLoop>(m, "LcmOutputDrivenLoop")
     .def(py::init<drake::lcm::DrakeLcm*,
                   std::unique_ptr<drake::systems::Diagram<double>>,
-                  const drake::systems::LeafSystem<double>*,
+                  const drake::systems::System<double>*,
                   const std::string&, bool>(), py::arg("drake_lcm"),
                   py::arg("diagram"), py::arg("lcm_parser"),
                   py::arg("input_channel"),  py::arg("is_forced_publish"))

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "dairlib/lcmt_controller_switch.hpp"
 #include "dairlib/lcmt_robot_output.hpp"
@@ -69,7 +70,7 @@ class LcmDrivenLoop {
   ///     @param is_forced_publish A flag which enables publishing via diagram.
   LcmDrivenLoop(drake::lcm::DrakeLcm* drake_lcm,
                 std::unique_ptr<drake::systems::Diagram<double>> diagram,
-                const drake::systems::LeafSystem<double>* lcm_parser,
+                const drake::systems::System<double>* lcm_parser,
                 const std::string& input_channel, bool is_forced_publish)
       : LcmDrivenLoop(drake_lcm, std::move(diagram), lcm_parser,
                       std::vector<std::string>(1, input_channel), input_channel,
@@ -86,7 +87,7 @@ class LcmDrivenLoop {
   ///     @param is_forced_publish A flag which enables publishing via diagram.
   LcmDrivenLoop(drake::lcm::DrakeLcm* drake_lcm,
                 std::unique_ptr<drake::systems::Diagram<double>> diagram,
-                const drake::systems::LeafSystem<double>* lcm_parser,
+                const drake::systems::System<double>* lcm_parser,
                 std::vector<std::string> input_channels,
                 const std::string& active_channel,
                 const std::string& switch_channel, bool is_forced_publish,
@@ -317,7 +318,7 @@ class LcmDrivenLoop {
  private:
   drake::lcm::DrakeLcm* drake_lcm_;
   drake::systems::Diagram<double>* diagram_ptr_;
-  const drake::systems::LeafSystem<double>* lcm_parser_;
+  const drake::systems::System<double>* lcm_parser_;
   std::unique_ptr<drake::systems::Simulator<double>> simulator_;
 
   std::string diagram_name_ = "diagram";


### PR DESCRIPTION
Small change to make LcmDrivenLoop more flexible (my use case is a nested diagram which accepts lcmt_robot_output. This is necessary since Diagram subclasses System, not LeafSystem).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/355)
<!-- Reviewable:end -->
