### PR TITLE
Remove single-object params that have been replaced by multi-object params

### DIFF
--- a/examples/sampling_c3/anything/parameters/goal_params.yaml
+++ b/examples/sampling_c3/anything/parameters/goal_params.yaml
@@ -11,7 +11,6 @@ position_success_threshold: 0.02
 orientation_success_threshold: 0.1  # 0.1 rad = 5.7 degrees
 only_use_xy_position: true
 
-resting_object_height: -0.004                # in world frame
 resting_object_heights: [-0.002685910000000003, -0.0024437, -0.001956050000000001, 0.0001434999999999978]                                               # in world frame
 ee_target_z_offset_above_object: 0.06   # defines EE goal w.r.t. object position
 
@@ -28,10 +27,7 @@ angle_hysteresis: 0.4
 # Factor to convert an angular error to angular velocity command (0=disabled).
 angle_err_to_vel_factor: 0
 
-# Initial goal (and only goal for fixed goal mode) DEPRECATED.
-fixed_target_position: [0.65, 0.18745379, -0.004]
-fixed_target_orientation: [-0.9327733, 0, 0, 0.36046353]
-
+# Initial goal (and only goal for fixed goal mode).
 fixed_target_positions: [[0.51, -0.30000000000000004, -0.002685910000000003], [0.5, -0.10000000000000003, -0.0024437], [0.51, 0.09999999999999998, -0.001956050000000001], [0.5, 0.30000000000000004, 0.0001434999999999978]]
 fixed_target_orientations: [[0.71, 0, 0, 0.71], [1, 0, 0, 0.05], [0.71, 0, 0, -0.73], [1, 0, 0, 0.02]]
 

--- a/examples/sampling_c3/anything/parameters/sampling_c3_controller_params.yaml
+++ b/examples/sampling_c3/anything/parameters/sampling_c3_controller_params.yaml
@@ -13,10 +13,11 @@ franka_driver_channels_file: common/parameters/franka_drake_lcm_driver_channels.
 lcm_channels_hardware_file: examples/sampling_c3/anything/parameters/lcm_channels_hardware.yaml
 lcm_channels_simulation_file: examples/sampling_c3/anything/parameters/lcm_channels_simulation.yaml
 
-object_model: examples/sampling_c3/urdf/nut/nut_controller.sdf
+# NOTE:  Do not need to edit object_models -- only edit base_names, and
+# multiyaml_rewrite.py will automatically write the correct object model paths
+# from the base_names list.
 object_models: [examples/sampling_c3/urdf/G_shape_video/G_shape_video_controller.sdf, examples/sampling_c3/urdf/R_shape_texture/R_shape_texture_controller.sdf, examples/sampling_c3/urdf/A_shape_video/A_shape_video_controller.sdf, examples/sampling_c3/urdf/S_shape_texture/S_shape_texture_controller.sdf]
-object_body_name: body
-base_name: A_shape_video
+
 # base_names: [P_shape_texture, U_shape_texture, S_shape_texture, H_shape_texture]
 # base_names: [I_shape_texture, C_shape_texture, R_shape_texture, A_shape_video]
 # base_names: [U_shape_texture, R_shape_texture, D_shape_texture, F_shape_texture]

--- a/examples/sampling_c3/anything/parameters/sim_params.yaml
+++ b/examples/sampling_c3/anything/parameters/sim_params.yaml
@@ -1,4 +1,3 @@
-object_model: examples/sampling_c3/urdf/nut/nut.sdf           # TODO @bibit what do we want here?
 object_models: [examples/sampling_c3/urdf/G_shape_video/G_shape_video.sdf, examples/sampling_c3/urdf/R_shape_texture/R_shape_texture.sdf, examples/sampling_c3/urdf/A_shape_video/A_shape_video.sdf, examples/sampling_c3/urdf/S_shape_texture/S_shape_texture.sdf]
 franka_publish_rate: 1000
 object_publish_rate: 10
@@ -11,5 +10,4 @@ dt: 0.001
 realtime_rate: 1
 
 q_init_franka: [2.191, 1.1, -1.33, -2.22, 1.30, 2.02, 0.08]
