### PR TITLE
Fixes to bazel build files

### DIFF
--- a/examples/sampling_c3/BUILD.bazel
+++ b/examples/sampling_c3/BUILD.bazel
@@ -9,8 +9,8 @@ cc_library(
 
 filegroup(
     name = "all_example_params_yamls",
-    srcs = glob(["*/parameters/*.yaml"]),
     visibility = ["//visibility:public"],
+    data = ["//examples/sampling_c3/jacktoy:parameters"],
 )
 
 filegroup(

--- a/examples/sampling_c3/jacktoy/BUILD.bazel
+++ b/examples/sampling_c3/jacktoy/BUILD.bazel
@@ -4,23 +4,12 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "urdfs",
-    data = glob([
-        "urdf/**",
-    ]),
-)
-
-cc_library(
     name = "parameters",
     data = glob([
-        "*yaml",
+        "parameters/*.yaml",
     ]),
 )
 
-cc_library(
-    name = "franka_hardware",
-    deps = [],
-)
 
 cc_library(
     name = "lcm_channels_jacktoy",


### PR DESCRIPTION
Likely a result of the upgrade to Bazel 8.2, which leads to errors on empty globs. I wonder if these empty globs weren't actually needed in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/381)
<!-- Reviewable:end -->
