### PR TITLE
Keep track of previously attempted samples and avoid repeating if ineffective

### DIFF
--- a/examples/sampling_c3/anything/parameters/sampling_params.yaml
+++ b/examples/sampling_c3/anything/parameters/sampling_params.yaml
@@ -28,6 +28,12 @@ N_sample_buffer: 200
 pos_error_sample_retention: 0.002
 ang_error_sample_retention: 0.02  # 0.0349 rad = 2 deg
 
+# Unsuccessful sample buffer parameters.  Position and angular error sample
+# retention match that for the sample buffer above.
+avoid_choosing_unsuccessful_samples: true
+N_unsuccessful_sample_buffer: 10
+unsuccessful_radius: 0.01
+
 # Shared across multiple sampling strategies.
 sampling_radius: 0.16  # kRadiallySymmetric, kRandomOnCircle, kRandomOnSphere
 sampling_height: 0.005 # kRadiallySymmetric, kRandomOnCircle, kRandomOnPerimeter

--- a/examples/sampling_c3/franka_sampling_c3_controller.cc
+++ b/examples/sampling_c3/franka_sampling_c3_controller.cc
@@ -544,10 +544,18 @@ int DoMain(int argc, char* argv[]) {
   // Sample-related senders/publishers.
   auto sample_buffer_sender = builder.AddSystem<systems::SampleBufferSender>(
       controller_params.sampling_params.N_sample_buffer,
-      plant_lcs.num_positions());
+      plant_lcs.num_positions(), "sample_buffer_sender");
   auto sample_buffer_publisher =
       builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_sample_buffer>(
           lcm_channel_params.sample_buffer_channel, &lcm,
+          TriggerTypeSet({TriggerType::kForced})));
+  auto unsuccessful_sample_buffer_sender =
+      builder.AddSystem<systems::SampleBufferSender>(
+          controller_params.sampling_params.N_unsuccessful_sample_buffer,
+          plant_lcs.num_positions(), "unsuccessful_sample_buffer_sender");
+  auto unsuccessful_sample_buffer_publisher =
+      builder.AddSystem(LcmPublisherSystem::Make<dairlib::lcmt_sample_buffer>(
+          lcm_channel_params.unsuccessful_sample_buffer_channel, &lcm,
           TriggerTypeSet({TriggerType::kForced})));
   auto sample_locations_publisher = builder.AddSystem(
       LcmPublisherSystem::Make<dairlib::lcmt_timestamped_saved_traj>(
@@ -727,6 +735,12 @@ int DoMain(int argc, char* argv[]) {
                   sample_buffer_sender->get_input_port_samples());
   builder.Connect(controller->get_output_port_sample_buffer_costs(),
                   sample_buffer_sender->get_input_port_sample_costs());
+  builder.Connect(unsuccessful_sample_buffer_sender->get_output_port_sample_buffer(),
+                  unsuccessful_sample_buffer_publisher->get_input_port());
+  builder.Connect(controller->get_output_port_unsuccessful_sample_buffer_configurations(),
+                  unsuccessful_sample_buffer_sender->get_input_port_samples());
+  builder.Connect(controller->get_output_port_unsuccessful_sample_buffer_costs(),
+                  unsuccessful_sample_buffer_sender->get_input_port_sample_costs());
 
   std::cout << "Before drawandsave" << std::endl;
   auto owned_diagram = builder.Build();

--- a/examples/sampling_c3/generate_samples.cc
+++ b/examples/sampling_c3/generate_samples.cc
@@ -38,8 +38,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
     std::vector<std::vector<Face>> faces_per_object,
     std::vector<std::vector<double>> face_bins_per_object,
     std::vector<double> total_area_per_object,
-    std::vector<bool> object_on_target
-      ) {
+    std::vector<bool> object_on_target,
+    const MatrixXd& unsuccessful_sample_buffer
+) {
   // Determine number of samples based on mode.
   int num_samples;
   if (is_doing_c3) {
@@ -67,8 +68,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
       candidate_states[i].head(3) = RadiallySymmetricSampling(
         n_q, n_v, x_lcs, num_samples, i, sampling_params.sampling_radius,
         sampling_params.sampling_height);
-      if (sampling_params.filter_samples_for_safety &&
-          !IsSampleInWorkspace(candidate_states[i], sampling_c3_options)) {
+      if (!SampleIsAcceptable(
+            candidate_states[i], sampling_params, sampling_c3_options,
+            unsuccessful_sample_buffer)) {
         throw std::runtime_error(
           "Error:  Radially symmetric sample location is outside workspace.");
       }
@@ -79,8 +81,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
         candidate_states[i].head(3) = RandomOnCircleSampling(
           n_q, n_v, x_lcs, sampling_params.sampling_radius,
           sampling_params.sampling_height);
-      } while (sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+      } while (!SampleIsAcceptable(
+                  candidate_states[i], sampling_params, sampling_c3_options,
+                  unsuccessful_sample_buffer));
     }
   } else if (strategy == SamplingStrategy::kRandomOnSphere) {
     for (int i = 0; i < num_samples; i++) {
@@ -89,8 +92,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
           n_q, n_v, x_lcs, sampling_params.sampling_radius,
           sampling_params.min_angle_from_vertical,
           sampling_params.max_angle_from_vertical);
-      } while (sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+      } while (!SampleIsAcceptable(
+                  candidate_states[i], sampling_params, sampling_c3_options,
+                  unsuccessful_sample_buffer));
     }
   } else if (strategy == SamplingStrategy::kFixed) {
     if (num_samples > sampling_params.fixed_sample_locations.size()) {
@@ -103,8 +107,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
       }
       candidate_states[i].head(3) = FixedSample(
         sampling_params.fixed_sample_locations.row(i));
-      if (sampling_params.filter_samples_for_safety &&
-          !IsSampleInWorkspace(candidate_states[i], sampling_c3_options)) {
+      if (!SampleIsAcceptable(
+            candidate_states[i], sampling_params, sampling_c3_options,
+            unsuccessful_sample_buffer)) {
         throw std::runtime_error(
           "Error:  Fixed sample location is outside workspace.");
       }
@@ -115,8 +120,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
         candidate_states[i].head(3) = PerimeterSampling(
           n_q, n_v, n_u, x_lcs, plant, context, plant_ad, context_ad,
           contact_geoms, sampling_params, sampling_c3_options);
-      } while (sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+      } while (!SampleIsAcceptable(
+                  candidate_states[i], sampling_params, sampling_c3_options,
+                  unsuccessful_sample_buffer));
     }
   } else if (strategy == SamplingStrategy::kRandomOnShell) {
     for (int i = 0; i < num_samples; i++) {
@@ -124,8 +130,9 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
         candidate_states[i].head(3) = ShellSampling(
           n_q, n_v, n_u, x_lcs, plant, context, plant_ad, context_ad,
           contact_geoms, sampling_params, sampling_c3_options);
-      } while (sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+      } while (!SampleIsAcceptable(
+                  candidate_states[i], sampling_params, sampling_c3_options,
+                  unsuccessful_sample_buffer));
     }
   } else if (strategy == SamplingStrategy::kMeshNormal) {
     for (int i = 0; i < num_samples; i++){
@@ -133,18 +140,21 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
         candidate_states[i] = MeshNormalSampling(
           n_q, n_v, n_u, x_lcs, plant, context, plant_ad, context_ad,
           sampling_params, query_object, faces, face_bins);
-      } while(sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+      } while(!SampleIsAcceptable(
+                candidate_states[i], sampling_params, sampling_c3_options,
+                unsuccessful_sample_buffer));
     }
   } else if (strategy == SamplingStrategy::kMeshNormalMultiObject) {
     for (int i = 0; i < num_samples; i++) {
       do {
         candidate_states[i] = MeshNormalSamplingMultiObject(
           n_q, n_v, n_u, x_lcs, plant, context, plant_ad, context_ad,
-          contact_geoms, sampling_params, sampling_c3_options, query_object, faces_per_object,
-          face_bins_per_object, total_area_per_object, object_on_target);
-      } while (sampling_params.filter_samples_for_safety &&
-               !IsSampleInWorkspace(candidate_states[i], sampling_c3_options));
+          contact_geoms, sampling_params, sampling_c3_options, query_object,
+          faces_per_object, face_bins_per_object, total_area_per_object,
+          object_on_target);
+      } while (!SampleIsAcceptable(
+                  candidate_states[i], sampling_params, sampling_c3_options,
+                  unsuccessful_sample_buffer));
     }
   }
   