-q_init_object: [0, 0, 0, 1, 0.5, 0, -0.004]
 q_init_objects: [[0.393, 0, 0, 0.92, 0.4, -0.3, 0.0], [0.393, 0, 0, 0.92, 0.42000000000000004, -0.09999999999999998, 0.0], [0.393, 0, 0, 0.92, 0.44, 0.10000000000000003, 0.0], [0.393, 0, 0, 0.92, 0.46, 0.3000000000000001, 0.0]]

--- a/examples/sampling_c3/anything/parameters/vis_params.yaml
+++ b/examples/sampling_c3/anything/parameters/vis_params.yaml
@@ -1,5 +1,4 @@
 ee_vis_model: examples/sampling_c3/urdf/ee_visualization_model.urdf
-object_vis_model: examples/sampling_c3/urdf/nut/nut.sdf
 object_vis_models: [examples/sampling_c3/urdf/G_shape_video/G_shape_video.sdf, examples/sampling_c3/urdf/R_shape_texture/R_shape_texture.sdf, examples/sampling_c3/urdf/A_shape_video/A_shape_video.sdf, examples/sampling_c3/urdf/S_shape_texture/S_shape_texture.sdf]
 visualizer_publish_rate: 30
 

--- a/examples/sampling_c3/franka_sampling_c3_controller.cc
+++ b/examples/sampling_c3/franka_sampling_c3_controller.cc
@@ -383,10 +383,8 @@ int DoMain(int argc, char* argv[]) {
   auto reduced_order_model_receiver =
       builder.AddSystem<systems::FrankaKinematics>(
           plant_franka, franka_context.get(), plant_object,
-          object_context.get(), kEndEffectorName,
-          controller_params.object_body_name,
-          controller_params.include_end_effector_orientation,
-          controller_params.base_names);
+          object_context.get(), kEndEffectorName, controller_params.base_names,
+          controller_params.include_end_effector_orientation);
 
   std::cout << "Before target generator" << std::endl;
   // Select the target generator based on the demo.

--- a/examples/sampling_c3/franka_visualizer.cc
+++ b/examples/sampling_c3/franka_visualizer.cc
@@ -170,9 +170,8 @@ int do_main(int argc, char* argv[]) {
   auto reduced_order_model_receiver =
       builder.AddSystem<systems::FrankaKinematics>(
           plant_franka, franka_context.get(), plant_object,
-          object_context.get(), kEndEffectorName,
-          controller_params.object_body_name, false,
-          controller_params.base_names);
+          object_context.get(), kEndEffectorName, controller_params.base_names,
+          false);
 
   builder.Connect(franka_state_receiver->get_output_port(),
                   reduced_order_model_receiver->get_input_port_franka_state());
