### PR TITLE
Fix bug in external force tracking feature of OSC

### DIFF
--- a/systems/controllers/osc/operational_space_control.cc
+++ b/systems/controllers/osc/operational_space_control.cc
@@ -403,7 +403,11 @@ VectorXd OperationalSpaceControl::SolveQp(
   const auto active_contact_names = contact_names_map_.count(fsm_state) > 0
                                         ? contact_names_map_.at(fsm_state)
                                         : std::vector<std::string>();
-  id_qp_.UpdateDynamics(x_w_spr, active_contact_names, {});
+  std::vector<std::string> active_external_forces = {};
+  for (const auto& force_tracking_data : *force_tracking_data_vec_) {
+    active_external_forces.push_back(force_tracking_data->GetName());
+  }
+  id_qp_.UpdateDynamics(x_w_spr, active_contact_names, active_external_forces);
 
   //  Invariant Impacts
   //  Only update when near an impact


### PR DESCRIPTION
In the `UpdateDynamics` function of the `OperationalSpaceControl` class, an empty list of external contact force names is currently passed, preventing the Jacobian matrix from being updated and resulting in improper force tracking.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/391)
<!-- Reviewable:end -->