@@ -152,6 +162,46 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
     throw std::runtime_error("Error:  Sampling strategy not recognized.");
   }
   return candidate_states;
+}
+
+bool SampleIsAcceptable(
+    const Eigen::VectorXd& candidate_state,
+    const SamplingParams& sampling_params,
+    const SamplingC3Options& sampling_c3_options,
+    const MatrixXd& unsuccessful_samples) {
+  // Condition 1:  Sample is within the workspace.
+  bool is_in_workspace = IsSampleInWorkspace(
+    candidate_state, sampling_c3_options);
+  bool condition_1 = sampling_params.filter_samples_for_safety?
+    is_in_workspace : true;
+
+  // Condition 2:  Sample avoids being near any unsuccessful samples.
+  bool avoids_bad_spots = SampleAvoidsBadSpots(
+    candidate_state, sampling_params, unsuccessful_samples);
+  bool condition_2 = sampling_params.avoid_choosing_unsuccessful_samples?
+    avoids_bad_spots : true;
+
+  return condition_1 && condition_2;
+}
+
+bool SampleAvoidsBadSpots(
+    const Eigen::VectorXd& candidate_state,
+    const SamplingParams& sampling_params,
+    const MatrixXd& unsuccessful_samples
+) {
+  Vector3d ee_candidate = candidate_state.head(3);
+  for (int i = 0; i < unsuccessful_samples.rows(); i++) {
+    // If made it through all unsuccessful samples without detecting the
+    // candidate sample is too close, the unsuccessful samples are avoided.
+    if (unsuccessful_samples.row(i).sum() == 0) { break; }
+
+    // Detect if the candidate sample is too close to the unsuccessful sample.
+    Vector3d ee_bad = unsuccessful_samples.row(i).head(3);
+    if ((ee_candidate - ee_bad).norm() < sampling_params.unsuccessful_radius) {
+      return false;
+    }
+  }
+  return true;
 }
 
 // kRadiallySymmetric:  Equally spaced on perimeter of circle of fixed radius