@@ -402,9 +401,8 @@ int do_main(int argc, char* argv[]) {
 
   if (vis_params.visualize_c3_plan_best) {
     auto object_pose_drawer_best = builder.AddSystem<systems::LcmPoseDrawer>(
-        meshcat, FindResourceOrThrow(vis_params.object_vis_model),
-        "object_position_target", "object_orientation_target",
-        "plans/best_planned", sampling_c3_options.N, true,
+        meshcat, vis_params.object_vis_models, position_names,
+        orientation_names, "plans/best_planned", sampling_c3_options.N, true,
         vis_params.c3_best_object_color);
     builder.Connect(trajectory_sub_object_best->get_output_port(),
                     object_pose_drawer_best->get_input_port_trajectory());
@@ -420,10 +418,9 @@ int do_main(int argc, char* argv[]) {
 
     auto dynamically_feasible_object_pose_drawer_best =
         builder.AddSystem<systems::LcmPoseDrawer>(
-            meshcat, FindResourceOrThrow(vis_params.object_vis_model),
-            "object_position_target", "object_orientation_target",
-            "plans/dynamically_feasible_best_plan", sampling_c3_options.N + 1,
-            true, vis_params.df_best_object_color);
+            meshcat, vis_params.object_vis_models, position_names,
+            orientation_names, "plans/dynamically_feasible_best_plan",
+            sampling_c3_options.N + 1, true, vis_params.df_best_object_color);
     builder.Connect(
         dynamically_feasible_trajectory_sub_object_best->get_output_port(),
         dynamically_feasible_object_pose_drawer_best

--- a/examples/sampling_c3/jacktoy/parameters/goal_params.yaml
+++ b/examples/sampling_c3/jacktoy/parameters/goal_params.yaml
@@ -11,8 +11,7 @@ position_success_threshold: 0.02
 orientation_success_threshold: 0.1  # 0.1 rad = 5.7 degrees
 only_use_xy_position: true  # only use xy position for detecting if goal is met
 
-resting_object_height: 0.031971466      # in world frame
-resting_object_heights: [0.031971466]
+resting_object_heights: [0.031971466]   # in world frame
 ee_target_z_offset_above_object: 0.06   # defines EE goal w.r.t. object position
 
 # Lookahead parameters to define a sub-goal for C3.
@@ -29,9 +28,6 @@ angle_hysteresis: 0.4
 angle_err_to_vel_factor: 0
 
 # Initial goal (and only goal for fixed goal mode).
-fixed_target_position: [0.45, 0.2, 0.031971466]
-fixed_target_orientation: [ 0.8804762392171493, 0.27984814233312133,
-                           -0.3647051996310009, -0.11591689595929514]
 fixed_target_positions: [[0.45, 0.2, 0.031971466]]
 fixed_target_orientations: [[0.8804762392171493, 0.27984814233312133,
                            -0.3647051996310009, -0.11591689595929514]]

--- a/examples/sampling_c3/jacktoy/parameters/sampling_c3_controller_params.yaml
+++ b/examples/sampling_c3/jacktoy/parameters/sampling_c3_controller_params.yaml
@@ -17,13 +17,9 @@ lcm_channels_simulation_file: examples/sampling_c3/shared_parameters/lcm_channel
 
 # Note:  Use capsule_1 body name as representative of the pose of the entire
 # jack model.  This works because capsule_1's origin is the same as the jack's.
-object_model: examples/sampling_c3/urdf/jack_control.sdf
-object_body_name: capsule_1
-base_name: something
-
-include_end_effector_orientation: false
-
 object_models: [examples/sampling_c3/urdf/jack_control.sdf]
 base_names: [capsule_1]
+
+include_end_effector_orientation: false
 
 control_loop_delay_ms: 0

--- a/examples/sampling_c3/jacktoy/parameters/sim_params.yaml
+++ b/examples/sampling_c3/jacktoy/parameters/sim_params.yaml
@@ -1,4 +1,3 @@
-object_model: examples/sampling_c3/urdf/jack.sdf
 object_models: [examples/sampling_c3/urdf/jack.sdf]
 
 franka_publish_rate: 1000
@@ -12,5 +11,4 @@ dt: 0.0001
 realtime_rate: 1
 
 q_init_franka: [2.191, 1.1, -1.33, -2.22, 1.30, 2.02, 0.08]
-q_init_object: [-0.3347435, -0.026718954, 0.8878204, 0.31518626, 0.4, 0.30, 0.03]
 q_init_objects: [[-0.3347435, -0.026718954, 0.8878204, 0.31518626, 0.4, 0.30, 0.03]]

--- a/examples/sampling_c3/jacktoy/parameters/vis_params.yaml
+++ b/examples/sampling_c3/jacktoy/parameters/vis_params.yaml
@@ -1,5 +1,4 @@
 ee_vis_model: examples/sampling_c3/urdf/ee_visualization_model.urdf
-object_vis_model: examples/sampling_c3/urdf/jack.sdf
 object_vis_models: [examples/sampling_c3/urdf/jack.sdf]
 visualizer_publish_rate: 30
 

--- a/examples/sampling_c3/parameter_headers/franka_sim_params.h
+++ b/examples/sampling_c3/parameter_headers/franka_sim_params.h
@@ -5,7 +5,6 @@
 #include "drake/common/yaml/yaml_read_archive.h"
 
 struct FrankaSimParams {
-  std::string object_model;
   std::vector<std::string> object_models;
   double dt;
   double realtime_rate;
@@ -15,12 +14,10 @@ struct FrankaSimParams {
   bool visualize_drake_sim;
   bool publish_efforts;
   Eigen::VectorXd q_init_franka;
-  Eigen::VectorXd q_init_object;
   std::vector<Eigen::VectorXd> q_init_objects;
 
   template <typename Archive>
   void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(object_model));
     a->Visit(DRAKE_NVP(object_models));
     a->Visit(DRAKE_NVP(dt));
     a->Visit(DRAKE_NVP(realtime_rate));
@@ -30,7 +27,6 @@ struct FrankaSimParams {
     a->Visit(DRAKE_NVP(visualize_drake_sim));
     a->Visit(DRAKE_NVP(publish_efforts));
     a->Visit(DRAKE_NVP(q_init_franka));
-    a->Visit(DRAKE_NVP(q_init_object));
     a->Visit(DRAKE_NVP(q_init_objects));
   }
 };

--- a/examples/sampling_c3/parameter_headers/goal_params.h
+++ b/examples/sampling_c3/parameter_headers/goal_params.h
@@ -23,8 +23,7 @@ struct SamplingC3GoalParams {
   double orientation_success_threshold;
   bool only_use_xy_position;
 
-  double resting_object_height;  // in world frame
-  std::vector<double> resting_object_heights;
+  std::vector<double> resting_object_heights;  // in world frame for each object
   double ee_target_z_offset_above_object;  // defines EE goal wrt object height
 
   /// Lookahead parameters to define a sub-goal for C3.
@@ -43,9 +42,6 @@ struct SamplingC3GoalParams {
   double angle_err_to_vel_factor;
 
   /// Initial goal (and only goal for fixed goal mode).
-  Eigen::Vector3d fixed_target_position;
-  Eigen::Vector4d fixed_target_orientation;
-
   std::vector<Eigen::Vector3d> fixed_target_positions;
   std::vector<Eigen::Vector4d> fixed_target_orientations;
 
@@ -65,15 +61,12 @@ struct SamplingC3GoalParams {
     ENUM_DESERIALIZE(a, goal_mode);
     a->Visit(DRAKE_NVP(position_success_threshold));
     a->Visit(DRAKE_NVP(orientation_success_threshold));
-    a->Visit(DRAKE_NVP(resting_object_height));
     a->Visit(DRAKE_NVP(resting_object_heights));
     a->Visit(DRAKE_NVP(ee_target_z_offset_above_object));
     a->Visit(DRAKE_NVP(lookahead_step_size));
     a->Visit(DRAKE_NVP(lookahead_angle));
     a->Visit(DRAKE_NVP(angle_hysteresis));
     a->Visit(DRAKE_NVP(angle_err_to_vel_factor));
-    a->Visit(DRAKE_NVP(fixed_target_position));
-    a->Visit(DRAKE_NVP(fixed_target_orientation));
     a->Visit(DRAKE_NVP(fixed_target_positions));
     a->Visit(DRAKE_NVP(fixed_target_orientations));
     a->Visit(DRAKE_NVP(random_goal_x_limits));

--- a/examples/sampling_c3/parameter_headers/sampling_c3_controller_params.h
+++ b/examples/sampling_c3/parameter_headers/sampling_c3_controller_params.h
@@ -26,10 +26,7 @@ struct SamplingC3ControllerParams {
   std::string lcm_channels_hardware_file;
   std::string lcm_channels_simulation_file;
 
-  std::string object_model;
   std::vector<std::string> object_models;
-  std::string object_body_name;
-  std::string base_name;
   std::vector<std::string> base_names;
 
   double workspace_margin;
@@ -60,9 +57,6 @@ struct SamplingC3ControllerParams {
     a->Visit(DRAKE_NVP(franka_driver_channels_file));
     a->Visit(DRAKE_NVP(lcm_channels_hardware_file));
     a->Visit(DRAKE_NVP(lcm_channels_simulation_file));
-    a->Visit(DRAKE_NVP(object_model));
-    a->Visit(DRAKE_NVP(object_body_name));
-    a->Visit(DRAKE_NVP(base_name));
     a->Visit(DRAKE_NVP(include_end_effector_orientation));
     a->Visit(DRAKE_NVP(control_loop_delay_ms));
 

--- a/examples/sampling_c3/parameter_headers/visualizer_params.h
+++ b/examples/sampling_c3/parameter_headers/visualizer_params.h
@@ -6,7 +6,6 @@
 
 struct SamplingC3VisualizerParams {
   std::string ee_vis_model;
-  std::string object_vis_model;
   std::vector<std::string> object_vis_models;
   double visualizer_publish_rate;
 
@@ -45,7 +44,6 @@ struct SamplingC3VisualizerParams {
   template <typename Archive>
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(ee_vis_model));
-    a->Visit(DRAKE_NVP(object_vis_model));
     a->Visit(DRAKE_NVP(object_vis_models));
     a->Visit(DRAKE_NVP(visualizer_publish_rate));
     a->Visit(DRAKE_NVP(camera_pose));

--- a/examples/sampling_c3/push_t/parameters/goal_params.yaml
+++ b/examples/sampling_c3/push_t/parameters/goal_params.yaml
@@ -11,8 +11,7 @@ position_success_threshold: 0.02
 orientation_success_threshold: 0.1  # 0.1 rad = 5.7 degrees
 only_use_xy_position: true
 
-resting_object_height: -0.009      # in world frame
-resting_object_heights: [-0.009]
+resting_object_heights: [-0.009]   # in world frame
 ee_target_z_offset_above_object: 0.06   # defines EE goal w.r.t. object position
 
 # Lookahead parameters to define a sub-goal for C3.
@@ -28,10 +27,7 @@ angle_hysteresis: 0.4
 # Factor to convert an angular error to angular velocity command (0=disabled).
 angle_err_to_vel_factor: 0
 
-# Initial goal (and only goal for fixed goal mode) DEPRECATED.
-fixed_target_position: [0.65, 0.18745379, -0.009]
-fixed_target_orientation: [-0.9327733, 0, 0, 0.36046353]
-
+# Initial goal (and only goal for fixed goal mode).
 fixed_target_positions: [[0.5, 0.0, -0.009]]
 fixed_target_orientations: [[0.707, 0, 0, 0.707]]
 

--- a/examples/sampling_c3/push_t/parameters/sampling_c3_controller_params.yaml
+++ b/examples/sampling_c3/push_t/parameters/sampling_c3_controller_params.yaml
@@ -15,10 +15,6 @@ lcm_channels_simulation_file: examples/sampling_c3/shared_parameters/lcm_channel
 
 # Note:  Use vertical_link body name as representative of the pose of the entire
 # T model.  This works because vertical_link's origin is the same as the T's.
-object_model: examples/sampling_c3/urdf/push_t_control.sdf
-object_body_name: vertical_link
-base_name: dummy
-
 object_models: [examples/sampling_c3/urdf/push_t_control.sdf]
 base_names: [vertical_link]
 

--- a/examples/sampling_c3/push_t/parameters/sim_params.yaml
+++ b/examples/sampling_c3/push_t/parameters/sim_params.yaml
@@ -1,4 +1,3 @@
-object_model: examples/sampling_c3/urdf/push_t.sdf
 object_models: [examples/sampling_c3/urdf/push_t.sdf]
 
 franka_publish_rate: 1000
@@ -12,5 +11,4 @@ dt: 0.0001
 realtime_rate: 1
 
 q_init_franka: [2.191, 1.1, -1.33, -2.22, 1.30, 2.02, 0.08]
-q_init_object: [1.0, 0, 0, 0, 0.5, 0, -0.009]
 q_init_objects: [[1.0, 0, 0, 0, 0.5, 0, -0.009]]

--- a/examples/sampling_c3/push_t/parameters/vis_params.yaml
+++ b/examples/sampling_c3/push_t/parameters/vis_params.yaml
@@ -1,5 +1,4 @@
 ee_vis_model: examples/sampling_c3/urdf/ee_visualization_model.urdf
-object_vis_model: examples/sampling_c3/urdf/push_t.sdf
 object_vis_models: [examples/sampling_c3/urdf/push_t.sdf]
 visualizer_publish_rate: 30
 

--- a/systems/franka_kinematics.cc
+++ b/systems/franka_kinematics.cc
@@ -14,56 +14,24 @@ FrankaKinematics::FrankaKinematics(const MultibodyPlant<double>& franka_plant,
                                    const std::string& end_effector_name,
                                    const std::string& object_name,
                                    bool include_end_effector_orientation)
-    : franka_plant_(franka_plant),
-      franka_context_(franka_context),
-      object_plant_(object_plant),
-      object_context_(object_context),
-      world_(franka_plant_.world_frame()),
-      end_effector_name_(end_effector_name),
-      object_name_(object_name),
-      include_end_effector_orientation_(include_end_effector_orientation) {
-  this->set_name("franka_kinematics");
-  franka_state_port_ =
-      this->DeclareVectorInputPort(
-              "x_franka", OutputVector<double>(franka_plant.num_positions(),
-                                               franka_plant.num_velocities(),
-                                               franka_plant.num_actuators()))
-          .get_index();
-
-  object_state_port_ =
-      this->DeclareVectorInputPort(
-              "x_object", StateVector<double>(object_plant.num_positions(),
-                                              object_plant.num_velocities()))
-          .get_index();
-  num_end_effector_positions_ = 3 + include_end_effector_orientation_ * 3;
-  num_object_positions_ = 7 * 2;
-  num_end_effector_velocities_ = 3 + include_end_effector_orientation_ * 3;
-  num_object_velocities_ = 6 * 2;
-  lcs_state_port_ =
-      this->DeclareVectorOutputPort(
-              "x_lcs",
-              FrankaKinematicsVector<double>(
-                  num_end_effector_positions_, num_object_positions_,
-                  num_end_effector_velocities_, num_object_velocities_),
-              &FrankaKinematics::ComputeLCSState)
-          .get_index();
-}
+    : FrankaKinematics(franka_plant, franka_context, object_plant,
+                       object_context, end_effector_name,
+                       std::vector<std::string>{object_name},
+                       include_end_effector_orientation) {}
 
 FrankaKinematics::FrankaKinematics(const MultibodyPlant<double>& franka_plant,
                                    Context<double>* franka_context,
                                    const MultibodyPlant<double>& object_plant,
                                    Context<double>* object_context,
                                    const std::string& end_effector_name,
-                                   const std::string& object_name,
-                                   bool include_end_effector_orientation,
-                                   std::vector<std::string> object_names)
+                                   std::vector<std::string> object_names,
+                                   bool include_end_effector_orientation)
     : franka_plant_(franka_plant),
       franka_context_(franka_context),
       object_plant_(object_plant),
       object_context_(object_context),
       world_(franka_plant_.world_frame()),
       end_effector_name_(end_effector_name),
-      object_name_(object_name),
       include_end_effector_orientation_(include_end_effector_orientation),
       object_names_(object_names) {
   num_objects_ = object_names_.size();

--- a/systems/franka_kinematics.h
+++ b/systems/franka_kinematics.h
@@ -47,9 +47,8 @@ class FrankaKinematics : public drake::systems::LeafSystem<double> {
                             const MultibodyPlant<double>& object_plant,
                             Context<double>* object_context,
                             const std::string& end_effector_name,
-                            const std::string& object_name,
-                            bool include_end_effector_orientation,
-                            std::vector<std::string> object_names);
+                            std::vector<std::string> object_names,
+                            bool include_end_effector_orientation);
 
   std::vector<const drake::systems::InputPort<double>*>
   get_input_ports_object_state() const {
@@ -80,16 +79,17 @@ class FrankaKinematics : public drake::systems::LeafSystem<double> {
   int num_object_positions_;
   int num_end_effector_velocities_;
   int num_object_velocities_;
-  std::vector<std::string> object_names_;
-  int num_objects_;
 
   const MultibodyPlant<double>& franka_plant_;
   Context<double>* franka_context_;
   const MultibodyPlant<double>& object_plant_;
   Context<double>* object_context_;
   const drake::multibody::Frame<double>& world_;
+
   std::string end_effector_name_;
-  std::string object_name_;
+  std::vector<std::string> object_names_;
+  int num_objects_;
+
   const bool include_end_effector_orientation_;
 };
 


### PR DESCRIPTION
**Code clean-up:**  Push Anything introduced the multi-object sampling C3 demo.  The implementation added multi-object parameters alongside the existing single-object parameters.  This PR removes the single-object parameters that are no longer used, instead using only the multi-object parameters (which, if lists of length 1, can represent single-object experiments as well).  All 3 SC3 demos (`jacktoy`, `push_t`, and `anything`) are still functional with these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DAIRLab/dairlib/412)
<!-- Reviewable:end -->
