### PR TITLE
Fix some missing .yaml file dependencies

### DIFF
--- a/examples/franka/BUILD.bazel
+++ b/examples/franka/BUILD.bazel
@@ -278,6 +278,7 @@ cc_library(
     ],
     data = glob([
         "parameters/*.yaml",
+        "parameters/**/*.yaml",
     ]),
     deps = [
         "@drake//:drake_shared_library",

--- a/examples/franka/forward_kinematics_for_lcs.cc
+++ b/examples/franka/forward_kinematics_for_lcs.cc
@@ -35,6 +35,7 @@ using drake::math::RigidTransform;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::TriggerType;
 using drake::systems::TriggerTypeSet;
@@ -185,11 +186,12 @@ int DoMain(int argc, char* argv[]) {
   builder.Connect(c3_state_sender->get_output_port_target_c3_state(),
                   c3_target_state_publisher->get_input_port());
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_forward_kinematics"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_forward_kinematics"));
 
   // Run lcm-driven simulation
   systems::LcmDrivenLoop<dairlib::lcmt_robot_output> loop(
-      &lcm, std::move(owned_diagram), franka_state_receiver,
+      &lcm, shared_diagram, franka_state_receiver,
       lcm_channel_params.franka_state_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
 

--- a/examples/franka/franka_bridge_driver_in.cc
+++ b/examples/franka/franka_bridge_driver_in.cc
@@ -24,6 +24,7 @@
 using drake::math::RigidTransform;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::Simulator;
 using drake::systems::lcm::LcmPublisherSystem;
@@ -86,10 +87,11 @@ int DoMain(int argc, char* argv[]) {
   builder.Connect(*franka_command_translator, *franka_command_pub);
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_bridge_driver_in"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_bridge_driver_in"));
 
   systems::LcmDrivenLoop<dairlib::lcmt_robot_input> loop(
-      &lcm, std::move(owned_diagram), franka_command_translator,
+      &lcm, shared_diagram, franka_command_translator,
       lcm_channel_params.franka_input_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   loop.Simulate();

--- a/examples/franka/franka_bridge_driver_out.cc
+++ b/examples/franka/franka_bridge_driver_out.cc
@@ -24,6 +24,7 @@
 using drake::math::RigidTransform;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::Simulator;
 using drake::systems::lcm::LcmPublisherSystem;
@@ -88,10 +89,11 @@ int DoMain(int argc, char* argv[]) {
   builder.Connect(*franka_state_translator, *franka_state_pub);
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_bridge_driver_out"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_bridge_driver_out"));
 
   systems::LcmDrivenLoop<drake::lcmt_panda_status> loop(
-      &lcm, std::move(owned_diagram), franka_state_translator,
+      &lcm, shared_diagram, franka_state_translator,
       franka_driver_channel_params.franka_status_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   loop.Simulate();

--- a/examples/franka/franka_c3_controller.cc
+++ b/examples/franka/franka_c3_controller.cc
@@ -35,6 +35,7 @@ using drake::math::RigidTransform;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::TriggerType;
 using drake::systems::TriggerTypeSet;
@@ -311,13 +312,14 @@ int DoMain(int argc, char* argv[]) {
   //                  lcs_factory->get_input_port_lcs_input());
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_c3_controller"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_c3_controller"));
   plant_diagram->set_name(("franka_c3_plant"));
   //  DrawAndSaveDiagramGraph(*plant_diagram);
 
   // Run lcm-driven simulation
   systems::LcmDrivenLoop<dairlib::lcmt_robot_output> loop(
-      &lcm, std::move(owned_diagram), franka_state_receiver,
+      &lcm, shared_diagram, franka_state_receiver,
       lcm_channel_params.franka_state_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   //  auto& controller_context = loop.get_diagram()->GetMutableSubsystemContext(

--- a/examples/franka/franka_c3_controller_two_objects.cc
+++ b/examples/franka/franka_c3_controller_two_objects.cc
@@ -37,6 +37,7 @@ using drake::math::RigidTransform;
 using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::TriggerType;
 using drake::systems::TriggerTypeSet;
@@ -325,13 +326,14 @@ int DoMain(int argc, char* argv[]) {
   //                  lcs_factory->get_input_port_lcs_input());
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_c3_controller"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_c3_controller"));
   plant_diagram->set_name(("franka_c3_plant"));
   //  DrawAndSaveDiagramGraph(*plant_diagram);
 
   // Run lcm-driven simulation
   systems::LcmDrivenLoop<dairlib::lcmt_robot_output> loop(
-      &lcm, std::move(owned_diagram), franka_state_receiver,
+      &lcm, shared_diagram, franka_state_receiver,
       lcm_channel_params.franka_state_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   //  auto& controller_context = loop.get_diagram()->GetMutableSubsystemContext(

--- a/examples/franka/franka_lcm_ros_bridge.cc
+++ b/examples/franka/franka_lcm_ros_bridge.cc
@@ -33,6 +33,7 @@
 using drake::math::RigidTransform;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::Simulator;
 using drake::systems::lcm::LcmPublisherSystem;
@@ -103,8 +104,8 @@ int DoMain(int argc, char* argv[]) {
                   robot_input_ros_publisher->get_input_port());
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_lcm_ros_bridge"));
-  const auto& diagram = *owned_diagram;
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_lcm_ros_bridge"));
 
   // figure out what the arguments to this mean
   ros::AsyncSpinner spinner(1);
@@ -112,7 +113,7 @@ int DoMain(int argc, char* argv[]) {
   signal(SIGINT, SigintHandler);
 
   systems::LcmDrivenLoop<dairlib::lcmt_robot_input> loop(
-      &drake_lcm, std::move(owned_diagram), robot_input_receiver,
+      &drake_lcm, shared_diagram, robot_input_receiver,
       lcm_channel_params.franka_input_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   loop.Simulate();

--- a/examples/franka/franka_osc_controller.cc
+++ b/examples/franka/franka_osc_controller.cc
@@ -37,6 +37,7 @@ namespace dairlib {
 
 using drake::math::RigidTransform;
 using drake::multibody::Parser;
+using drake::systems::Diagram;
 using drake::systems::DiagramBuilder;
 using drake::systems::TriggerType;
 using drake::systems::TriggerTypeSet;
@@ -272,10 +273,11 @@ int DoMain(int argc, char* argv[]) {
                   osc->get_input_port_tracking_data("end_effector_force"));
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_osc_controller"));
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_osc_controller"));
   // Run lcm-driven simulation
   systems::LcmDrivenLoop<dairlib::lcmt_robot_output> loop(
-      &lcm, std::move(owned_diagram), state_receiver,
+      &lcm, shared_diagram, state_receiver,
       lcm_channel_params.franka_state_channel, true);
   DrawAndSaveDiagramGraph(*loop.get_diagram());
   loop.Simulate();

--- a/examples/franka/franka_ros_lcm_bridge.cc
+++ b/examples/franka/franka_ros_lcm_bridge.cc
@@ -133,10 +133,11 @@ int DoMain(int argc, char* argv[]) {
   /* -------------------------------------------------------------------------------------------*/
 
   auto owned_diagram = builder.Build();
-  owned_diagram->set_name(("franka_ros_lcm_bridge"));
-  const auto& diagram = *owned_diagram;
+  std::shared_ptr<Diagram<double>> shared_diagram = std::move(owned_diagram);
+  shared_diagram->set_name(("franka_ros_lcm_bridge"));
+  const auto& diagram = *shared_diagram;
   DrawAndSaveDiagramGraph(diagram);
-  drake::systems::Simulator<double> simulator(std::move(owned_diagram));
+  drake::systems::Simulator<double> simulator(shared_diagram);
   auto& diagram_context = simulator.get_mutable_context();
 
   // figure out what the arguments to this mean

--- a/examples/franka/franka_visualizer.cc
+++ b/examples/franka/franka_visualizer.cc
@@ -244,6 +244,8 @@ int do_main(int argc, char* argv[]) {
                     c3_target_drawer->get_input_port_c3_state_actual());
     builder.Connect(c3_state_target_sub->get_output_port(),
                     c3_target_drawer->get_input_port_c3_state_target());
+    builder.Connect(c3_state_target_sub->get_output_port(),
+                    c3_target_drawer->get_input_port_c3_state_final_target());
   }
 
   if (sim_params.visualize_c3_forces) {
@@ -281,6 +283,8 @@ int do_main(int argc, char* argv[]) {
       &builder, scene_graph, meshcat, std::move(params));
 
   auto diagram = builder.Build();
+  diagram->set_name("franka_c3_visualizer");
+  DrawAndSaveDiagramGraph(*diagram);
   auto context = diagram->CreateDefaultContext();
 
   auto& franka_state_sub_context =

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -170,3 +170,8 @@ cc_test(
         "@gtest//:main",
     ],
 )
+
+filegroup(
+    name = "solver_params",
+    srcs = glob(["*.yaml"]),
+)

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -75,6 +75,9 @@ cc_library(
     name = "c3_controller",
     srcs = ["c3/c3_controller.cc"],
     hdrs = ["c3/c3_controller.h"],
+    data = [
+        "//solvers:solver_params",
+    ],
     deps = [
         "//lcm:lcm_trajectory_saver",
         "//lcmtypes:lcmt_robot",
@@ -91,6 +94,9 @@ cc_library(
     name = "sampling_c3_controller",
     srcs = ["sampling_based_c3_controller.cc"],
     hdrs = ["sampling_based_c3_controller.h"],
+    data = [
+        "//solvers:solver_params",
+    ],
     deps = [
         "//lcm:lcm_trajectory_saver",
         "//lcmtypes:lcmt_robot",


### PR DESCRIPTION
**Background**


I am trying to reproduce the work in "Dynamic On-palm manipulation via controlled sliding" paper. 

**Description**

I found out some of the targets in `examples/franka/franka_sim.pmd` where built with `bazel build //...`but failed to run due to missing .yaml files at runtime. When running with `bazel run`, I would get an error in the lines of

```
terminate called after throwing an instance of 'drake_vendor::YAML::BadFile'
  what():  bad file: solvers/osqp_options_default.yaml
```

which, after a quick search, indicates the file does not exists in the directory specified.

This PR defines the adequate targets in the BAZEL.build files to include the missing files inside bazel's sandbox, in particular for the following targets:

```
bazel run //examples/franka:franka_sim
bazel run //examples/franka:franka_visualizer
bazel run //examples/franka:franka_c3_controller
bazel run //examples/franka:franka_osc_controller
bazel run //examples/franka:forward_kinematics_for_lcs
```

**Tests**

Apart from building the relevant targets and making sure they run, I did not ran any other tests. I assume there is a CI  system that will check unit tests pass; otherwise please let me know which tests to run


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/387)
<!-- Reviewable:end -->