--- a/examples/sampling_c3/generate_samples.h
+++ b/examples/sampling_c3/generate_samples.h
@@ -16,6 +16,7 @@
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+using Eigen::MatrixXd;
 using dairlib::systems::Face;
 
 namespace dairlib {
@@ -42,7 +43,21 @@ std::vector<Eigen::VectorXd> GenerateSampleStates(
     std::vector<std::vector<Face>> faces_per_object,
     std::vector<std::vector<double>> face_bins_per_object,
     std::vector<double> total_area_per_object,
-    std::vector<bool> object_on_target
+    std::vector<bool> object_on_target,
+    const MatrixXd& unsuccessful_sample_buffer
+);
+
+bool SampleIsAcceptable(
+    const Eigen::VectorXd& candidate_state,
+    const SamplingParams& sampling_params,
+    const SamplingC3Options& sampling_c3_options,
+    const MatrixXd& unsuccessful_samples
+);
+
+bool SampleAvoidsBadSpots(
+    const Eigen::VectorXd& candidate_state,
+    const SamplingParams& sampling_params,
+    const MatrixXd& unsuccessful_samples
 );
 
 /// Individual sampling strategies returning 3D EE position

--- a/examples/sampling_c3/parameter_headers/lcm_channels.h
+++ b/examples/sampling_c3/parameter_headers/lcm_channels.h
@@ -32,6 +32,7 @@ struct SamplingC3LcmChannels {
 
   std::string sample_locations_channel;
   std::string sample_buffer_channel;
+  std::string unsuccessful_sample_buffer_channel;
   std::string dynamically_feasible_curr_actor_plan_channel;
   std::string dynamically_feasible_curr_plan_channel;
   std::string dynamically_feasible_best_actor_plan_channel;
@@ -72,6 +73,7 @@ struct SamplingC3LcmChannels {
 
     a->Visit(DRAKE_NVP(sample_locations_channel));
     a->Visit(DRAKE_NVP(sample_buffer_channel));
+    a->Visit(DRAKE_NVP(unsuccessful_sample_buffer_channel));
     a->Visit(DRAKE_NVP(dynamically_feasible_curr_actor_plan_channel));
     a->Visit(DRAKE_NVP(dynamically_feasible_curr_plan_channel));
     a->Visit(DRAKE_NVP(dynamically_feasible_best_actor_plan_channel));

--- a/examples/sampling_c3/parameter_headers/sampling_params.h
+++ b/examples/sampling_c3/parameter_headers/sampling_params.h
@@ -45,6 +45,11 @@ struct SamplingParams {
   double pos_error_sample_retention;
   double ang_error_sample_retention;
 
+  /// Sample buffer parameters.
+  bool avoid_choosing_unsuccessful_samples;
+  int N_unsuccessful_sample_buffer;
+  double unsuccessful_radius;
+
   /// Shared across multiple sampling strategies.
   double sampling_radius;               // kRadiallySymmetric, kRandomOnCircle,
                                         // kRandomOnSphere
@@ -97,6 +102,9 @@ struct SamplingParams {
     a->Visit(DRAKE_NVP(N_sample_buffer));
     a->Visit(DRAKE_NVP(pos_error_sample_retention));
     a->Visit(DRAKE_NVP(ang_error_sample_retention));
+    a->Visit(DRAKE_NVP(avoid_choosing_unsuccessful_samples));
+    a->Visit(DRAKE_NVP(N_unsuccessful_sample_buffer));
+    a->Visit(DRAKE_NVP(unsuccessful_radius));
     a->Visit(DRAKE_NVP(sample_projection_clearance));
     a->Visit(DRAKE_NVP(buffer_distance));
     a->Visit(DRAKE_NVP(max_attempts));

--- a/examples/sampling_c3/shared_parameters/lcm_channels_hardware.yaml
+++ b/examples/sampling_c3/shared_parameters/lcm_channels_hardware.yaml
@@ -30,6 +30,8 @@ c3_actual_state_channel: C3_ACTUAL              # lcmt_c3_state
 sample_locations_channel: SAMPLE_LOCATIONS
 sample_costs_channel: SAMPLE_COSTS
 sample_buffer_channel: SAMPLE_BUFFER            # lcmt_sample_buffer
+unsuccessful_sample_buffer_channel: UNSUCCESSFUL_SAMPLE_BUFFER
+                                                # lcmt_sample_buffer
 
 dynamically_feasible_curr_actor_plan_channel: DYNAMICALLY_FEASIBLE_CURR_ACTOR_PLAN
 dynamically_feasible_curr_plan_channel: DYNAMICALLY_FEASIBLE_CURR_PLAN

--- a/examples/sampling_c3/shared_parameters/lcm_channels_simulation.yaml
+++ b/examples/sampling_c3/shared_parameters/lcm_channels_simulation.yaml
@@ -31,6 +31,8 @@ c3_actual_state_channel: C3_ACTUAL              # lcmt_c3_state
 sample_locations_channel: SAMPLE_LOCATIONS
 sample_costs_channel: SAMPLE_COSTS
 sample_buffer_channel: SAMPLE_BUFFER            # lcmt_sample_buffer
+unsuccessful_sample_buffer_channel: UNSUCCESSFUL_SAMPLE_BUFFER
+                                                # lcmt_sample_buffer
 
 dynamically_feasible_curr_actor_plan_channel: DYNAMICALLY_FEASIBLE_CURR_ACTOR_PLAN
 dynamically_feasible_curr_plan_channel: DYNAMICALLY_FEASIBLE_CURR_PLAN

--- a/systems/controllers/sampling_based_c3_controller.cc
+++ b/systems/controllers/sampling_based_c3_controller.cc
@@ -1066,7 +1066,8 @@ auto c3_start = std::chrono::high_resolution_clock::now();
       mode_switch_reason_ = ModeSwitchReason::kToC3Xbox;
       pursued_target_source_ = PursuedTargetSource::kNoTarget;
       // Add the current state to the unsuccessful sample buffer.  It gets
-      // automatically removed if the object moves.
+      // automatically removed if the object moves beyond the buffer movement
+      // thresholds.
       AddToUnsuccessfulBuffer(candidate_states[0]);
     }
     // Switch to C3 if the current sample is better, with hysteresis.
@@ -1091,7 +1092,8 @@ auto c3_start = std::chrono::high_resolution_clock::now();
       }
       pursued_target_source_ = PursuedTargetSource::kNoTarget;
       // Add the current state to the unsuccessful sample buffer.  It gets
-      // automatically removed if the object moves.
+      // automatically removed if the object moves beyond the buffer movement
+      // thresholds.
       AddToUnsuccessfulBuffer(candidate_states[0]);
     }
   }

--- a/systems/controllers/sampling_based_c3_controller.cc
+++ b/systems/controllers/sampling_based_c3_controller.cc
@@ -417,15 +417,34 @@ SamplingC3Controller::SamplingC3Controller(
   sample_costs_buffer_ = -1 * VectorXd::Ones(sampling_params_.N_sample_buffer);
   sample_buffer_configurations_port_ =
       this->DeclareAbstractOutputPort(
-              "sample_buffer_configurations", sample_buffer_,
-              &SamplingC3Controller::OutputSampleBufferConfigurations)
-          .get_index();
+            "sample_buffer_configurations", sample_buffer_,
+            &SamplingC3Controller::OutputSampleBufferConfigurations)
+        .get_index();
 
   sample_buffer_costs_port_ =
       this->DeclareAbstractOutputPort(
-              "sample_buffer_costs", sample_costs_buffer_,
-              &SamplingC3Controller::OutputSampleBufferCosts)
-          .get_index();
+            "sample_buffer_costs", sample_costs_buffer_,
+            &SamplingC3Controller::OutputSampleBufferCosts)
+        .get_index();
+
+  // Unsuccessful sample buffer related output ports.
+  unsuccessful_sample_buffer_ = MatrixXd::Zero(
+    sampling_params_.N_unsuccessful_sample_buffer, n_q_);
+  unsuccessful_sample_costs_buffer_ = -1 * VectorXd::Ones(
+    sampling_params_.N_unsuccessful_sample_buffer);
+  unsuccessful_sample_buffer_configurations_port_ =
+      this->DeclareAbstractOutputPort(
+            "unsuccessful_sample_buffer_configurations",
+            unsuccessful_sample_buffer_,
+            &SamplingC3Controller::OutputUnsuccessfulSampleBufferConfigurations)
+        .get_index();
+
+  unsuccessful_sample_buffer_costs_port_ =
+      this->DeclareAbstractOutputPort(
+            "unsuccessful_sample_buffer_costs",
+            unsuccessful_sample_costs_buffer_,
+            &SamplingC3Controller::OutputUnsuccessfulSampleBufferCosts)
+        .get_index();
 
   plan_start_time_index_ = DeclareDiscreteState(1);
   x_pred_curr_plan_ = VectorXd::Zero(n_x_);
