### PR TITLE
Update LcmDrivenLoop to add a message queue size parameter

### DIFF
--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -60,6 +60,9 @@ namespace systems {
  * for multi-threaded locking; it should only be used in cases where the
  * governing DrakeLcmInterface::HandleSubscriptions is called from the same
  * thread that owns all copies of this object.
+ *
+ * This is a duplicate of drake::lcm::Subscriber, but makes the subscription_
+ * object public, which we need to change the queue size.
  */
 template <typename Message>
 class Subscriber final {

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -53,6 +53,71 @@ namespace systems {
 /// Note that we implement the class only in the header file because we don't
 /// know what MessageTypes are beforehand.
 
+/**
+ * Subscribes to and stores a copy of the most recent message on a given
+ * channel, for some @p Message type.  All copies of a given Subscriber share
+ * the same underlying data.  This class does NOT provide any mutex behavior
+ * for multi-threaded locking; it should only be used in cases where the
+ * governing DrakeLcmInterface::HandleSubscriptions is called from the same
+ * thread that owns all copies of this object.
+ */
+template <typename Message>
+class Subscriber final {
+ public:
+  // Intentionally copyable so that it can be returned and stored by-value.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Subscriber);
+
+  /**
+   * Subscribes to the (non-empty) @p channel on the given (non-null)
+   * @p lcm instance.  The `lcm` pointer is only used during construction; it
+   * is not retained by this object.  When a undecodable message is received,
+   * @p on_error handler is invoked; when `on_error` is not provided, an
+   * exception will be thrown instead.
+   */
+  Subscriber(drake::lcm::DrakeLcmInterface* lcm, const std::string& channel,
+             std::function<void()> on_error = {}) {
+    subscription_ = drake::lcm::Subscribe<Message>(
+        lcm, channel,
+        [data = data_](const Message& message) {
+          data->message = message;
+          data->count++;
+        },
+        std::move(on_error));
+    if (subscription_) {
+      subscription_->set_unsubscribe_on_delete(true);
+    }
+  }
+
+  /**
+   * Returns the most recently received message, or a value-initialized (zeros)
+   * message otherwise.
+   */
+  const Message& message() const { return data_->message; }
+  Message& message() { return data_->message; }
+
+  /** Returns the total number of received messages. */
+  int64_t count() const { return data_->count; }
+  int64_t& count() { return data_->count; }
+
+  /** Clears all data (sets the message and count to all zeros). */
+  void clear() {
+    data_->message = {};
+    data_->count = 0;
+  }
+
+  struct Data {
+    Message message{};
+    int64_t count{0};
+  };
+  // Share a single copy of our (mutable) message storage, for all Subscribers
+  // to view or modify *and* for our subscription closure to write into.  This
+  // will not be destroyed until all Subscribers are gone AND the subscription
+  // closure has been destroyed.
+  std::shared_ptr<Data> data_{std::make_shared<Data>()};
+  // Keep our subscription active as long as a copy of this Subscriber remains.
+  std::shared_ptr<drake::lcm::DrakeSubscriptionInterface> subscription_;
+};
+
 // We set a default value for SwitchMessageType so that we can generalize this
 // to both single and multi inputs.
 template <typename InputMessageType,
@@ -71,10 +136,11 @@ class LcmDrivenLoop {
   LcmDrivenLoop(drake::lcm::DrakeLcm* drake_lcm,
                 std::unique_ptr<drake::systems::Diagram<double>> diagram,
                 const drake::systems::System<double>* lcm_parser,
-                const std::string& input_channel, bool is_forced_publish)
+                const std::string& input_channel, bool is_forced_publish,
+                int queue_capacity=1)
       : LcmDrivenLoop(drake_lcm, std::move(diagram), lcm_parser,
                       std::vector<std::string>(1, input_channel), input_channel,
-                      "", is_forced_publish){};
+                      "", is_forced_publish, queue_capacity){};
 
   /// Constructor for multi-input LcmDrivenLoop
   ///     @param drake_lcm DrakeLcm
@@ -91,6 +157,7 @@ class LcmDrivenLoop {
                 std::vector<std::string> input_channels,
                 const std::string& active_channel,
                 const std::string& switch_channel, bool is_forced_publish,
+                int queue_capacity=1,
                 const std::string& backup_drive_channel = "")
       : drake_lcm_(drake_lcm),
         lcm_parser_(lcm_parser),
@@ -108,7 +175,7 @@ class LcmDrivenLoop {
     DRAKE_DEMAND(!input_channels.empty());
     if (input_channels.size() > 1) {
       DRAKE_DEMAND(!switch_channel.empty());
-      switch_sub_ = std::make_unique<drake::lcm::Subscriber<SwitchMessageType>>(
+      switch_sub_ = std::make_unique<Subscriber<SwitchMessageType>>(
           drake_lcm_, switch_channel);
     }
 
@@ -116,7 +183,8 @@ class LcmDrivenLoop {
     for (const auto& name : input_channels) {
       std::cout << "Constructing subscriber for " << name << std::endl;
       name_to_input_sub_map_.insert(std::make_pair(
-          name, drake::lcm::Subscriber<InputMessageType>(drake_lcm_, name)));
+          name, Subscriber<InputMessageType>(drake_lcm_, name)));
+      name_to_input_sub_map_.at(name).subscription_->set_queue_capacity(queue_capacity);
     }
 
     // Make sure input_channels contains active_channel, and then set initial
@@ -133,7 +201,7 @@ class LcmDrivenLoop {
     active_channel_ = active_channel;
 
     if (!backup_drive_channel.empty()) {
-      state_sub_ = std::make_unique<drake::lcm::Subscriber<lcmt_robot_output>>(
+      state_sub_ = std::make_unique<Subscriber<lcmt_robot_output>>(
           drake_lcm_, backup_drive_channel);
     }
   };
@@ -155,6 +223,14 @@ class LcmDrivenLoop {
   drake::systems::Diagram<double>* get_diagram() { return diagram_ptr_; }
   drake::systems::Context<double>& get_diagram_mutable_context() {
     return simulator_->get_mutable_context();
+  }
+
+
+  InputMessageType wait_for_message() const {
+    LcmHandleSubscriptionsUntil(drake_lcm_, [&]() {
+      return name_to_input_sub_map_.at(active_channel_).count() > 0;
+    });
+    return name_to_input_sub_map_.at(active_channel_).message();
   }
 
   // Start simulating the diagram
@@ -225,6 +301,11 @@ class LcmDrivenLoop {
         return is_new_input_message || is_new_switch_message ||
             is_new_state_message;
       });
+
+      // Pump drake's LCM subscribers to empty their internal queues
+      // until all LCM buffers are up-to-date.
+      // Addresses https://github.com/RobotLocomotion/drake/issues/15234
+      while (drake_lcm_->HandleSubscriptions(0) > 0);
 
       // Update the diagram context when there is new input message
       if (is_new_input_message || too_long_between_input_messages_) {
@@ -323,11 +404,9 @@ class LcmDrivenLoop {
 
   std::string diagram_name_ = "diagram";
   std::string active_channel_;
-  std::unique_ptr<drake::lcm::Subscriber<SwitchMessageType>> switch_sub_ =
-      nullptr;
-  std::map<std::string, drake::lcm::Subscriber<InputMessageType>>
-      name_to_input_sub_map_;
-  std::unique_ptr<drake::lcm::Subscriber<lcmt_robot_output>> state_sub_;
+  std::unique_ptr<Subscriber<SwitchMessageType>> switch_sub_ = nullptr;
+  std::map<std::string, Subscriber<InputMessageType>> name_to_input_sub_map_;
+  std::unique_ptr<Subscriber<lcmt_robot_output>> state_sub_;
 
   bool is_forced_publish_;
   bool too_long_between_input_messages_ = false;

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -136,6 +136,9 @@ class LcmDrivenLoop {
   ///     incoming lcm message
   ///     @param input_channel The name of the input channel
   ///     @param is_forced_publish A flag which enables publishing via diagram.
+  ///     @param queue_capacity The queue size for the LCM subscriber on the input channels.
+  ///            Defaults to 1, but should be set higher if stepping the LCMDrivenLoop will take
+  ///            longer than the driving channel.
   LcmDrivenLoop(drake::lcm::DrakeLcm* drake_lcm,
                 std::unique_ptr<drake::systems::Diagram<double>> diagram,
                 const drake::systems::System<double>* lcm_parser,
@@ -154,6 +157,9 @@ class LcmDrivenLoop {
   ///     @param active_channel The name of the initial active input channel
   ///     @param switch_channel The name of the switch channel
   ///     @param is_forced_publish A flag which enables publishing via diagram.
+  ///     @param queue_capacity The queue size for the LCM subscriber on the input channels.
+  ///            Defaults to 1, but should be set higher if stepping the LCMDrivenLoop will take
+  ///            longer than the driving channel.
   LcmDrivenLoop(drake::lcm::DrakeLcm* drake_lcm,
                 std::unique_ptr<drake::systems::Diagram<double>> diagram,
                 const drake::systems::System<double>* lcm_parser,

--- a/systems/framework/lcm_driven_loop.h
+++ b/systems/framework/lcm_driven_loop.h
@@ -234,14 +234,6 @@ class LcmDrivenLoop {
     return simulator_->get_mutable_context();
   }
 
-
-  InputMessageType wait_for_message() const {
-    LcmHandleSubscriptionsUntil(drake_lcm_, [&]() {
-      return name_to_input_sub_map_.at(active_channel_).count() > 0;
-    });
-    return name_to_input_sub_map_.at(active_channel_).message();
-  }
-
   // Start simulating the diagram
   void Simulate(double end_time = std::numeric_limits<double>::infinity()) {
     // Get mutable contexts


### PR DESCRIPTION
Addresses https://github.com/RobotLocomotion/drake/issues/15234 by adding the ability to set the queue size of LcmDrivenLoop's internal subscribers, and handling the lcm subscription until the queue is empty (up to date) on each loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/366)
<!-- Reviewable:end -->