@@ -620,7 +639,6 @@ drake::systems::EventStatus SamplingC3Controller::ComputePlan(
   current_position_error_ = 0;
   current_orientation_error_ = 0;
 
-  //std::cout << x_lcs_curr.transpose() << std::endl;
   for (int i = 0; i < controller_params_.num_objects; i++) {
     double error = (x_lcs_curr.segment(7 + 7*i, 3) -
       x_lcs_final_des.get_value().segment(7 + 7*i, 3)).norm();
@@ -658,9 +676,15 @@ drake::systems::EventStatus SamplingC3Controller::ComputePlan(
     //is_doing_c3_ = false;
     detected_goal_changes_++;
 
-    // Reset the sample buffer now that the costs have changed.
+    // Reset the sample buffers now that the costs have changed.
     sample_buffer_ = MatrixXd::Zero(sampling_params_.N_sample_buffer, n_q_);
-    sample_costs_buffer_ = -1 * VectorXd::Ones(sampling_params_.N_sample_buffer);
+    sample_costs_buffer_ = -1*VectorXd::Ones(sampling_params_.N_sample_buffer);
+    num_in_buffer_ = 0;
+    unsuccessful_sample_buffer_ = MatrixXd::Zero(
+      sampling_params_.N_unsuccessful_sample_buffer, n_q_);
+    unsuccessful_sample_costs_buffer_ = -1 * VectorXd::Ones(
+      sampling_params_.N_unsuccessful_sample_buffer);
+    num_in_unsuccessful_buffer_ = 0;
   }
 
   // If the object is close to desired XY location, track its full pose.
@@ -675,10 +699,16 @@ drake::systems::EventStatus SamplingC3Controller::ComputePlan(
       crossed_cost_switching_threshold_ = true;
       std::cout << "Crossed cost switching threshold." << std::endl;
 
-      // Reset the sample buffer and metrics now that the costs have changed.
+      // Reset the sample buffers and metrics now that the costs have changed.
       sample_buffer_ = MatrixXd::Zero(sampling_params_.N_sample_buffer, n_q_);
       sample_costs_buffer_ =
         -1 * VectorXd::Ones(sampling_params_.N_sample_buffer);
+      num_in_buffer_ = 0;
+      unsuccessful_sample_buffer_ = MatrixXd::Zero(
+        sampling_params_.N_unsuccessful_sample_buffer, n_q_);
+      unsuccessful_sample_costs_buffer_ = -1 * VectorXd::Ones(
+        sampling_params_.N_unsuccessful_sample_buffer);
+      num_in_unsuccessful_buffer_ = 0;
       if (is_doing_c3_) { ResetProgressMetrics(); }
     }
   }
@@ -709,12 +739,13 @@ drake::systems::EventStatus SamplingC3Controller::ComputePlan(
       (object_angular_error < goal_params_.orientation_success_threshold));
   }
 
-  std::vector<Eigen::VectorXd> candidate_states =
-    GenerateSampleStates(n_q_, n_v_, n_u_, x_lcs_curr, is_doing_c3_,
-                         sampling_params_, sampling_c3_options_, plant_,
-                         context_, plant_ad_, context_ad_, contact_pairs_, 
-                         faces_, face_bins_, faces_per_object_,  face_bins_per_object_, 
-                         total_area_per_object_, object_on_target);
+  std::vector<Eigen::VectorXd> candidate_states = GenerateSampleStates(
+    n_q_, n_v_, n_u_, x_lcs_curr, is_doing_c3_, sampling_params_,
+    sampling_c3_options_, plant_, context_, plant_ad_, context_ad_,
+    contact_pairs_, faces_, face_bins_, faces_per_object_,
+    face_bins_per_object_, total_area_per_object_, object_on_target,
+    unsuccessful_sample_buffer_
+  );
 
   // Add the previous best repositioning target to the candidate states at the
   // index 1 always. (Index 0 will become the current state.)
@@ -867,14 +898,13 @@ auto c3_start = std::chrono::high_resolution_clock::now();
   }
     auto c3_end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double, std::milli> duration_ms = c3_end - c3_start;
-
-    //std::cout << "Parallelization: " << duration_ms.count() << " ms" << std::endl;
   // End of parallelization
+
   // Update the sample buffer.  Do this before switching modes since 1) if in
   // repositioning mode, don't add the repositioning target over and over again,
   // and 2) since the best sample in the buffer may be the best sample overall
   // and could be considered as a repositioning target.
-  MaintainSampleBuffer(x_lcs_curr);
+  MaintainSampleBuffers(x_lcs_curr);
 
   // Augment the considered samples with the best from the buffer, if eligible.
   AugmentSamplesWithBuffer(c3_objects);
@@ -1035,6 +1065,9 @@ auto c3_start = std::chrono::high_resolution_clock::now();
       is_doing_c3_ = true;
       mode_switch_reason_ = ModeSwitchReason::kToC3Xbox;
       pursued_target_source_ = PursuedTargetSource::kNoTarget;
+      // Add the current state to the unsuccessful sample buffer.  It gets
+      // automatically removed if the object moves.
+      AddToUnsuccessfulBuffer(candidate_states[0]);
     }
     // Switch to C3 if the current sample is better, with hysteresis.
     else if (
@@ -1057,6 +1090,9 @@ auto c3_start = std::chrono::high_resolution_clock::now();
         std::cout << "Switching to C3 because lower in cost" << std::endl;
       }
       pursued_target_source_ = PursuedTargetSource::kNoTarget;
+      // Add the current state to the unsuccessful sample buffer.  It gets
+      // automatically removed if the object moves.
+      AddToUnsuccessfulBuffer(candidate_states[0]);
     }
   }
 
@@ -1072,7 +1108,6 @@ auto c3_start = std::chrono::high_resolution_clock::now();
   }
   // Update C3 objects and intermediates for current and best samples.
   c3_curr_plan_ = c3_objects.at(SampleIndex::kCurrentLocation);
-
   c3_best_plan_ = c3_objects.at(best_sample_index_);
 
   // TODO If doing warmstarting, will need to save z, delta, and w vectors.
@@ -1640,83 +1675,80 @@ void SamplingC3Controller::UpdateRepositioningExecutionTrajectory(
   // No need to add object position and orientation.
 }
 
-// Maintain the sample buffer:  prune outdated samples and add new.
-void SamplingC3Controller::MaintainSampleBuffer(const VectorXd& x_lcs) const {
-  // Determine if samples are outdated by comparing to the current object
-  // position and orientation.
-  std::vector<Vector3d> object_poss;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    object_poss.push_back(x_lcs.segment(7 + 7*i, 3));
-  } 
-  std::vector<Eigen::Vector4d> object_quats;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    object_quats.push_back(x_lcs.segment(3 + 7*i, 4).normalized());
-  } 
-  std::vector<MatrixXd> buffers_xyzs;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    buffers_xyzs.push_back(sample_buffer_.block(0, 7 + 7*i, sampling_params_.N_sample_buffer, 3));
-  }
-  std::vector<MatrixXd> buffers_quats;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    buffers_quats.push_back(sample_buffer_.block(0, 3 + 7*i, sampling_params_.N_sample_buffer, 4));
-  }
-
-  // First, remove outdated samples that have moved too much from current object
-  // configuration.
-  std::vector<VectorXd> quat_dots;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    quat_dots.push_back((buffers_quats.at(i) * object_quats.at(i)).array().abs());
-  }
-  std::vector<VectorXd> angles;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    angles.push_back(2.0 * quat_dots.at(i).array().acos());
-  }
-
+// Prune outdated samples from a sample buffer, based on object motion.
+void SamplingC3Controller::PruneOutdatedSamplesFromBuffer(
+    const Eigen::VectorXd& x_lcs,
+    int* num_in_buffer,
+    Eigen::MatrixXd* sample_buffer,
+    Eigen::VectorXd* sample_costs_buffer) const {
+  int n_buffer_length = sample_costs_buffer->size();
+  // Get object positions and orientations, both current and from the buffer.
   std::vector<Eigen::Array<bool, Eigen::Dynamic, 1>> mask_satisfies_rot;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    mask_satisfies_rot.push_back(angles.at(i).array() < sampling_params_.ang_error_sample_retention);
-  }
-
-  std::vector<MatrixXd> pos_deltas;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    pos_deltas.push_back(buffers_xyzs.at(i).rowwise() - object_poss.at(i).transpose());
-  }
-  std::vector<VectorXd> distances;
-  for (int i = 0; i < controller_params_.num_objects; i++) {
-    distances.push_back(pos_deltas.at(i).rowwise().norm());
-  }
   std::vector<Eigen::Array<bool, Eigen::Dynamic, 1>> mask_satisfies_pos;
   for (int i = 0; i < controller_params_.num_objects; i++) {
-    mask_satisfies_pos.push_back(distances.at(i).array() < sampling_params_.pos_error_sample_retention);
+    Vector3d object_pos = x_lcs.segment(7 + 7*i, 3);
+    Eigen::Vector4d object_quat = x_lcs.segment(3 + 7*i, 4).normalized();
+    MatrixXd buffer_xyzs = sample_buffer->block(0, 7 + 7*i, n_buffer_length, 3);
+    MatrixXd buffer_quats = sample_buffer->block(0, 3 + 7*i, n_buffer_length, 4);
+
+    // Compute the angular difference.
+    VectorXd quat_dots = (buffer_quats * object_quat).array().abs();
+    quat_dots = quat_dots.cwiseMax(-1.0).cwiseMin(1.0);
+    VectorXd angles = 2.0 * quat_dots.array().acos();
+    mask_satisfies_rot.push_back(
+      angles.array() < sampling_params_.ang_error_sample_retention);
+
+    // Compute the linear difference.
+    MatrixXd pos_deltas = buffer_xyzs.rowwise() - object_pos.transpose();
+    VectorXd distances = pos_deltas.rowwise().norm();
+    mask_satisfies_pos.push_back(
+      distances.array() < sampling_params_.pos_error_sample_retention);
   }
-  MatrixXd retained_samples =
-    MatrixXd::Zero(sampling_params_.N_sample_buffer, n_q_);
-  VectorXd retained_costs =
-    -1 * VectorXd::Ones(sampling_params_.N_sample_buffer);
 
   // Keep buffer if none of objects moved
   int retained_count = 0;
-  for (int i = 0; i < sampling_params_.N_sample_buffer; i++) {
+  MatrixXd retained_samples = MatrixXd::Zero(n_buffer_length, n_q_);
+  VectorXd retained_costs = -1 * VectorXd::Ones(n_buffer_length);
+  for (int i = 0; i < *num_in_buffer; i++) {
     bool keep = true;
     for (int j = 0; j < controller_params_.num_objects; j++) {
       if (!(mask_satisfies_rot.at(j)[i] && mask_satisfies_pos.at(j)[i])) { 
         keep = false;
         break;
-      } 
+      }
     }
     if (keep) {
-      retained_samples.row(retained_count) = sample_buffer_.row(i);
-      retained_costs[retained_count] = sample_costs_buffer_[i];
+      retained_samples.row(retained_count) = sample_buffer->row(i);
+      retained_costs[retained_count] = (*sample_costs_buffer)[i];
       retained_count++;
-    }    
-    if (sample_costs_buffer_[i] < 0) {
+    }
+    if ((*sample_costs_buffer)[i] < 0) {
       break;
-    } 
+    }
   }
-  sample_buffer_ = retained_samples;
-  sample_costs_buffer_ = retained_costs;
+  *num_in_buffer = retained_count;
+  *sample_buffer = retained_samples;
+  *sample_costs_buffer = retained_costs;
+}
 
-  // Second, in preparation for adding new samples stored in
+// Maintain the sample buffers (both for keeping track of unattempted samples
+// and their costs, and of attempted unsuccessful samples):  prune outdated
+// samples and add new.
+void SamplingC3Controller::MaintainSampleBuffers(const VectorXd& x_lcs) const {
+  // First, handle the unsuccessful sample buffer.  This buffer just needs to
+  // prune outdated samples; new samples get added one at a time when the
+  // controller goes from repositioning to C3 mode.
+  PruneOutdatedSamplesFromBuffer(
+    x_lcs, &num_in_unsuccessful_buffer_, &unsuccessful_sample_buffer_,
+    &unsuccessful_sample_costs_buffer_);
+
+  // Second, handle the unattempted sample buffer.  First, prune outdated
+  // samples.
+  PruneOutdatedSamplesFromBuffer(
+    x_lcs, &num_in_buffer_, &sample_buffer_, &sample_costs_buffer_);
+  int retained_count = num_in_buffer_;
+
+  // Third, in preparation for adding new samples stored in
   // all_sample_locations_ (excluding the current location), if the buffer is
   // going to overflow, get rid of the oldest samples first.  NOTE:  Step 4
   // moves the lowest cost sample in the buffer to the end, so the best sample
@@ -1735,7 +1767,7 @@ void SamplingC3Controller::MaintainSampleBuffer(const VectorXd& x_lcs) const {
       sample_costs_buffer_.segment(shift_by, retained_count);
   }
 
-  // Third, add the new samples stored in all_sample_locations_ and
+  // Fourth, add the new samples stored in all_sample_locations_ and
   // all_sample_costs_.  Don't add the current location (so the sample buffer
   // contains more broadly sampled locations) or a currently pursued
   // repositioning target.
@@ -1751,7 +1783,8 @@ void SamplingC3Controller::MaintainSampleBuffer(const VectorXd& x_lcs) const {
       new_config.segment(0, 3) = all_sample_locations_[i - retained_count];
       // Ensure a normalized quaternion is written to the buffer.
       for (int i = 0; i < controller_params_.num_objects; i++) {
-        new_config.segment(3 + 7*i, 4) = object_quats.at(i);
+        Eigen::Vector4d object_quat = x_lcs.segment(3 + 7*i, 4).normalized();
+        new_config.segment(3 + 7*i, 4) = object_quat;
       }
       sample_buffer_.row(buffer_count) = new_config;
       sample_costs_buffer_[buffer_count] =
@@ -1827,6 +1860,52 @@ void SamplingC3Controller::AugmentSamplesWithBuffer(
       all_sample_dynamically_feasible_plans_.push_back(
         dynamically_feasible_buffer_plan_);
     }
+  }
+}
+
+// Add the current state to the unsuccessful buffer.
+void SamplingC3Controller::AddToUnsuccessfulBuffer(
+    const Eigen::VectorXd& x_lcs) const {
+  // Check if the unsuccessful buffer is going to overflow.
+  if (num_in_unsuccessful_buffer_ ==
+      sampling_params_.N_unsuccessful_sample_buffer) {
+    std::cout<<"!!! WARNING !!! Unsuccessful sample buffer overflow"<<std::endl;
+    for (int i = 0; i < num_in_unsuccessful_buffer_-1; i++) {
+      unsuccessful_sample_buffer_.row(i) = unsuccessful_sample_buffer_.row(i+1);
+      unsuccessful_sample_costs_buffer_[i] =
+        unsuccessful_sample_costs_buffer_[i+1];
+    }
+    num_in_unsuccessful_buffer_--;
+  }
+  // Add the current location to the unsuccessful buffer.
+  unsuccessful_sample_buffer_.row(num_in_unsuccessful_buffer_) = x_lcs.head(n_q_);
+  unsuccessful_sample_costs_buffer_[num_in_unsuccessful_buffer_] = 
+    all_sample_costs_[0];
+  num_in_unsuccessful_buffer_++;
+
+  // If desired, remove nearby samples from the unattempted sample buffer.
+  if (sampling_params_.avoid_choosing_unsuccessful_samples) {
+    int retained_count = 0;
+    MatrixXd retained_samples = MatrixXd::Zero(
+      sampling_params_.N_sample_buffer, n_q_);
+    VectorXd retained_costs = -1 * VectorXd::Ones(
+      sampling_params_.N_sample_buffer);
+    for (int i = 0; i < num_in_buffer_; i++) {
+      // Check the EE position of the sample, and remove the sample from the
+      // buffer if too close to the new unsuccessful sample.
+      Vector3d ee_sample = sample_buffer_.row(i).head(3);
+      double ee_dist = (ee_sample - x_lcs.head(3)).norm();
+      if (ee_dist > sampling_params_.unsuccessful_radius) {
+        retained_samples.row(retained_count) = sample_buffer_.row(i);
+        retained_costs[retained_count] = sample_costs_buffer_[i];
+        retained_count++;
+      }
+    }
+    std::cout<<"Removed "<<num_in_buffer_ - retained_count<<
+      " samples from buffer to avoid repeats"<<std::endl;
+    num_in_buffer_ = retained_count;
+    sample_buffer_ = retained_samples;
+    sample_costs_buffer_ = retained_costs;
   }
 }
 
@@ -2917,6 +2996,18 @@ void SamplingC3Controller::OutputSampleBufferCosts(
     const drake::systems::Context<double>& context,
     Eigen::VectorXd* sample_buffer_costs) const {
   *sample_buffer_costs = sample_costs_buffer_;
+}
+
+void SamplingC3Controller::OutputUnsuccessfulSampleBufferConfigurations(
+    const drake::systems::Context<double>& context,
+    Eigen::MatrixXd* unsuccessful_sample_buffer_configurations) const {
+  *unsuccessful_sample_buffer_configurations = unsuccessful_sample_buffer_;
+}
+
+void SamplingC3Controller::OutputUnsuccessfulSampleBufferCosts(
+    const drake::systems::Context<double>& context,
+    Eigen::VectorXd* unsuccessful_sample_buffer_costs) const {
+  *unsuccessful_sample_buffer_costs = unsuccessful_sample_costs_buffer_;
 }
 
 }  // namespace systems

--- a/systems/controllers/sampling_based_c3_controller.h
+++ b/systems/controllers/sampling_based_c3_controller.h
@@ -194,6 +194,15 @@ class SamplingC3Controller : public drake::systems::LeafSystem<double> {
   get_output_port_sample_buffer_costs() const {
     return this->get_output_port(sample_buffer_costs_port_);
   }
+  const drake::systems::OutputPort<double>&
+  get_output_port_unsuccessful_sample_buffer_configurations() const {
+    return this->get_output_port(
+      unsuccessful_sample_buffer_configurations_port_);
+  }
+  const drake::systems::OutputPort<double>&
+  get_output_port_unsuccessful_sample_buffer_costs() const {
+    return this->get_output_port(unsuccessful_sample_buffer_costs_port_);
+  }
 
  private:
   /// Function for computing one control loop
@@ -229,10 +238,18 @@ class SamplingC3Controller : public drake::systems::LeafSystem<double> {
   void UpdateRepositioningExecutionTrajectory(const Eigen::VectorXd& x_lcs,
     const double& t_context) const;
 
-  void MaintainSampleBuffer(const Eigen::VectorXd& x_lcs) const;
+  void PruneOutdatedSamplesFromBuffer(
+    const Eigen::VectorXd& x_lcs,
+    int* num_in_buffer,
+    Eigen::MatrixXd* sample_buffer,
+    Eigen::VectorXd* sample_costs_buffer) const;
+
+  void MaintainSampleBuffers(const Eigen::VectorXd& x_lcs) const;
 
   void AugmentSamplesWithBuffer(
     std::vector<std::shared_ptr<solvers::C3Base>>& c3_objects) const;
+
+  void AddToUnsuccessfulBuffer(const Eigen::VectorXd& x_lcs) const;
 
   void KeepTrackOfC3ModeProgress(
     const drake::VectorX<double>& x_lcs_curr,
@@ -316,6 +333,12 @@ class SamplingC3Controller : public drake::systems::LeafSystem<double> {
   void OutputSampleBufferCosts(
       const drake::systems::Context<double>& context,
       Eigen::VectorXd* sample_buffer_costs) const;
+  void OutputUnsuccessfulSampleBufferConfigurations(
+      const drake::systems::Context<double>& context,
+      Eigen::MatrixXd* unsuccessful_sample_buffer_configurations) const;
+  void OutputUnsuccessfulSampleBufferCosts(
+      const drake::systems::Context<double>& context,
+      Eigen::VectorXd* unsuccessful_sample_buffer_costs) const;
 
   std::vector<double> face_bins_;
   std::vector<Face> faces_;
@@ -355,6 +378,8 @@ class SamplingC3Controller : public drake::systems::LeafSystem<double> {
   drake::systems::OutputPortIndex debug_lcmt_port_;
   drake::systems::OutputPortIndex sample_buffer_configurations_port_;
   drake::systems::OutputPortIndex sample_buffer_costs_port_;
+  drake::systems::OutputPortIndex unsuccessful_sample_buffer_configurations_port_;
+  drake::systems::OutputPortIndex unsuccessful_sample_buffer_costs_port_;
 
   // This plant_ has been made 'not const' so that the context can be updated.
   drake::multibody::MultibodyPlant<double>& plant_;
@@ -458,6 +483,11 @@ class SamplingC3Controller : public drake::systems::LeafSystem<double> {
   mutable int num_in_buffer_ = 0;
   mutable Eigen::MatrixXd sample_buffer_;  // (N_sample_buffer x n_q)
   mutable Eigen::VectorXd sample_costs_buffer_;
+
+  // Unsuccessful sample buffer-related variables.
+  mutable int num_in_unsuccessful_buffer_ = 0;
+  mutable Eigen::MatrixXd unsuccessful_sample_buffer_;  // (num_in_unsuccessful_buffer_ x n_q)
+  mutable Eigen::VectorXd unsuccessful_sample_costs_buffer_;
 
   // Miscellaneous sample related variables.
   mutable bool is_doing_c3_ = true;

--- a/systems/senders/sample_buffer_sender.cc
+++ b/systems/senders/sample_buffer_sender.cc
@@ -12,9 +12,10 @@ using drake::systems::Context;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-SampleBufferSender::SampleBufferSender(int buffer_size, int n_config)
+SampleBufferSender::SampleBufferSender(
+  int buffer_size, int n_config, std::string name)
     : buffer_size_(buffer_size), n_config_(n_config) {
-  this->set_name("sample_buffer_sender");
+  this->set_name(name);
 
   MatrixXd sample_buffer = MatrixXd::Zero(buffer_size_, n_config_);
   VectorXd cost_buffer = VectorXd::Zero(buffer_size_);

--- a/systems/senders/sample_buffer_sender.h
+++ b/systems/senders/sample_buffer_sender.h
@@ -14,7 +14,7 @@ namespace systems {
 /// Converts sample costs and configurations to LCM type lcmt_sample_buffer
 class SampleBufferSender : public drake::systems::LeafSystem<double> {
  public:
-  SampleBufferSender(int buffer_size, int n_config);
+  SampleBufferSender(int buffer_size, int n_config, std::string name);
 
   const drake::systems::InputPort<double>& get_input_port_sample_costs() const {
     return this->get_input_port(sample_costs_port_);


### PR DESCRIPTION
This change adds the ability to avoid repeating attempting near previously ineffective samples.  The "unsuccessful sample buffer" keeps track of system configurations when the controller enters C3 mode.  These configurations are cleaned out when the object(s) move beyond a threshold in position and/or orientation -- this reuses the threshold for maintaining relevant samples in the sample buffer.

The following are new hyperparameters for this feature, all in sampling parameters:

- `avoid_choosing_unsuccessful_samples` (bool) turns on this feature.  When the feature is off, the unsuccessful sample buffer is still maintained but has no effect on what samples can be pursued by the controller.
- `N_unsuccessful_sample_buffer` (int) is the size of the unsuccessful sample buffer.  In my single object tests in simulation, I only saw a maximum of 5 added to this buffer at a time, so I believe a value of 10 is sufficient.  If the unsuccessful sample buffer ever fills up, a warning print notifies the user.
- `unsuccessful_radius` (double) is the distance to any previously attempted sample within which more samples are rejected.

The unsuccessful sample buffer is published over LCM via the `UNSUCCESSFUL_SAMPLE_BUFFER` channel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/401)
<!-- Reviewable:end -->
